### PR TITLE
feat: optimize sync process with pagination and batch processing

### DIFF
--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { plaudConnections, recordings, userSettings, users } from "@/db/schema";
 import { env } from "@/lib/env";
@@ -262,7 +262,6 @@ export async function syncRecordingsForUser(
             const plaudRecordings = recordingsResponse.data_file_list;
 
             if (plaudRecordings.length === 0) {
-                hasMore = false;
                 break;
             }
 


### PR DESCRIPTION
## Summary

Optimizes the Plaud recording sync process to prevent timeouts with large recording sets.

## Changes

### Pagination
- Fetch recordings in pages of **50** (instead of all 99,999)
- Early exit when no new recordings found for 2 consecutive pages

### Batch Processing  
- Download **5 recordings concurrently** (instead of sequential)
- Use `Promise.allSettled` to continue on individual failures

### Decoupled Transcription
- Auto-transcription now runs **in background after sync completes**
- Returns `pendingTranscriptionIds` for tracking
- Prevents transcription timeouts from blocking sync

## Config Constants
```typescript
const SYNC_CONFIG = {
  PAGE_SIZE: 50,
  BATCH_CONCURRENCY: 5,
  MAX_PAGES: 20,
}
```

## Testing
- All existing tests pass
- Type-check passes
- Recommend testing with real Plaud account with many recordings