### PR TITLE
fix: allow custom Plaud API server URLs

### DIFF
--- a/src/app/api/plaud/connect/route.ts
+++ b/src/app/api/plaud/connect/route.ts
@@ -5,11 +5,7 @@ import { plaudConnections, plaudDevices } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { encrypt } from "@/lib/encryption";
 import { PlaudClient } from "@/lib/plaud/client";
-import {
-    DEFAULT_SERVER_KEY,
-    PLAUD_SERVERS,
-    type PlaudServerKey,
-} from "@/lib/plaud/servers";
+import { DEFAULT_SERVER_KEY, resolveApiBase } from "@/lib/plaud/servers";
 
 export async function POST(request: Request) {
     try {
@@ -24,7 +20,11 @@ export async function POST(request: Request) {
             );
         }
 
-        const { bearerToken, server: serverKey } = await request.json();
+        const {
+            bearerToken,
+            server: serverKey,
+            customApiBase,
+        } = await request.json();
 
         if (!bearerToken) {
             return NextResponse.json(
@@ -34,14 +34,18 @@ export async function POST(request: Request) {
         }
 
         const resolvedKey = (serverKey ?? DEFAULT_SERVER_KEY) as string;
-        if (!Object.hasOwn(PLAUD_SERVERS, resolvedKey)) {
+        const apiBase = resolveApiBase(resolvedKey, customApiBase);
+        if (!apiBase) {
             return NextResponse.json(
-                { error: `Unknown server: ${resolvedKey}` },
+                {
+                    error:
+                        resolvedKey === "custom"
+                            ? "Please enter a valid Plaud API URL (https://...plaud.ai)"
+                            : `Unknown server: ${resolvedKey}`,
+                },
                 { status: 400 },
             );
         }
-
-        const apiBase = PLAUD_SERVERS[resolvedKey as PlaudServerKey].apiBase;
         const client = new PlaudClient(bearerToken, apiBase);
         const isValid = await client.testConnection();
 

--- a/src/app/api/plaud/connection/route.ts
+++ b/src/app/api/plaud/connection/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { plaudConnections } from "@/db/schema";
 import { auth } from "@/lib/auth";
-import { PLAUD_SERVERS, type PlaudServerKey } from "@/lib/plaud/servers";
+import { serverKeyFromApiBase } from "@/lib/plaud/servers";
 
 export async function GET(request: Request) {
     try {
@@ -24,20 +24,17 @@ export async function GET(request: Request) {
             .where(eq(plaudConnections.userId, session.user.id))
             .limit(1);
 
-        let server: PlaudServerKey | undefined;
-        if (connection) {
-            const entry = (
-                Object.entries(PLAUD_SERVERS) as [
-                    PlaudServerKey,
-                    (typeof PLAUD_SERVERS)[PlaudServerKey],
-                ][]
-            ).find(([, s]) => s.apiBase === connection.apiBase);
-            server = entry?.[0];
+        if (!connection) {
+            return NextResponse.json({ connected: false });
         }
 
+        const server = serverKeyFromApiBase(connection.apiBase);
+
         return NextResponse.json({
-            connected: !!connection,
+            connected: true,
             server,
+            // Include the raw URL so the UI can populate the custom field
+            ...(server === "custom" && { apiBase: connection.apiBase }),
         });
     } catch (error) {
         console.error("Error checking Plaud connection:", error);

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -52,6 +52,7 @@ export function OnboardingDialog({
     const [step, setStep] = useState<OnboardingStep>("welcome");
     const [bearerToken, setBearerToken] = useState("");
     const [server, setServer] = useState<PlaudServerKey>(DEFAULT_SERVER_KEY);
+    const [customApiBase, setCustomApiBase] = useState("");
     const [isLoading, setIsLoading] = useState(false);
     const [hasPlaudConnection, setHasPlaudConnection] = useState(false);
     const [hasAiProvider, setHasAiProvider] = useState(false);
@@ -65,6 +66,9 @@ export function OnboardingDialog({
                         setHasPlaudConnection(true);
                         if (data.server) {
                             setServer(data.server as PlaudServerKey);
+                        }
+                        if (data.apiBase) {
+                            setCustomApiBase(data.apiBase);
                         }
                     }
                 })
@@ -90,6 +94,7 @@ export function OnboardingDialog({
             setStep("welcome");
             setBearerToken("");
             setServer(DEFAULT_SERVER_KEY);
+            setCustomApiBase("");
             setIsLoading(false);
             setHasPlaudConnection(false);
             setHasAiProvider(false);
@@ -107,7 +112,11 @@ export function OnboardingDialog({
             const response = await fetch("/api/plaud/connect", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ bearerToken, server }),
+                body: JSON.stringify({
+                    bearerToken,
+                    server,
+                    ...(server === "custom" && { customApiBase }),
+                }),
             });
 
             if (!response.ok) {
@@ -363,6 +372,20 @@ export function OnboardingDialog({
                                                         .description
                                                 }
                                             </p>
+                                            {server === "custom" && (
+                                                <div className="mt-2">
+                                                    <Input
+                                                        placeholder="https://api-xxx.plaud.ai"
+                                                        value={customApiBase}
+                                                        onChange={(e) =>
+                                                            setCustomApiBase(
+                                                                e.target.value,
+                                                            )
+                                                        }
+                                                        disabled={isLoading}
+                                                    />
+                                                </div>
+                                            )}
                                         </div>
                                         <div className="space-y-2">
                                             <Label htmlFor="bearer-token">

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -27,6 +27,7 @@ export function OnboardingForm() {
     const [step, setStep] = useState<Step>("plaud");
     const [bearerToken, setBearerToken] = useState("");
     const [server, setServer] = useState<PlaudServerKey>(DEFAULT_SERVER_KEY);
+    const [customApiBase, setCustomApiBase] = useState("");
     const [isLoading, setIsLoading] = useState(false);
     const router = useRouter();
 
@@ -41,7 +42,11 @@ export function OnboardingForm() {
             const response = await fetch("/api/plaud/connect", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ bearerToken, server }),
+                body: JSON.stringify({
+                    bearerToken,
+                    server,
+                    ...(server === "custom" && { customApiBase }),
+                }),
             });
 
             if (!response.ok) throw new Error("Failed to connect");
@@ -126,6 +131,18 @@ export function OnboardingForm() {
                         <p className="text-xs text-muted-foreground">
                             {PLAUD_SERVERS[server].description}
                         </p>
+                        {server === "custom" && (
+                            <div className="mt-2">
+                                <Input
+                                    placeholder="https://api-xxx.plaud.ai"
+                                    value={customApiBase}
+                                    onChange={(e) =>
+                                        setCustomApiBase(e.target.value)
+                                    }
+                                    disabled={isLoading}
+                                />
+                            </div>
+                        )}
                     </div>
 
                     <div className="space-y-2">

--- a/src/lib/plaud/servers.ts
+++ b/src/lib/plaud/servers.ts
@@ -16,7 +16,62 @@ export const PLAUD_SERVERS = {
             "Asia Pacific server — used by APAC accounts (api-apse1.plaud.ai)",
         apiBase: "https://api-apse1.plaud.ai",
     },
+    custom: {
+        label: "Custom",
+        description:
+            "Enter a custom Plaud API server URL (e.g. https://api-xxx.plaud.ai)",
+        apiBase: "",
+    },
 } as const;
 
 export type PlaudServerKey = keyof typeof PLAUD_SERVERS;
 export const DEFAULT_SERVER_KEY: PlaudServerKey = "global";
+
+/**
+ * Validate that a URL is a legitimate Plaud API server.
+ * Must be HTTPS and on a plaud.ai subdomain.
+ */
+export function isValidPlaudApiUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return (
+            parsed.protocol === "https:" &&
+            (parsed.hostname === "plaud.ai" ||
+                parsed.hostname.endsWith(".plaud.ai"))
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Resolve a server key (and optional custom URL) to an API base URL.
+ * Returns null if the input is invalid.
+ */
+export function resolveApiBase(
+    serverKey: string,
+    customApiBase?: string,
+): string | null {
+    if (serverKey === "custom") {
+        if (!customApiBase || !isValidPlaudApiUrl(customApiBase)) return null;
+        // Normalize: strip trailing slash
+        return customApiBase.replace(/\/+$/, "");
+    }
+    if (!Object.hasOwn(PLAUD_SERVERS, serverKey)) return null;
+    return PLAUD_SERVERS[serverKey as Exclude<PlaudServerKey, "custom">]
+        .apiBase;
+}
+
+/**
+ * Find the server key for a stored apiBase URL.
+ * Returns the key if it matches a known server, otherwise "custom".
+ */
+export function serverKeyFromApiBase(apiBase: string): PlaudServerKey {
+    const entry = (
+        Object.entries(PLAUD_SERVERS) as [
+            PlaudServerKey,
+            (typeof PLAUD_SERVERS)[PlaudServerKey],
+        ][]
+    ).find(([key, s]) => key !== "custom" && s.apiBase === apiBase);
+    return entry?.[0] ?? "custom";
+}

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -9,7 +9,13 @@ import {
     vi,
 } from "vitest";
 import { DEFAULT_PLAUD_API_BASE, PlaudClient } from "../lib/plaud/client";
-import { DEFAULT_SERVER_KEY, PLAUD_SERVERS } from "../lib/plaud/servers";
+import {
+    DEFAULT_SERVER_KEY,
+    isValidPlaudApiUrl,
+    PLAUD_SERVERS,
+    resolveApiBase,
+    serverKeyFromApiBase,
+} from "../lib/plaud/servers";
 
 const originalFetch = global.fetch;
 let mockFetch: Mock;
@@ -230,6 +236,78 @@ describe("PlaudClient", () => {
         it("should reject unknown server keys", () => {
             const unknownKey = "evil";
             expect(unknownKey in PLAUD_SERVERS).toBe(false);
+        });
+    });
+
+    describe("isValidPlaudApiUrl", () => {
+        it("should accept valid plaud.ai HTTPS URLs", () => {
+            expect(isValidPlaudApiUrl("https://api.plaud.ai")).toBe(true);
+            expect(isValidPlaudApiUrl("https://api-euc1.plaud.ai")).toBe(true);
+            expect(isValidPlaudApiUrl("https://api-apse1.plaud.ai")).toBe(true);
+            expect(isValidPlaudApiUrl("https://api-usw1.plaud.ai")).toBe(true);
+        });
+
+        it("should reject non-plaud domains", () => {
+            expect(isValidPlaudApiUrl("https://evil.com")).toBe(false);
+            expect(isValidPlaudApiUrl("https://plaud.ai.evil.com")).toBe(false);
+            expect(isValidPlaudApiUrl("https://notplaud.ai")).toBe(false);
+        });
+
+        it("should reject non-HTTPS URLs", () => {
+            expect(isValidPlaudApiUrl("http://api.plaud.ai")).toBe(false);
+        });
+
+        it("should reject invalid URLs", () => {
+            expect(isValidPlaudApiUrl("")).toBe(false);
+            expect(isValidPlaudApiUrl("not-a-url")).toBe(false);
+        });
+    });
+
+    describe("resolveApiBase", () => {
+        it("should resolve known server keys", () => {
+            expect(resolveApiBase("global")).toBe("https://api.plaud.ai");
+            expect(resolveApiBase("eu")).toBe("https://api-euc1.plaud.ai");
+            expect(resolveApiBase("apse1")).toBe("https://api-apse1.plaud.ai");
+        });
+
+        it("should resolve custom key with valid URL", () => {
+            expect(resolveApiBase("custom", "https://api-usw1.plaud.ai")).toBe(
+                "https://api-usw1.plaud.ai",
+            );
+        });
+
+        it("should strip trailing slashes from custom URLs", () => {
+            expect(resolveApiBase("custom", "https://api.plaud.ai/")).toBe(
+                "https://api.plaud.ai",
+            );
+        });
+
+        it("should return null for custom key with invalid URL", () => {
+            expect(resolveApiBase("custom", "https://evil.com")).toBeNull();
+            expect(resolveApiBase("custom", "")).toBeNull();
+            expect(resolveApiBase("custom")).toBeNull();
+        });
+
+        it("should return null for unknown server keys", () => {
+            expect(resolveApiBase("evil")).toBeNull();
+        });
+    });
+
+    describe("serverKeyFromApiBase", () => {
+        it("should return known keys for known URLs", () => {
+            expect(serverKeyFromApiBase("https://api.plaud.ai")).toBe("global");
+            expect(serverKeyFromApiBase("https://api-euc1.plaud.ai")).toBe(
+                "eu",
+            );
+            expect(serverKeyFromApiBase("https://api-apse1.plaud.ai")).toBe(
+                "apse1",
+            );
+        });
+
+        it("should return 'custom' for unknown URLs", () => {
+            expect(serverKeyFromApiBase("https://api-usw1.plaud.ai")).toBe(
+                "custom",
+            );
         });
     });
 


### PR DESCRIPTION
Closes #42

## Problem
Users on undiscovered regional Plaud servers (e.g. `api-apse1.plaud.ai` before it was hardcoded) were blocked during onboarding because only known server options were available in the dropdown.

## Solution
Added a **Custom** option to the server selector that reveals a URL input field. Custom URLs are validated server-side to ensure they are `https://` on a `.plaud.ai` subdomain (prevents SSRF).

### Changes
- `src/lib/plaud/servers.ts` — Added `custom` server entry + `isValidPlaudApiUrl()`, `resolveApiBase()`, `serverKeyFromApiBase()` helpers
- `src/app/api/plaud/connect/route.ts` — Accepts `customApiBase` in request body
- `src/app/api/plaud/connection/route.ts` — Returns custom server info for reconnect UI
- `src/components/onboarding-dialog.tsx` + `onboarding-form.tsx` — Custom URL input when "Custom" is selected
- `src/tests/plaud.test.ts` — 11 new tests for validation and resolution

### Edge cases
- Trailing slashes normalized
- Existing custom connections pre-populate the URL field on reconnect
- Clear error messages for invalid custom URLs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Custom” Plaud API server option in onboarding so users on regional servers not yet listed can connect. Validates URLs to be `https://` on `.plaud.ai` to keep connections safe.

- **New Features**
  - “Custom” server option with URL input in onboarding dialog and form.
  - Server-side validation for `https://` `.plaud.ai` URLs; strips trailing slashes and shows clear errors.
  - Connection endpoint returns `server` and `apiBase` so reconnect flows prefill custom URLs.
  - New helpers (`isValidPlaudApiUrl`, `resolveApiBase`, `serverKeyFromApiBase`) and 11 tests covering validation and resolution.

<sup>Written for commit 738efbd0dfc56b55e5f293eebd1f3c365c63d124. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

