### PR TITLE
docs: clarify bearer token format in onboarding and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,11 @@ The onboarding wizard will guide you through:
 2. Open DevTools (`F12`) → **Network** tab
 3. Refresh the page
 4. Find any request to the Plaud API server (e.g. `api.plaud.ai` or `api-euc1.plaud.ai` for EU accounts)
-5. Copy the **Authorization** header value (starts with `Bearer `)
+5. Copy the **Authorization** header value (just the JWT token after `Bearer ` — do not include the word "Bearer")
 6. Note which API server hostname appears in the requests — you will need to select it during onboarding
 
 > 💡 **Tip**: The bearer token is used to sync recordings from your Plaud device. Keep it secure!
+> ⚠️ **Note**: Only paste the JWT token (e.g., `eyJhbGciOiJ...`), not the full `Bearer eyJ...` header value.
 
 ### 💾 Storage Options
 

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -98,8 +98,7 @@ export function OnboardingForm() {
                             <li>Refresh the page</li>
                             <li>Find any request to the Plaud API server</li>
                             <li>
-                                Copy the Authorization header value (starts with
-                                &quot;Bearer &quot;)
+                                Copy the Authorization header value (just the token part after &quot;Bearer &quot;)
                             </li>
                         </ol>
                     </Panel>
@@ -150,7 +149,7 @@ export function OnboardingForm() {
                         <Input
                             id="bearerToken"
                             type="text"
-                            placeholder="Bearer ..."
+                            placeholder="eyJhbGciOiJ..."
                             value={bearerToken}
                             onChange={(e) => setBearerToken(e.target.value)}
                             disabled={isLoading}

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -98,7 +98,8 @@ export function OnboardingForm() {
                             <li>Refresh the page</li>
                             <li>Find any request to the Plaud API server</li>
                             <li>
-                                Copy the Authorization header value (just the token part after &quot;Bearer &quot;)
+                                Copy the Authorization header value (just the
+                                token part after &quot;Bearer &quot;)
                             </li>
                         </ol>
                     </Panel>


### PR DESCRIPTION

## Description

Updates the onboarding UI and documentation to clarify that users should paste only the JWT token (e.g., `eyJhbGciOiJ...`) rather than the full Authorization header value (e.g., `Bearer eyJhbGciOiJ...`). This prevents confusion and 401 authentication errors when users accidentally include the "Bearer " prefix in the token field.

**Note:** An alternative approach would be to automatically strip the "Bearer " prefix on the backend if detected, which could be implemented in a follow-up PR.

## Type of Change

- [x] Documentation update

## Changes Made

- Updated onboarding hint text to clarify: "Copy the Authorization header value (just the token part after "Bearer ")"
- Changed input placeholder from `"Bearer ..."` to `"eyJhbGciOiJ..."` to show expected format
- Added warning note to README about only pasting the JWT token, not the full `Bearer eyJ...` header value

## Testing

### Test Environment
- OS: macOS
- Node version: 20.x
- Browser: Chrome

### Test Steps
1. Navigate to onboarding page
2. Verify hint text no longer suggests copying full "Bearer ..." value
3. Verify placeholder shows JWT format without "Bearer" prefix
4. Verify README instructions are clear about token format

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] Type checking passes (`pnpm type-check`)

## Additional Notes

The token input field now makes it clearer that only the JWT portion should be pasted. This addresses the common user error of pasting `Bearer eyJhbG...` instead of just `eyJhbG...`, which previously caused 401 Unauthorized errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the bearer token format in onboarding and README so users paste only the JWT (e.g., eyJ...), not the full "Bearer ..." header. Prevents 401 errors from including the "Bearer " prefix.

- **Bug Fixes**
  - Onboarding hint: “Copy the Authorization header value (just the token after ‘Bearer ’)”.
  - Input placeholder changed from “Bearer ...” to “eyJhbGciOiJ...”.
  - README: updated step to call out “do not include the word ‘Bearer’” and added a warning note to paste only the JWT.

<sup>Written for commit 3b719e0b418c0c8addac3cead9ea43cccef9a804. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

