### PR TITLE
feat: lightweight CLI for syncing and transcribing recordings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ next-env.d.ts
 /storage
 /audio
 plans/
+
+# cli
+cli/node_modules
+cli/bun.lock

--- a/cli/README.md
+++ b/cli/README.md
@@ -120,9 +120,38 @@ openplaud sync --json                        # JSON output for scripting
 openplaud sync -l de                         # Language hint for all transcriptions
 ```
 
+### `openplaud dictionary`
+
+Manage a dictionary of domain-specific terms and correction rules that improve transcription accuracy. Terms are passed to the Whisper `prompt` parameter to bias recognition. Correction rules are also applied as post-processing find-and-replace on the output.
+
+```bash
+openplaud dictionary              # Show all terms and corrections
+openplaud dictionary show         # Same as above
+openplaud dictionary edit         # Open in $EDITOR
+openplaud dictionary path         # Print the file path
+openplaud dictionary add TiVA     # Add a term
+openplaud dictionary add "Plot → Plaud"  # Add a correction rule
+```
+
+The dictionary file lives at `~/.config/openplaud-cli/dictionary.txt`. Format:
+
+```
+# Terms — bias Whisper toward recognizing these words
+TiVA
+Preclinics
+Smartkomm
+
+# Corrections — also replace in output if Whisper still gets it wrong
+Plot → Plaud
+Diva → TiVA
+Smart-Com → Smartkomm
+```
+
+The dictionary is loaded automatically on every transcription — no flags needed.
+
 ## Configuration
 
-Credentials are stored in `~/.config/openplaud-cli/config.json` with `0600` permissions (owner-only read/write). Sync state is tracked in `~/.config/openplaud-cli/state.json`.
+Credentials are stored in `~/.config/openplaud-cli/config.json` with `0600` permissions (owner-only read/write). Sync state is tracked in `~/.config/openplaud-cli/state.json`. The dictionary is at `~/.config/openplaud-cli/dictionary.txt`.
 
 ### Getting Your Plaud Bearer Token
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,167 @@
+# OpenPlaud CLI
+
+Lightweight command-line interface for syncing and transcribing recordings from [Plaud Note](https://plaud.ai) devices. Reuses the Plaud API client from the main OpenPlaud project — no database, no web server, just a single binary.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) ≥ 1.0
+- A Plaud account with a bearer token (see [Getting Your Token](#getting-your-plaud-bearer-token))
+- An OpenAI-compatible API key for transcription (OpenAI, Groq, etc.)
+
+## Quick Start
+
+```bash
+# From the repository root
+cd cli
+bun install
+
+# Set up credentials
+bun src/index.ts auth \
+  --token "eyJhbGciOi..." \
+  --server eu \
+  --whisper-key "sk-..." \
+  --whisper-model whisper-1
+
+# List your recordings
+bun src/index.ts recordings
+
+# Transcribe a specific recording
+bun src/index.ts transcribe <recording-id>
+
+# Sync all new recordings (download + transcribe)
+bun src/index.ts sync --output-dir ./plaud-recordings
+```
+
+## Commands
+
+### `openplaud auth`
+
+Configure credentials. Validates the bearer token against the Plaud API before saving.
+
+```bash
+# Full setup
+openplaud auth \
+  --token "eyJhbGciOi..." \
+  --server eu \
+  --whisper-key "sk-..." \
+  --whisper-model whisper-1
+
+# Update just the Whisper provider (e.g. switch to Groq)
+openplaud auth \
+  --whisper-key "gsk_..." \
+  --whisper-url "https://api.groq.com/openai/v1" \
+  --whisper-model whisper-large-v3
+
+# Show current config (redacted)
+openplaud auth --show
+```
+
+**API Servers:**
+- `global` — api.plaud.ai (default for most accounts)
+- `eu` — api-euc1.plaud.ai (European accounts, Frankfurt)
+- `apse1` — api-apse1.plaud.ai (Asia Pacific, Singapore)
+- Or pass a custom `https://*.plaud.ai` URL
+
+### `openplaud devices`
+
+List Plaud devices connected to your account.
+
+```bash
+openplaud devices          # Human-readable
+openplaud devices --json   # Machine-readable
+```
+
+### `openplaud recordings`
+
+List recordings from your Plaud account.
+
+```bash
+openplaud recordings                     # Last 20 recordings
+openplaud recordings -n 50               # Last 50
+openplaud recordings --since 2h          # Recorded in the last 2 hours
+openplaud recordings --since 7d          # Last 7 days
+openplaud recordings --since 2025-01-01  # Since a specific date
+openplaud recordings --json              # JSON output
+openplaud recordings --ids-only          # Just IDs (for scripting)
+```
+
+### `openplaud download`
+
+Download a recording's audio file.
+
+```bash
+openplaud download <id>                   # Downloads to ./<id>.mp3
+openplaud download <id> -o braindump.mp3  # Custom output path
+openplaud download <id> --opus            # OPUS format (smaller)
+```
+
+### `openplaud transcribe`
+
+Download and transcribe a single recording. Audio is downloaded, sent to the configured Whisper API, and the transcription is printed to stdout.
+
+```bash
+openplaud transcribe <id>                # Print transcription to stdout
+openplaud transcribe <id> -o notes.txt   # Save to file
+openplaud transcribe <id> --json         # JSON with metadata
+openplaud transcribe <id> -l de          # Hint: German language
+```
+
+### `openplaud sync`
+
+Sync new recordings since the last sync. Downloads audio, transcribes, saves both to disk, and tracks state so the next sync only fetches what's new.
+
+```bash
+openplaud sync                               # Sync since last run
+openplaud sync --since 7d                    # Sync last 7 days
+openplaud sync --output-dir ./recordings     # Save to specific directory
+openplaud sync --no-transcribe               # Download only, skip Whisper
+openplaud sync --dry-run                     # Preview what would be synced
+openplaud sync --json                        # JSON output for scripting
+openplaud sync -l de                         # Language hint for all transcriptions
+```
+
+## Configuration
+
+Credentials are stored in `~/.config/openplaud-cli/config.json` with `0600` permissions (owner-only read/write). Sync state is tracked in `~/.config/openplaud-cli/state.json`.
+
+### Getting Your Plaud Bearer Token
+
+1. Go to [plaud.ai](https://plaud.ai) and log in
+2. Open DevTools (`F12`) → **Network** tab
+3. Refresh the page
+4. Find any request to `api.plaud.ai` (or `api-euc1.plaud.ai` for EU)
+5. Copy the `Authorization` header value (the part after `Bearer `)
+6. Note which API server hostname you see — use the matching `--server` flag
+
+### Whisper Providers
+
+The CLI works with any OpenAI-compatible Whisper API:
+
+| Provider | Base URL | Model | Cost |
+|----------|----------|-------|------|
+| OpenAI | *(default)* | `whisper-1` | $0.006/min |
+| Groq | `https://api.groq.com/openai/v1` | `whisper-large-v3` | Free |
+| Together AI | `https://api.together.xyz/v1` | `whisper-large-v3` | Varies |
+
+## Scripting Examples
+
+```bash
+# Transcribe the latest recording and copy to clipboard
+openplaud recordings --ids-only -n 1 | xargs openplaud transcribe | pbcopy
+
+# Sync and pipe each transcription somewhere
+openplaud sync --json | jq -r '.[] | select(.transcription) | .transcription'
+
+# Daily cron: sync new recordings to a directory
+0 */2 * * * cd /path/to/openplaud/cli && bun src/index.ts sync -o ~/plaud-sync -l de
+```
+
+## Development
+
+```bash
+cd cli
+bun install
+bun src/index.ts --help
+```
+
+The CLI imports the Plaud API client from `../src/lib/plaud/` — the same code that powers the OpenPlaud web app. No duplication.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "openplaud-cli",
+    "version": "0.1.0",
+    "description": "Lightweight CLI for syncing and transcribing Plaud Note recordings",
+    "type": "module",
+    "bin": {
+        "openplaud": "./src/index.ts"
+    },
+    "scripts": {
+        "start": "bun src/index.ts",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "commander": "^13.1.0",
+        "openai": "^6.9.1"
+    },
+    "devDependencies": {
+        "@types/node": "^20",
+        "typescript": "^5"
+    }
+}

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,0 +1,16 @@
+import { PlaudClient, DEFAULT_PLAUD_API_BASE } from "@/lib/plaud/client";
+import { resolveApiBase } from "@/lib/plaud/servers";
+import type { CliConfig } from "./config";
+
+/**
+ * Create a PlaudClient from CLI config.
+ * Unlike the web app's createPlaudClient, this doesn't need encryption —
+ * the CLI stores the raw token in a file with 0600 permissions.
+ */
+export function createClient(config: CliConfig): PlaudClient {
+    const apiBase =
+        resolveApiBase(config.apiServer, config.customApiBase) ??
+        DEFAULT_PLAUD_API_BASE;
+
+    return new PlaudClient(config.bearerToken, apiBase);
+}

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -21,7 +21,6 @@ export const authCommand = new Command("auth")
     .option(
         "-s, --server <server>",
         `Plaud API server: ${SERVER_KEYS.join(", ")}, or a custom URL`,
-        "eu",
     )
     .option(
         "--whisper-key <key>",
@@ -76,18 +75,34 @@ export const authCommand = new Command("auth")
             process.exit(1);
         }
 
-        // Resolve API server
+        // Resolve API server — only overwrite when --server was explicitly passed
         let apiServer: PlaudServerKey = existing?.apiServer ?? "eu";
         let customApiBase: string | undefined = existing?.customApiBase;
 
-        if (opts.server) {
+        if (opts.server !== undefined) {
             if (opts.server in PLAUD_SERVERS) {
                 apiServer = opts.server as PlaudServerKey;
                 customApiBase = undefined;
-            } else if (
-                opts.server.startsWith("https://") &&
-                opts.server.includes("plaud.ai")
-            ) {
+            } else if (opts.server.startsWith("https://")) {
+                // Validate the hostname is exactly plaud.ai or a subdomain of it
+                let hostname: string;
+                try {
+                    hostname = new URL(opts.server).hostname;
+                } catch {
+                    console.error(
+                        `Invalid server URL: ${opts.server}`,
+                    );
+                    process.exit(1);
+                }
+                if (
+                    hostname !== "plaud.ai" &&
+                    !hostname.endsWith(".plaud.ai")
+                ) {
+                    console.error(
+                        `Custom server must be a plaud.ai domain (got: ${hostname})`,
+                    );
+                    process.exit(1);
+                }
                 apiServer = "custom";
                 customApiBase = opts.server.replace(/\/+$/, "");
             } else {

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,0 +1,175 @@
+import { Command } from "commander";
+import { PLAUD_SERVERS, type PlaudServerKey } from "@/lib/plaud/servers";
+import { PlaudClient } from "@/lib/plaud/client";
+import {
+    type CliConfig,
+    getConfigDir,
+    loadConfig,
+    saveConfig,
+} from "../config";
+
+const SERVER_KEYS = Object.keys(PLAUD_SERVERS).filter(
+    (k) => k !== "custom",
+) as PlaudServerKey[];
+
+export const authCommand = new Command("auth")
+    .description("Configure Plaud API credentials and Whisper settings")
+    .option(
+        "-t, --token <token>",
+        "Plaud bearer token (from browser DevTools)",
+    )
+    .option(
+        "-s, --server <server>",
+        `Plaud API server: ${SERVER_KEYS.join(", ")}, or a custom URL`,
+        "eu",
+    )
+    .option(
+        "--whisper-key <key>",
+        "OpenAI-compatible API key for Whisper transcription",
+    )
+    .option(
+        "--whisper-url <url>",
+        "OpenAI-compatible base URL (e.g. https://api.groq.com/openai/v1)",
+    )
+    .option(
+        "--whisper-model <model>",
+        "Whisper model name (default: whisper-1)",
+    )
+    .option("--show", "Show current configuration (redacted)")
+    .action(async (opts) => {
+        if (opts.show) {
+            return showConfig();
+        }
+
+        const existing = loadConfig();
+
+        if (
+            !opts.token &&
+            !opts.whisperKey &&
+            !opts.whisperUrl &&
+            !opts.whisperModel &&
+            !existing
+        ) {
+            console.error("Usage: openplaud auth --token <bearer-token>");
+            console.error("");
+            console.error("Required for first setup:");
+            console.error(
+                "  --token <token>    Bearer token from plaud.ai DevTools",
+            );
+            console.error("");
+            console.error("Optional:");
+            console.error(
+                `  --server <server>  API server: ${SERVER_KEYS.join(", ")} (default: eu)`,
+            );
+            console.error(
+                "  --whisper-key      API key for Whisper transcription",
+            );
+            console.error(
+                "  --whisper-url      Base URL for OpenAI-compatible Whisper API",
+            );
+            console.error(
+                "  --whisper-model    Whisper model (default: whisper-1)",
+            );
+            console.error("");
+            console.error("Show current config:");
+            console.error("  openplaud auth --show");
+            process.exit(1);
+        }
+
+        // Resolve API server
+        let apiServer: PlaudServerKey = existing?.apiServer ?? "eu";
+        let customApiBase: string | undefined = existing?.customApiBase;
+
+        if (opts.server) {
+            if (opts.server in PLAUD_SERVERS) {
+                apiServer = opts.server as PlaudServerKey;
+                customApiBase = undefined;
+            } else if (
+                opts.server.startsWith("https://") &&
+                opts.server.includes("plaud.ai")
+            ) {
+                apiServer = "custom";
+                customApiBase = opts.server.replace(/\/+$/, "");
+            } else {
+                console.error(
+                    `Invalid server. Use one of: ${SERVER_KEYS.join(", ")} or a https://*.plaud.ai URL`,
+                );
+                process.exit(1);
+            }
+        }
+
+        const config: CliConfig = {
+            bearerToken: opts.token ?? existing?.bearerToken ?? "",
+            apiServer,
+            customApiBase,
+            whisperApiKey:
+                opts.whisperKey ?? existing?.whisperApiKey ?? undefined,
+            whisperBaseUrl:
+                opts.whisperUrl ?? existing?.whisperBaseUrl ?? undefined,
+            whisperModel:
+                opts.whisperModel ?? existing?.whisperModel ?? undefined,
+        };
+
+        if (!config.bearerToken) {
+            console.error("Bearer token is required. Use --token <token>");
+            process.exit(1);
+        }
+
+        // Validate the bearer token by trying to list devices
+        process.stdout.write("Validating bearer token... ");
+        const apiBase =
+            apiServer === "custom" && customApiBase
+                ? customApiBase
+                : PLAUD_SERVERS[
+                      apiServer as Exclude<PlaudServerKey, "custom">
+                  ]?.apiBase ?? PLAUD_SERVERS.global.apiBase;
+
+        const client = new PlaudClient(config.bearerToken, apiBase);
+        try {
+            const valid = await client.testConnection();
+            if (!valid) {
+                console.error(
+                    "FAILED\nBearer token is invalid or expired. Get a fresh one from plaud.ai DevTools.",
+                );
+                process.exit(1);
+            }
+            console.log("OK");
+        } catch (err) {
+            console.error(
+                `FAILED\n${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+
+        saveConfig(config);
+        console.log(`Configuration saved to ${getConfigDir()}/config.json`);
+        showConfig(config);
+    });
+
+function showConfig(config?: CliConfig | null): void {
+    const c = config ?? loadConfig();
+    if (!c) {
+        console.log("Not configured. Run `openplaud auth` first.");
+        return;
+    }
+
+    const redact = (s: string | undefined) =>
+        s ? `${s.slice(0, 8)}...${s.slice(-4)}` : "(not set)";
+
+    const serverLabel =
+        c.apiServer === "custom"
+            ? c.customApiBase ?? "custom (no URL)"
+            : PLAUD_SERVERS[c.apiServer as Exclude<PlaudServerKey, "custom">]
+                  ?.label ?? c.apiServer;
+
+    console.log("");
+    console.log("  Plaud API");
+    console.log(`    Token:   ${redact(c.bearerToken)}`);
+    console.log(`    Server:  ${serverLabel}`);
+    console.log("");
+    console.log("  Whisper (transcription)");
+    console.log(`    API Key: ${redact(c.whisperApiKey)}`);
+    console.log(`    Base URL: ${c.whisperBaseUrl || "(default: OpenAI)"}`);
+    console.log(`    Model:   ${c.whisperModel || "whisper-1"}`);
+    console.log("");
+}

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -13,13 +13,13 @@ export const devicesCommand = new Command("devices")
             const response = await client.listDevices();
             const devices = response.data_devices;
 
-            if (devices.length === 0) {
-                console.log("No devices found on this account.");
+            if (opts.json) {
+                console.log(JSON.stringify(devices, null, 2));
                 return;
             }
 
-            if (opts.json) {
-                console.log(JSON.stringify(devices, null, 2));
+            if (devices.length === 0) {
+                console.log("No devices found on this account.");
                 return;
             }
 

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import { requireConfig } from "../config";
+import { createClient } from "../client";
+
+export const devicesCommand = new Command("devices")
+    .description("List Plaud devices connected to your account")
+    .option("--json", "Output as JSON")
+    .action(async (opts) => {
+        const config = requireConfig();
+        const client = createClient(config);
+
+        try {
+            const response = await client.listDevices();
+            const devices = response.data_devices;
+
+            if (devices.length === 0) {
+                console.log("No devices found on this account.");
+                return;
+            }
+
+            if (opts.json) {
+                console.log(JSON.stringify(devices, null, 2));
+                return;
+            }
+
+            console.log(`Found ${devices.length} device(s):\n`);
+            for (const device of devices) {
+                console.log(`  ${device.name || "(unnamed)"}`);
+                console.log(`    Serial:  ${device.sn}`);
+                console.log(`    Model:   ${device.model}`);
+                console.log(`    Version: ${device.version_number}`);
+                console.log("");
+            }
+        } catch (err) {
+            console.error(
+                `Failed to list devices: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/cli/src/commands/dictionary.ts
+++ b/cli/src/commands/dictionary.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { readFileSync, appendFileSync } from "node:fs";
 import { Command } from "commander";
 import {
@@ -30,12 +30,16 @@ dictionaryCommand
         const path = ensureDictionaryFile();
         const editor = process.env.EDITOR || process.env.VISUAL || "vi";
         console.log(`Opening ${path} in ${editor}...`);
-        try {
-            execFileSync(editor, [path], { stdio: "inherit" });
-        } catch {
+        // Use shell: true so $EDITOR values with arguments (e.g. "code --wait") work
+        const result = spawnSync(`${editor} "${path}"`, {
+            stdio: "inherit",
+            shell: true,
+        });
+        if (result.error || result.status !== 0) {
             console.error(
                 `Failed to open editor. Edit the file directly: ${path}`,
             );
+            process.exit(1);
         }
     });
 

--- a/cli/src/commands/dictionary.ts
+++ b/cli/src/commands/dictionary.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, appendFileSync } from "node:fs";
+import { Command } from "commander";
+import {
+    getDictionaryPath,
+    ensureDictionaryFile,
+    loadDictionary,
+} from "../dictionary";
+
+export const dictionaryCommand = new Command("dictionary")
+    .description(
+        "Manage the dictionary for improved transcription accuracy (terms and corrections)",
+    )
+    .action(() => {
+        // Default action: show the dictionary
+        showDictionary();
+    });
+
+dictionaryCommand
+    .command("show")
+    .description("Show all terms and corrections in the dictionary")
+    .action(() => {
+        showDictionary();
+    });
+
+dictionaryCommand
+    .command("edit")
+    .description("Open the dictionary file in your editor ($EDITOR)")
+    .action(() => {
+        const path = ensureDictionaryFile();
+        const editor = process.env.EDITOR || process.env.VISUAL || "vi";
+        console.log(`Opening ${path} in ${editor}...`);
+        try {
+            execFileSync(editor, [path], { stdio: "inherit" });
+        } catch {
+            console.error(
+                `Failed to open editor. Edit the file directly: ${path}`,
+            );
+        }
+    });
+
+dictionaryCommand
+    .command("path")
+    .description("Print the dictionary file path")
+    .action(() => {
+        console.log(getDictionaryPath());
+    });
+
+dictionaryCommand
+    .command("add")
+    .description(
+        'Add a term or correction (e.g., "TiVA" or "Diva → TiVA")',
+    )
+    .argument("<entry...>", "Term or correction to add")
+    .action((entryParts: string[]) => {
+        const entry = entryParts.join(" ");
+        const path = ensureDictionaryFile();
+
+        // Check if it already exists
+        const content = readFileSync(path, "utf-8");
+        if (content.split("\n").some((line) => line.trim() === entry)) {
+            console.log(`Already in dictionary: ${entry}`);
+            return;
+        }
+
+        appendFileSync(path, `${entry}\n`, "utf-8");
+        console.log(`Added: ${entry}`);
+    });
+
+function showDictionary(): void {
+    const dict = loadDictionary();
+
+    if (dict.terms.length === 0 && dict.corrections.length === 0) {
+        console.log("Dictionary is empty.");
+        console.log(
+            "\nAdd terms to improve transcription accuracy:",
+        );
+        console.log("  openplaud dictionary add TiVA");
+        console.log('  openplaud dictionary add "Plot → Plaud"');
+        console.log("  openplaud dictionary edit");
+        return;
+    }
+
+    const plainTerms = dict.terms.filter(
+        (t) => !dict.corrections.some((c) => c.to === t),
+    );
+
+    if (plainTerms.length > 0) {
+        console.log(`Terms (${plainTerms.length}):`);
+        for (const term of plainTerms) {
+            console.log(`  ${term}`);
+        }
+    }
+
+    if (dict.corrections.length > 0) {
+        if (plainTerms.length > 0) console.log("");
+        console.log(`Corrections (${dict.corrections.length}):`);
+        for (const { from, to } of dict.corrections) {
+            console.log(`  ${from} → ${to}`);
+        }
+    }
+
+    console.log(`\nFile: ${getDictionaryPath()}`);
+}

--- a/cli/src/commands/download.ts
+++ b/cli/src/commands/download.ts
@@ -1,0 +1,32 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import { requireConfig } from "../config";
+import { createClient } from "../client";
+
+export const downloadCommand = new Command("download")
+    .description("Download a recording's audio file")
+    .argument("<id>", "Recording ID (from `openplaud recordings`)")
+    .option("-o, --output <path>", "Output file path (default: <id>.mp3)")
+    .option("--opus", "Download in OPUS format instead of MP3")
+    .action(async (id: string, opts) => {
+        const config = requireConfig();
+        const client = createClient(config);
+
+        const ext = opts.opus ? "opus" : "mp3";
+        const outputPath = resolve(opts.output || `${id}.${ext}`);
+
+        try {
+            process.stdout.write(`Downloading recording ${id}... `);
+            const buffer = await client.downloadRecording(id, !!opts.opus);
+            writeFileSync(outputPath, buffer);
+            const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
+            console.log(`OK (${sizeMB} MB)`);
+            console.log(`Saved to: ${outputPath}`);
+        } catch (err) {
+            console.error(
+                `\nFailed to download: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/cli/src/commands/recordings.ts
+++ b/cli/src/commands/recordings.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander";
+import { requireConfig } from "../config";
+import { createClient } from "../client";
+import { formatDuration, formatDate, formatSize, parseSince } from "../format";
+import type { PlaudRecording } from "@/types/plaud";
+
+function printRecording(rec: PlaudRecording, index?: number): void {
+    const prefix = index !== undefined ? `  ${index + 1}. ` : "  ";
+    console.log(`${prefix}${rec.filename || "(untitled)"}`);
+    console.log(`      ID:       ${rec.id}`);
+    console.log(`      Date:     ${formatDate(rec.start_time)}`);
+    console.log(`      Duration: ${formatDuration(rec.duration)}`);
+    console.log(`      Size:     ${formatSize(rec.filesize)}`);
+    console.log(`      Device:   ${rec.serial_number}`);
+    if (rec.is_trans) console.log("      Status:   transcribed (on Plaud)");
+    console.log("");
+}
+
+export const recordingsCommand = new Command("recordings")
+    .description("List recordings from your Plaud account")
+    .option("-n, --limit <number>", "Maximum recordings to show", "20")
+    .option("--skip <number>", "Skip first N recordings", "0")
+    .option(
+        "--since <date>",
+        "Only show recordings after this date (ISO 8601 or relative like '2h', '7d')",
+    )
+    .option("--trash", "Show trashed recordings instead")
+    .option("--json", "Output as JSON")
+    .option("--ids-only", "Output only recording IDs (one per line)")
+    .action(async (opts) => {
+        const config = requireConfig();
+        const client = createClient(config);
+
+        const limit = Number.parseInt(opts.limit, 10);
+        const skip = Number.parseInt(opts.skip, 10);
+
+        try {
+            const response = await client.getRecordings(
+                skip,
+                limit,
+                opts.trash ? 1 : 0,
+                "edit_time",
+                true,
+            );
+
+            let recordings = response.data_file_list;
+
+            // Filter by --since if provided
+            if (opts.since) {
+                const sinceMs = parseSince(opts.since);
+                recordings = recordings.filter(
+                    (r) => r.start_time >= sinceMs,
+                );
+            }
+
+            if (recordings.length === 0) {
+                console.log("No recordings found.");
+                return;
+            }
+
+            if (opts.json) {
+                console.log(JSON.stringify(recordings, null, 2));
+                return;
+            }
+
+            if (opts.idsOnly) {
+                for (const rec of recordings) {
+                    console.log(rec.id);
+                }
+                return;
+            }
+
+            console.log(
+                `Showing ${recordings.length} of ${response.data_file_total} recording(s):\n`,
+            );
+            for (let i = 0; i < recordings.length; i++) {
+                printRecording(recordings[i], i);
+            }
+        } catch (err) {
+            console.error(
+                `Failed to list recordings: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -227,9 +227,22 @@ export const syncCommand = new Command("sync")
                 }
             }
 
-            // Only advance lastSyncAt if at least one recording succeeded.
-            // This ensures failed recordings are retried on the next sync.
-            if (anySucceeded) {
+            // Advance lastSyncAt carefully: if any recordings still need
+            // retry (transcription failed or download error), set the cutoff
+            // just before the oldest unfinished recording so it's re-fetched
+            // on the next default sync.  If everything succeeded, advance to now.
+            const needsRetry = results.filter((r) => r.status !== "ok");
+            if (needsRetry.length > 0) {
+                const oldestRetryMs = Math.min(
+                    ...newRecordings
+                        .filter((rec) =>
+                            needsRetry.some((r) => r.id === rec.id),
+                        )
+                        .map((rec) => rec.start_time),
+                );
+                // Set cutoff 1 ms before the oldest unfinished recording
+                state.lastSyncAt = new Date(oldestRetryMs - 1).toISOString();
+            } else if (anySucceeded) {
                 state.lastSyncAt = new Date().toISOString();
             }
             saveState(state);

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -140,9 +140,15 @@ export const syncCommand = new Command("sync")
                         rec.id,
                         false,
                     );
-                    const safeName =
+                    const baseName =
                         rec.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
                         rec.id;
+                    // Include recording ID suffix to prevent filename collisions
+                    const shortId = rec.id.slice(-8);
+                    const safeName =
+                        baseName === rec.id
+                            ? baseName
+                            : `${baseName}_${shortId}`;
                     const audioPath = resolve(outputDir, `${safeName}.mp3`);
                     writeFileSync(audioPath, audioBuffer);
                     const sizeMB = (
@@ -152,6 +158,7 @@ export const syncCommand = new Command("sync")
                     process.stderr.write(`OK (${sizeMB} MB)`);
 
                     let transcription: string | undefined;
+                    let transcriptionFailed = false;
 
                     // Transcribe if configured and not skipped
                     if (opts.transcribe !== false && config.whisperApiKey) {
@@ -174,6 +181,7 @@ export const syncCommand = new Command("sync")
                             writeFileSync(txtPath, transcription);
                             process.stderr.write("OK");
                         } catch (err) {
+                            transcriptionFailed = true;
                             process.stderr.write(
                                 `FAILED (${err instanceof Error ? err.message : String(err)})`,
                             );
@@ -182,6 +190,9 @@ export const syncCommand = new Command("sync")
 
                     process.stderr.write("\n");
 
+                    const status = transcriptionFailed
+                        ? "transcription_failed"
+                        : "ok";
                     results.push({
                         id: rec.id,
                         filename: rec.filename,
@@ -189,12 +200,16 @@ export const syncCommand = new Command("sync")
                         transcription,
                         durationMs: rec.duration,
                         recordedAt: new Date(rec.start_time).toISOString(),
-                        status: "ok",
+                        status,
                     });
 
-                    // Track this recording as synced
-                    if (!state.knownRecordings) state.knownRecordings = {};
-                    state.knownRecordings[rec.id] = rec.version_ms;
+                    // Only mark as synced if fully successful — failed
+                    // transcriptions will be retried on the next sync run
+                    if (!transcriptionFailed) {
+                        if (!state.knownRecordings)
+                            state.knownRecordings = {};
+                        state.knownRecordings[rec.id] = rec.version_ms;
+                    }
                     anySucceeded = true;
                 } catch (err) {
                     process.stderr.write(
@@ -222,13 +237,18 @@ export const syncCommand = new Command("sync")
             // Summary
             const succeeded = results.filter((r) => r.status === "ok");
             const failed = results.filter((r) => r.status === "error");
+            const txFailed = results.filter(
+                (r) => r.status === "transcription_failed",
+            );
 
             if (opts.json) {
                 console.log(JSON.stringify(results, null, 2));
             } else {
-                console.log(
-                    `\nSync complete: ${succeeded.length} succeeded, ${failed.length} failed.`,
-                );
+                let summary = `\nSync complete: ${succeeded.length} succeeded, ${failed.length} failed.`;
+                if (txFailed.length > 0) {
+                    summary += ` ${txFailed.length} transcription(s) failed (will retry next sync).`;
+                }
+                console.log(summary);
 
                 if (succeeded.length > 0) {
                     console.log(`\nTranscriptions saved to: ${outputDir}`);
@@ -249,6 +269,6 @@ interface SyncResult {
     transcription?: string;
     durationMs?: number;
     recordedAt?: string;
-    status: "ok" | "error";
+    status: "ok" | "error" | "transcription_failed";
     error?: string;
 }

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -1,0 +1,254 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import { requireConfig } from "../config";
+import { loadState, saveState } from "../config";
+import { createClient } from "../client";
+import { transcribeAudio, DEFAULT_WHISPER_MODEL } from "../transcription";
+import { formatDuration, parseSince } from "../format";
+import type { PlaudRecording } from "@/types/plaud";
+
+const PAGE_SIZE = 50;
+
+export const syncCommand = new Command("sync")
+    .description(
+        "Sync new recordings: download audio, optionally transcribe, output results",
+    )
+    .option(
+        "--since <date>",
+        "Only sync recordings after this date (default: last sync time)",
+    )
+    .option("--no-transcribe", "Skip transcription, only download audio")
+    .option(
+        "-o, --output-dir <dir>",
+        "Directory to save audio and transcriptions",
+        ".",
+    )
+    .option(
+        "-l, --language <lang>",
+        "Language hint for Whisper (ISO 639-1, e.g. 'de', 'en')",
+    )
+    .option(
+        "--dry-run",
+        "Show what would be synced without downloading or transcribing",
+    )
+    .option("--json", "Output sync results as JSON")
+    .action(async (opts) => {
+        const config = requireConfig();
+        const client = createClient(config);
+        const state = loadState();
+
+        // Determine cutoff time
+        let sinceMs: number;
+        if (opts.since) {
+            sinceMs = parseSince(opts.since);
+        } else if (state.lastSyncAt) {
+            sinceMs = new Date(state.lastSyncAt).getTime();
+        } else {
+            // First sync ever — get everything from the last 24 hours
+            sinceMs = Date.now() - 24 * 60 * 60 * 1000;
+            console.log(
+                "First sync — fetching recordings from the last 24 hours.",
+            );
+            console.log(
+                "Use --since to go further back (e.g. --since 7d).\n",
+            );
+        }
+
+        try {
+            // Fetch all recordings, paginated — sort by start_time so our
+            // cutoff filter aligns with pagination order (newest first).
+            const newRecordings: PlaudRecording[] = [];
+            let skip = 0;
+            let hasMore = true;
+
+            process.stderr.write("Checking for new recordings... ");
+
+            while (hasMore) {
+                const response = await client.getRecordings(
+                    skip,
+                    PAGE_SIZE,
+                    0, // not trash
+                    "start_time", // sort by recording time, not edit time
+                    true, // descending (newest first)
+                );
+                const page = response.data_file_list;
+
+                if (page.length === 0) break;
+
+                for (const rec of page) {
+                    // Since we sort by start_time descending, once we hit
+                    // a recording older than our cutoff we can stop entirely.
+                    if (rec.start_time < sinceMs) {
+                        hasMore = false;
+                        break;
+                    }
+
+                    // Skip recordings we've already synced at this version
+                    const knownVersion = state.knownRecordings?.[rec.id];
+                    if (knownVersion && knownVersion >= rec.version_ms) {
+                        continue;
+                    }
+
+                    newRecordings.push(rec);
+                }
+
+                if (page.length < PAGE_SIZE) {
+                    hasMore = false;
+                }
+                skip += PAGE_SIZE;
+            }
+
+            console.log(`found ${newRecordings.length} new recording(s).`);
+
+            if (newRecordings.length === 0) {
+                return;
+            }
+
+            if (opts.dryRun) {
+                console.log("\nDry run — would sync:\n");
+                for (const rec of newRecordings) {
+                    const duration = formatDuration(rec.duration);
+                    const date = new Date(rec.start_time).toLocaleString();
+                    console.log(
+                        `  ${rec.filename || "(untitled)"} — ${duration} — ${date}`,
+                    );
+                    console.log(`    ID: ${rec.id}`);
+                }
+                return;
+            }
+
+            // Ensure output directory exists
+            const outputDir = resolve(opts.outputDir);
+            mkdirSync(outputDir, { recursive: true });
+
+            const results: SyncResult[] = [];
+            let anySucceeded = false;
+
+            for (let i = 0; i < newRecordings.length; i++) {
+                const rec = newRecordings[i];
+                const label = rec.filename || rec.id;
+                const progress = `[${i + 1}/${newRecordings.length}]`;
+
+                process.stderr.write(
+                    `${progress} ${label}: downloading... `,
+                );
+
+                try {
+                    // Download audio
+                    const audioBuffer = await client.downloadRecording(
+                        rec.id,
+                        false,
+                    );
+                    const safeName =
+                        rec.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
+                        rec.id;
+                    const audioPath = resolve(outputDir, `${safeName}.mp3`);
+                    writeFileSync(audioPath, audioBuffer);
+                    const sizeMB = (
+                        audioBuffer.length /
+                        (1024 * 1024)
+                    ).toFixed(1);
+                    process.stderr.write(`OK (${sizeMB} MB)`);
+
+                    let transcription: string | undefined;
+
+                    // Transcribe if configured and not skipped
+                    if (opts.transcribe !== false && config.whisperApiKey) {
+                        const model =
+                            config.whisperModel || DEFAULT_WHISPER_MODEL;
+                        process.stderr.write(` → transcribing (${model})... `);
+                        try {
+                            transcription = await transcribeAudio(
+                                audioBuffer,
+                                config,
+                                {
+                                    language: opts.language,
+                                    filename: `${safeName}.mp3`,
+                                },
+                            );
+                            const txtPath = resolve(
+                                outputDir,
+                                `${safeName}.txt`,
+                            );
+                            writeFileSync(txtPath, transcription);
+                            process.stderr.write("OK");
+                        } catch (err) {
+                            process.stderr.write(
+                                `FAILED (${err instanceof Error ? err.message : String(err)})`,
+                            );
+                        }
+                    }
+
+                    process.stderr.write("\n");
+
+                    results.push({
+                        id: rec.id,
+                        filename: rec.filename,
+                        audioPath,
+                        transcription,
+                        durationMs: rec.duration,
+                        recordedAt: new Date(rec.start_time).toISOString(),
+                        status: "ok",
+                    });
+
+                    // Track this recording as synced
+                    if (!state.knownRecordings) state.knownRecordings = {};
+                    state.knownRecordings[rec.id] = rec.version_ms;
+                    anySucceeded = true;
+                } catch (err) {
+                    process.stderr.write(
+                        `FAILED (${err instanceof Error ? err.message : String(err)})\n`,
+                    );
+                    results.push({
+                        id: rec.id,
+                        filename: rec.filename,
+                        status: "error",
+                        error:
+                            err instanceof Error
+                                ? err.message
+                                : String(err),
+                    });
+                }
+            }
+
+            // Only advance lastSyncAt if at least one recording succeeded.
+            // This ensures failed recordings are retried on the next sync.
+            if (anySucceeded) {
+                state.lastSyncAt = new Date().toISOString();
+            }
+            saveState(state);
+
+            // Summary
+            const succeeded = results.filter((r) => r.status === "ok");
+            const failed = results.filter((r) => r.status === "error");
+
+            if (opts.json) {
+                console.log(JSON.stringify(results, null, 2));
+            } else {
+                console.log(
+                    `\nSync complete: ${succeeded.length} succeeded, ${failed.length} failed.`,
+                );
+
+                if (succeeded.length > 0) {
+                    console.log(`\nTranscriptions saved to: ${outputDir}`);
+                }
+            }
+        } catch (err) {
+            console.error(
+                `Sync failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+    });
+
+interface SyncResult {
+    id: string;
+    filename: string;
+    audioPath?: string;
+    transcription?: string;
+    durationMs?: number;
+    recordedAt?: string;
+    status: "ok" | "error";
+    error?: string;
+}

--- a/cli/src/commands/transcribe.ts
+++ b/cli/src/commands/transcribe.ts
@@ -8,28 +8,33 @@ import type { PlaudRecording } from "@/types/plaud";
 import type { PlaudClient } from "@/lib/plaud/client";
 
 const SEARCH_PAGE_SIZE = 100;
-const MAX_SEARCH_PAGES = 10;
 
 /**
  * Find a recording by ID using paginated search.
  * The Plaud API doesn't expose a single-recording endpoint,
  * so we page through until we find it.
+ *
+ * No hard page cap — we search until the API returns fewer
+ * results than the page size (indicating the last page).
  */
 async function findRecordingById(
     client: PlaudClient,
     id: string,
 ): Promise<PlaudRecording | null> {
-    for (let page = 0; page < MAX_SEARCH_PAGES; page++) {
+    let skip = 0;
+    while (true) {
         const response = await client.getRecordings(
-            page * SEARCH_PAGE_SIZE,
+            skip,
             SEARCH_PAGE_SIZE,
             0,
             "edit_time",
             true,
         );
-        const match = response.data_file_list.find((r) => r.id === id);
+        const page = response.data_file_list;
+        const match = page.find((r) => r.id === id);
         if (match) return match;
-        if (response.data_file_list.length < SEARCH_PAGE_SIZE) break;
+        if (page.length < SEARCH_PAGE_SIZE) break;
+        skip += SEARCH_PAGE_SIZE;
     }
     return null;
 }

--- a/cli/src/commands/transcribe.ts
+++ b/cli/src/commands/transcribe.ts
@@ -1,0 +1,119 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import { requireConfig } from "../config";
+import { createClient } from "../client";
+import { transcribeAudio, DEFAULT_WHISPER_MODEL } from "../transcription";
+import type { PlaudRecording } from "@/types/plaud";
+import type { PlaudClient } from "@/lib/plaud/client";
+
+const SEARCH_PAGE_SIZE = 100;
+const MAX_SEARCH_PAGES = 10;
+
+/**
+ * Find a recording by ID using paginated search.
+ * The Plaud API doesn't expose a single-recording endpoint,
+ * so we page through until we find it.
+ */
+async function findRecordingById(
+    client: PlaudClient,
+    id: string,
+): Promise<PlaudRecording | null> {
+    for (let page = 0; page < MAX_SEARCH_PAGES; page++) {
+        const response = await client.getRecordings(
+            page * SEARCH_PAGE_SIZE,
+            SEARCH_PAGE_SIZE,
+            0,
+            "edit_time",
+            true,
+        );
+        const match = response.data_file_list.find((r) => r.id === id);
+        if (match) return match;
+        if (response.data_file_list.length < SEARCH_PAGE_SIZE) break;
+    }
+    return null;
+}
+
+export const transcribeCommand = new Command("transcribe")
+    .description(
+        "Download and transcribe a recording (downloads audio, sends to Whisper, outputs text)",
+    )
+    .argument("<id>", "Recording ID (from `openplaud recordings`)")
+    .option(
+        "-o, --output <path>",
+        "Write transcription to file instead of stdout",
+    )
+    .option(
+        "-l, --language <lang>",
+        "Language hint for Whisper (ISO 639-1, e.g. 'de', 'en')",
+    )
+    .option("--json", "Output as JSON with metadata")
+    .action(async (id: string, opts) => {
+        const config = requireConfig();
+        const client = createClient(config);
+
+        try {
+            // Find recording metadata
+            process.stderr.write(`Fetching recording ${id}... `);
+            const recording = await findRecordingById(client, id);
+
+            if (!recording) {
+                process.stderr.write("\n");
+                console.error(`Recording ${id} not found.`);
+                process.exit(1);
+            }
+            process.stderr.write("OK\n");
+
+            // Download audio
+            process.stderr.write("Downloading audio... ");
+            const audioBuffer = await client.downloadRecording(id, false);
+            const sizeMB = (audioBuffer.length / (1024 * 1024)).toFixed(1);
+            process.stderr.write(`OK (${sizeMB} MB)\n`);
+
+            // Transcribe
+            const model = config.whisperModel || DEFAULT_WHISPER_MODEL;
+            process.stderr.write(`Transcribing with ${model}... `);
+            const text = await transcribeAudio(audioBuffer, config, {
+                language: opts.language,
+                filename: `${recording.filename || id}.mp3`,
+            });
+            process.stderr.write("OK\n");
+
+            // Output
+            if (opts.json) {
+                const result = {
+                    id: recording.id,
+                    filename: recording.filename,
+                    duration_ms: recording.duration,
+                    recorded_at: new Date(recording.start_time).toISOString(),
+                    device: recording.serial_number,
+                    transcription: text,
+                    model,
+                    transcribed_at: new Date().toISOString(),
+                };
+                const jsonStr = JSON.stringify(result, null, 2);
+                if (opts.output) {
+                    writeFileSync(resolve(opts.output), jsonStr);
+                    process.stderr.write(
+                        `Written to: ${resolve(opts.output)}\n`,
+                    );
+                } else {
+                    console.log(jsonStr);
+                }
+            } else {
+                if (opts.output) {
+                    writeFileSync(resolve(opts.output), text);
+                    process.stderr.write(
+                        `Written to: ${resolve(opts.output)}\n`,
+                    );
+                } else {
+                    console.log(text);
+                }
+            }
+        } catch (err) {
+            console.error(
+                `\nFailed to transcribe: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { PlaudServerKey } from "@/lib/plaud/servers";
+
+const CONFIG_DIR = join(homedir(), ".config", "openplaud-cli");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+const STATE_FILE = join(CONFIG_DIR, "state.json");
+
+export interface CliConfig {
+    /** Plaud API bearer token (without "Bearer " prefix) */
+    bearerToken: string;
+    /** Which Plaud API server to use */
+    apiServer: PlaudServerKey;
+    /** Custom API base URL (only used when apiServer is "custom") */
+    customApiBase?: string;
+    /** OpenAI-compatible API key for Whisper transcription */
+    whisperApiKey?: string;
+    /** OpenAI-compatible base URL (e.g. https://api.groq.com/openai/v1) */
+    whisperBaseUrl?: string;
+    /** Whisper model to use (default: whisper-1) */
+    whisperModel?: string;
+}
+
+export interface CliState {
+    /** ISO timestamp of last successful sync */
+    lastSyncAt?: string;
+    /** Map of plaudFileId → version_ms for tracking changes */
+    knownRecordings?: Record<string, number>;
+}
+
+function ensureConfigDir(): void {
+    if (!existsSync(CONFIG_DIR)) {
+        mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+    }
+}
+
+export function loadConfig(): CliConfig | null {
+    if (!existsSync(CONFIG_FILE)) return null;
+    try {
+        return JSON.parse(readFileSync(CONFIG_FILE, "utf-8")) as CliConfig;
+    } catch {
+        return null;
+    }
+}
+
+export function saveConfig(config: CliConfig): void {
+    ensureConfigDir();
+    writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 4), {
+        encoding: "utf-8",
+        mode: 0o600,
+    });
+}
+
+export function loadState(): CliState {
+    if (!existsSync(STATE_FILE)) return {};
+    try {
+        return JSON.parse(readFileSync(STATE_FILE, "utf-8")) as CliState;
+    } catch {
+        return {};
+    }
+}
+
+export function saveState(state: CliState): void {
+    ensureConfigDir();
+    writeFileSync(STATE_FILE, JSON.stringify(state, null, 4), {
+        encoding: "utf-8",
+        mode: 0o600,
+    });
+}
+
+export function requireConfig(): CliConfig {
+    const config = loadConfig();
+    if (!config) {
+        console.error(
+            "Not configured. Run `openplaud auth` first to set up your credentials.",
+        );
+        process.exit(1);
+    }
+    return config;
+}
+
+export function getConfigDir(): string {
+    return CONFIG_DIR;
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+    chmodSync,
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { PlaudServerKey } from "@/lib/plaud/servers";
@@ -50,6 +56,8 @@ export function saveConfig(config: CliConfig): void {
         encoding: "utf-8",
         mode: 0o600,
     });
+    // Ensure permissions are correct even if the file already existed
+    chmodSync(CONFIG_FILE, 0o600);
 }
 
 export function loadState(): CliState {
@@ -67,6 +75,8 @@ export function saveState(state: CliState): void {
         encoding: "utf-8",
         mode: 0o600,
     });
+    // Ensure permissions are correct even if the file already existed
+    chmodSync(STATE_FILE, 0o600);
 }
 
 export function requireConfig(): CliConfig {

--- a/cli/src/dictionary.ts
+++ b/cli/src/dictionary.ts
@@ -1,0 +1,149 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getConfigDir } from "./config";
+
+const DICTIONARY_FILE = `${getConfigDir()}/dictionary.txt`;
+
+export interface Dictionary {
+    /** Terms to include in the Whisper prompt (biases recognition) */
+    terms: string[];
+    /** Correction rules: wrong → correct (applied as post-processing) */
+    corrections: Array<{ from: string; to: string }>;
+}
+
+/**
+ * Parse the dictionary file.
+ *
+ * Format:
+ * - Lines starting with # are comments
+ * - Empty lines are ignored
+ * - Lines with " → " are corrections: wrong → correct
+ * - Everything else is a plain term
+ *
+ * Example:
+ *   # People
+ *   Sophie
+ *   Ivo
+ *
+ *   # Corrections
+ *   Plot → Plaud
+ *   Diva → TiVA
+ */
+export function loadDictionary(): Dictionary {
+    if (!existsSync(DICTIONARY_FILE)) {
+        return { terms: [], corrections: [] };
+    }
+
+    const content = readFileSync(DICTIONARY_FILE, "utf-8");
+    return parseDictionary(content);
+}
+
+export function parseDictionary(content: string): Dictionary {
+    const terms: string[] = [];
+    const corrections: Array<{ from: string; to: string }> = [];
+
+    for (const rawLine of content.split("\n")) {
+        const line = rawLine.trim();
+
+        // Skip empty lines and comments
+        if (!line || line.startsWith("#")) continue;
+
+        // Correction rule: "wrong → correct"
+        const arrowIndex = line.indexOf(" → ");
+        if (arrowIndex !== -1) {
+            const from = line.slice(0, arrowIndex).trim();
+            const to = line.slice(arrowIndex + 3).trim();
+            if (from && to) {
+                corrections.push({ from, to });
+                // Also add the correct form as a term for the Whisper prompt
+                if (!terms.includes(to)) {
+                    terms.push(to);
+                }
+            }
+            continue;
+        }
+
+        // Plain term
+        if (!terms.includes(line)) {
+            terms.push(line);
+        }
+    }
+
+    return { terms, corrections };
+}
+
+/**
+ * Build a Whisper prompt string from the dictionary.
+ * Contains all correct terms, which biases Whisper toward recognizing them.
+ */
+export function buildWhisperPrompt(dict: Dictionary): string | undefined {
+    if (dict.terms.length === 0) return undefined;
+    return dict.terms.join(", ");
+}
+
+/**
+ * Apply correction rules to a transcription.
+ * Replaces all occurrences of each "from" pattern with "to".
+ * Uses word-boundary-aware matching to avoid partial replacements.
+ */
+export function applyCorrections(
+    text: string,
+    corrections: Array<{ from: string; to: string }>,
+): string {
+    let result = text;
+    for (const { from, to } of corrections) {
+        // Escape regex special characters in the "from" string
+        const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // Use a global, case-insensitive regex with word-ish boundaries.
+        // \b doesn't work well with hyphens and special chars, so we use
+        // a lookaround that checks for word boundaries or start/end of string.
+        const regex = new RegExp(
+            `(?<=^|[\\s,.:;!?"""''()\\[\\]{}])${escaped}(?=$|[\\s,.:;!?"""''()\\[\\]{}])`,
+            "gi",
+        );
+        result = result.replace(regex, to);
+    }
+    return result;
+}
+
+/**
+ * Get the dictionary file path.
+ */
+export function getDictionaryPath(): string {
+    return DICTIONARY_FILE;
+}
+
+/**
+ * Ensure the dictionary file exists (creates an empty one with a header comment).
+ */
+export function ensureDictionaryFile(): string {
+    if (!existsSync(DICTIONARY_FILE)) {
+        const dir = dirname(DICTIONARY_FILE);
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true, mode: 0o700 });
+        }
+        writeFileSync(
+            DICTIONARY_FILE,
+            [
+                "# OpenPlaud Dictionary",
+                "# ",
+                "# Terms listed here improve Whisper transcription accuracy.",
+                "# They are passed as context to the Whisper model and also",
+                "# used for post-processing corrections.",
+                "#",
+                "# Format:",
+                "#   term           — biases Whisper toward recognizing this word",
+                "#   wrong → right  — also replaces 'wrong' with 'right' in output",
+                "#",
+                "# Examples:",
+                "#   TiVA",
+                "#   Preclinics",
+                "#   Plot → Plaud",
+                "#   Diva → TiVA",
+                "",
+            ].join("\n"),
+            { encoding: "utf-8", mode: 0o644 },
+        );
+    }
+    return DICTIONARY_FILE;
+}

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared formatting and parsing utilities for CLI commands.
+ */
+
+export function formatDuration(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+        return `${hours}h ${minutes}m ${seconds}s`;
+    }
+    if (minutes > 0) {
+        return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+}
+
+export function formatDate(timestampMs: number): string {
+    return new Date(timestampMs).toLocaleString();
+}
+
+export function formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Parse a time reference into a Unix timestamp (ms).
+ * Accepts ISO 8601 dates or relative durations: "2h", "30m", "7d", "1w"
+ */
+export function parseSince(value: string): number {
+    // Relative duration: "2h", "30m", "7d", "1w"
+    const relMatch = value.match(/^(\d+)(m|h|d|w)$/);
+    if (relMatch) {
+        const amount = Number.parseInt(relMatch[1], 10);
+        const unit = relMatch[2];
+        const multipliers: Record<string, number> = {
+            m: 60 * 1000,
+            h: 60 * 60 * 1000,
+            d: 24 * 60 * 60 * 1000,
+            w: 7 * 24 * 60 * 60 * 1000,
+        };
+        return Date.now() - amount * multipliers[unit];
+    }
+
+    // ISO 8601 or any parseable date string
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+        return parsed;
+    }
+
+    console.error(
+        `Cannot parse time value: "${value}". Use ISO 8601 or relative (e.g. "2h", "7d")`,
+    );
+    process.exit(1);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { recordingsCommand } from "./commands/recordings";
 import { downloadCommand } from "./commands/download";
 import { transcribeCommand } from "./commands/transcribe";
 import { syncCommand } from "./commands/sync";
+import { dictionaryCommand } from "./commands/dictionary";
 
 const program = new Command()
     .name("openplaud")
@@ -20,5 +21,6 @@ program.addCommand(recordingsCommand);
 program.addCommand(downloadCommand);
 program.addCommand(transcribeCommand);
 program.addCommand(syncCommand);
+program.addCommand(dictionaryCommand);
 
 program.parse();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { Command } from "commander";
+import { authCommand } from "./commands/auth";
+import { devicesCommand } from "./commands/devices";
+import { recordingsCommand } from "./commands/recordings";
+import { downloadCommand } from "./commands/download";
+import { transcribeCommand } from "./commands/transcribe";
+import { syncCommand } from "./commands/sync";
+
+const program = new Command()
+    .name("openplaud")
+    .description(
+        "CLI for syncing and transcribing recordings from Plaud Note devices",
+    )
+    .version("0.1.0");
+
+program.addCommand(authCommand);
+program.addCommand(devicesCommand);
+program.addCommand(recordingsCommand);
+program.addCommand(downloadCommand);
+program.addCommand(transcribeCommand);
+program.addCommand(syncCommand);
+
+program.parse();

--- a/cli/src/transcription.ts
+++ b/cli/src/transcription.ts
@@ -42,8 +42,14 @@ export async function transcribeAudio(
     const model = config.whisperModel || DEFAULT_WHISPER_MODEL;
     const filename = options?.filename || "recording.mp3";
 
-    // Load dictionary for Whisper prompt and post-processing
-    const dictionary = loadDictionary();
+    // Load dictionary for Whisper prompt and post-processing.
+    // Gracefully fall back to empty if the file can't be read (e.g. permissions).
+    let dictionary: ReturnType<typeof loadDictionary>;
+    try {
+        dictionary = loadDictionary();
+    } catch {
+        dictionary = { terms: [], corrections: [] };
+    }
     const whisperPrompt = buildWhisperPrompt(dictionary);
 
     // Detect content type from buffer magic bytes

--- a/cli/src/transcription.ts
+++ b/cli/src/transcription.ts
@@ -1,10 +1,19 @@
 import { OpenAI } from "openai";
 import type { CliConfig } from "./config";
+import {
+    loadDictionary,
+    buildWhisperPrompt,
+    applyCorrections,
+} from "./dictionary";
 
 export const DEFAULT_WHISPER_MODEL = "whisper-1";
 
 /**
  * Transcribe an audio buffer using the OpenAI-compatible Whisper API.
+ *
+ * Automatically loads the dictionary from ~/.config/openplaud-cli/dictionary.txt:
+ * - Terms are passed as the Whisper `prompt` parameter to bias recognition
+ * - Correction rules (wrong → right) are applied as post-processing
  *
  * Works with any OpenAI-compatible provider:
  * - OpenAI (default): whisper-1
@@ -33,6 +42,10 @@ export async function transcribeAudio(
     const model = config.whisperModel || DEFAULT_WHISPER_MODEL;
     const filename = options?.filename || "recording.mp3";
 
+    // Load dictionary for Whisper prompt and post-processing
+    const dictionary = loadDictionary();
+    const whisperPrompt = buildWhisperPrompt(dictionary);
+
     // Detect content type from buffer magic bytes
     const contentType = detectAudioType(audioBuffer);
 
@@ -44,9 +57,17 @@ export async function transcribeAudio(
         file,
         model,
         ...(options?.language && { language: options.language }),
+        ...(whisperPrompt && { prompt: whisperPrompt }),
     });
 
-    return response.text;
+    let text = response.text;
+
+    // Apply correction rules from dictionary
+    if (dictionary.corrections.length > 0) {
+        text = applyCorrections(text, dictionary.corrections);
+    }
+
+    return text;
 }
 
 /**

--- a/cli/src/transcription.ts
+++ b/cli/src/transcription.ts
@@ -1,0 +1,95 @@
+import { OpenAI } from "openai";
+import type { CliConfig } from "./config";
+
+export const DEFAULT_WHISPER_MODEL = "whisper-1";
+
+/**
+ * Transcribe an audio buffer using the OpenAI-compatible Whisper API.
+ *
+ * Works with any OpenAI-compatible provider:
+ * - OpenAI (default): whisper-1
+ * - Groq (free): whisper-large-v3 at https://api.groq.com/openai/v1
+ * - Together AI, OpenRouter, local Ollama, etc.
+ */
+export async function transcribeAudio(
+    audioBuffer: Buffer,
+    config: CliConfig,
+    options?: {
+        language?: string;
+        filename?: string;
+    },
+): Promise<string> {
+    if (!config.whisperApiKey) {
+        throw new Error(
+            "No Whisper API key configured. Run `openplaud auth` to set one up.",
+        );
+    }
+
+    const client = new OpenAI({
+        apiKey: config.whisperApiKey,
+        ...(config.whisperBaseUrl && { baseURL: config.whisperBaseUrl }),
+    });
+
+    const model = config.whisperModel || DEFAULT_WHISPER_MODEL;
+    const filename = options?.filename || "recording.mp3";
+
+    // Detect content type from buffer magic bytes
+    const contentType = detectAudioType(audioBuffer);
+
+    const file = new File([new Uint8Array(audioBuffer)], filename, {
+        type: contentType,
+    });
+
+    const response = await client.audio.transcriptions.create({
+        file,
+        model,
+        ...(options?.language && { language: options.language }),
+    });
+
+    return response.text;
+}
+
+/**
+ * Detect audio format from file magic bytes.
+ */
+function detectAudioType(buffer: Buffer): string {
+    // OGG/Opus: starts with "OggS"
+    if (
+        buffer.length >= 4 &&
+        buffer[0] === 0x4f &&
+        buffer[1] === 0x67 &&
+        buffer[2] === 0x67 &&
+        buffer[3] === 0x53
+    ) {
+        return "audio/ogg";
+    }
+
+    // MP3: starts with ID3 tag or MPEG sync word
+    if (buffer.length >= 3) {
+        if (
+            buffer[0] === 0x49 &&
+            buffer[1] === 0x44 &&
+            buffer[2] === 0x33 // ID3
+        ) {
+            return "audio/mpeg";
+        }
+        if (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0) {
+            // MPEG sync
+            return "audio/mpeg";
+        }
+    }
+
+    // WAV: starts with "RIFF"
+    if (
+        buffer.length >= 4 &&
+        buffer[0] === 0x52 &&
+        buffer[1] === 0x49 &&
+        buffer[2] === 0x46 &&
+        buffer[3] === 0x46
+    ) {
+        return "audio/wav";
+    }
+
+    // Default to MP3 (Plaud mostly serves MP3)
+    return "audio/mpeg";
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "paths": {
+            "@/*": ["../src/*"]
+        }
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds a `cli/` directory with a standalone, Bun-based CLI that reuses the existing `PlaudClient` from `src/lib/plaud/`. No database, no web server, no Docker — just direct Plaud API access and OpenAI-compatible Whisper transcription from the terminal.

- **6 commands**: `auth`, `devices`, `recordings`, `download`, `transcribe`, `sync`
- **Reuses existing code**: imports `PlaudClient`, types, and server config from `src/lib/plaud/` — zero duplication
- **Any Whisper provider**: OpenAI, Groq (free), Together AI, local Ollama — anything OpenAI-compatible
- **Stateful sync**: tracks which recordings have been synced, only fetches what's new
- **Scriptable**: `--json`, `--ids-only` output modes for piping into other tools

### Commands

| Command | Description |
|---|---|
| `openplaud auth` | Configure Plaud bearer token + Whisper API credentials |
| `openplaud devices` | List connected Plaud devices |
| `openplaud recordings` | List recordings with `--since`, `--json`, `--ids-only` filtering |
| `openplaud download <id>` | Download audio file (MP3 or OPUS) |
| `openplaud transcribe <id>` | Download + transcribe a single recording via Whisper |
| `openplaud sync` | Stateful sync: download new recordings, transcribe, save to disk |

### Usage

```bash
cd cli && bun install

bun src/index.ts auth --token "..." --server eu --whisper-key "sk-..." --whisper-model whisper-1
bun src/index.ts recordings --since 7d
bun src/index.ts transcribe <id> -l de
bun src/index.ts sync --output-dir ./recordings
```

### Architecture

The CLI imports directly from the existing `src/lib/plaud/` — the same `PlaudClient`, types, and server definitions that power the web app. No code was duplicated or forked. Credentials are stored in `~/.config/openplaud-cli/config.json` with `0600` permissions (no encryption needed — file-system permissions are the security boundary, same as `~/.ssh/`).

### Future: standalone distribution

Currently the CLI must be run from within the cloned repo (it imports from `../../src/lib/plaud/`). A follow-up could extract the shared Plaud API client into a `packages/core/` workspace package, which would allow publishing the CLI independently to npm as `openplaud-cli`. Happy to work on that as a separate PR if there's interest.

## Test plan

- [x] `openplaud auth` validates bearer token against Plaud API before saving
- [x] `openplaud devices` lists connected devices
- [x] `openplaud recordings` lists recordings with metadata (duration, date, size)
- [x] `openplaud transcribe <id>` downloads audio and returns Whisper transcription
- [x] `openplaud sync --dry-run` shows what would be synced
- [x] All commands show helpful error when not configured
- [x] No credentials in source code — config stored in `~/.config/` with restricted permissions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone Bun-based CLI in `cli/` to sync and transcribe Plaud Note recordings from the terminal, with a dictionary to boost accuracy and several security/robustness fixes.

- **New Features**
  - Commands: `auth`, `devices`, `recordings`, `download`, `transcribe`, `sync`, `dictionary`.
  - Stateful sync fetches only new/updated recordings; optional transcription; supports `--dry-run`, `--json`.
  - Transcription via any OpenAI-compatible Whisper; language hints; saves `.txt`; dictionary terms passed as a prompt and post-corrected. Manage via `openplaud dictionary` (`show`, `edit`, `add`, `path`); stored at `~/.config/openplaud-cli/dictionary.txt`.
  - Audio downloads as MP3 or OPUS; custom output dir; `--ids-only` for scripting. Config at `~/.config/openplaud-cli/` with `0600`; `auth` validates token and supports custom Plaud API servers.

- **Bug Fixes**
  - Validate custom `--server` hostnames using URL parsing; no default overwrite on partial `auth` runs.
  - Enforce `0600` on existing config/state files.
  - Do not mark recordings as synced if transcription fails; rewind `lastSyncAt` to just before the oldest failed recording so it retries next sync; add recording ID suffix to filenames to avoid collisions.
  - Remove pagination cap when searching by ID in `transcribe`; `devices --json` returns `[]` when empty.
  - Use `spawnSync` with `shell:true` for `$EDITOR`; wrap dictionary loading in try/catch so read errors don’t abort transcription.

<sup>Written for commit 8f335c8ee48c64885457d47bf0b07208d76c5ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

