### PR TITLE
chore(ci): add CodeQL advisory workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan of main (Mondays 06:17 UTC). Randomised minute to
+    # avoid peak queue times.
+    - cron: "17 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  # required for private repos; harmless on public
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` adds more precise queries on top of the
+          # default set. `security-and-quality` also includes maintainability
+          # checks, which tend to be noisy for our stack.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds GitHub CodeQL analysis as an **advisory** check (not a required status gate yet).

## Why

OpenPlaud's attack surface (OTP auth, AES-256-GCM token storage, path handling, user-provided S3 creds, pluggable AI providers) benefits from automated security scanning. CodeQL catches categories biome + cubic don't — SQLi patterns, crypto misuse, path-traversal variants, unchecked deserialisation, etc.

## What this PR does

- Adds \`.github/workflows/codeql.yml\`
- Runs on PRs + pushes to \`main\`, plus a weekly Monday scan of \`main\`
- Uses \`security-extended\` query pack (stricter than default; skips the noisier \`security-and-quality\` maintainability queries that biome already covers)
- 30-min timeout as a safety net
- Concurrency group to cancel superseded runs

## What this PR does NOT do

- Does **not** add CodeQL to required status checks on the \`prod rules\` / \`safety\` rulesets. Advisory only.
- Does **not** enable "Require code quality results" on merge.

## Rollout plan

1. Land this, let it run for ~2 weeks
2. Triage findings in the Security tab
3. Fix or dismiss the backlog
4. Then decide whether to promote to required status check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CodeQL advisory workflow in CI to surface security issues in our JS/TS code. It runs on PRs and pushes to `main`, plus a weekly Monday scan; uses `security-extended` queries; cancels superseded runs; has a 30‑minute timeout; and is not a required status check.

<sup>Written for commit 5ee30876dc3a7c812eaed19b3203c9f6b6be34bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

