### PR TITLE
Add ffmpeg installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN bun build src/db/migrate-idempotent.ts --target=bun --outfile=migrate-idempo
 FROM base AS runner
 WORKDIR /app
 
+RUN apt-get update -qq && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 


### PR DESCRIPTION
## Description
Install ffmpeg in the final runtime image.

## FIX

[Bug]: Upload Audio fails with "File does not contain a valid audio stream" - ffmpeg not installed in Docker image #58

Bug Description

The "Upload Audio" feature fails for all file formats (MP3, WAV, etc.) with the error: "File does not contain a valid audio stream"
Root Cause

The upload route uses ffprobe to validate audio duration, but ffmpeg/ffprobe is not installed in the Docker image. This causes every upload to fail the duration check and return the error regardless of whether the file is valid. Steps to Reproduce

    Deploy OpenPlaud using the provided docker-compose.yml
    Go to Recordings > Upload Audio
    Select any valid MP3 or WAV file
    Error: "File does not contain a valid audio stream"

Fix

Add ffmpeg to the runner stage of the Dockerfile:

RUN apt-get update -qq && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Dependency update

## Related Issues

Relates to #58 

## Testing fix
1. Deploy OpenPlaud using the provided docker-compose.yml
2. Go to Recordings > Upload Audio
3. Select any valid MP3 or WAV file
4. The error “The file does not contain a valid audio stream” disappears, and the audio file loads correctly.

### Test Environment
- OS: Docker debian server
- Node version: bun -v 1.3.13
- Browser (if UI changes): no UI changes




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `ffmpeg` in the runtime Docker image so `ffprobe` can validate audio duration during uploads. This fixes the “File does not contain a valid audio stream” error for valid files in Docker deployments (fixes #58).

<sup>Written for commit a80b3a13e8405e444942cf5e2dc41ff288f59e17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

