### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
+      # softprops/action-gh-release renames hidden files (e.g. `.env.example`)
+      # by prefixing them with `default.` on upload, which breaks predictable
+      # download URLs. Copy to a non-hidden name so the asset is uploaded as
+      # `env.example` and stays curl-friendly.
+      - name: Prepare install artifacts
+        run: cp .env.example env.example
+
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
@@ -61,10 +68,11 @@ jobs:
           body: ${{ steps.notes.outputs.release-notes }}
           draft: true
           # Attach self-host install artifacts so users can
-          #   wget .../releases/latest/download/docker-compose.yml
+          #   curl -fLO .../releases/latest/download/docker-compose.yml
+          #   curl -fL  .../releases/latest/download/env.example -o .env
           # without cloning the repo.
           files: |
             docker-compose.yml
-            .env.example
+            env.example
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2026-04-28
 
 ### Changed
 - Self-host install now uses published Docker images instead of `git clone`. See [README](README.md#-quick-start) and [BRANCHING.md](BRANCHING.md). Existing `git pull && docker compose up --build` setups keep working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.2.0] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ OpenPlaud ships as a Docker image on GitHub Container Registry. You don't need t
 mkdir openplaud && cd openplaud
 
 curl -fLO https://github.com/openplaud/openplaud/releases/latest/download/docker-compose.yml
-curl -fL  https://github.com/openplaud/openplaud/releases/latest/download/.env.example -o .env
+curl -fL  https://github.com/openplaud/openplaud/releases/latest/download/env.example -o .env
 ```
 
 **2. Generate secrets and edit `.env`**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release commits for `v0.2.0`. Tag already pushed; this PR carries the corresponding `package.json` + `CHANGELOG.md` changes back to `main`.

## Commits

- `chore(release): v0.2.0` — bumps `package.json` from `0.1.0` to `0.2.0`, rewrites `## [Unreleased]` → `## [0.2.0] - YYYY-MM-DD` in `CHANGELOG.md`.
- `chore: add [Unreleased] section for next cycle` — re-adds an empty `## [Unreleased]` section to start collecting v0.3.0 entries.

Both produced by `scripts/release.ts`. No other files touched.

## Tag and workflows

- Tag `v0.2.0` already pushed (the script pushes the tag separately from these commits).
- `docker.yml` and `release.yml` are firing on the tag push — building the multi-arch image with `:0.2.0`, `:0.2`, `:latest`, and drafting a GitHub Release with `docker-compose.yml` + `.env.example` attached.

## Why a PR

`main` is branch-protected. The release script intentionally pushes only the tag and leaves the two commits for normal PR-style review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v0.2.0 release by bumping `package.json`, updating `CHANGELOG.md` to `0.2.0`, and adding a new `Unreleased` section. Tag `v0.2.0` is already pushed; CI builds multi-arch Docker images (`:0.2.0`, `:0.2`, `:latest`) and drafts the GitHub Release, and this PR merges the release metadata back to protected `main`.

- **Bug Fixes**
  - In `release.yml`, copy `.env.example` to `env.example` before upload to avoid `softprops/action-gh-release` dotfile renaming; README now curls `env.example` and saves to `.env`.

<sup>Written for commit 51925f9c5693a03b20bf96826cf6ccf772f8aacd. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/68?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

