### PR TITLE
fix(plaud): mint workspace token for recording endpoints (fixes #66)

### DIFF
--- a/src/app/api/dev/plaud/info/route.ts
+++ b/src/app/api/dev/plaud/info/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { plaudConnections } from "@/db/schema";
 import { auth } from "@/lib/auth";
-import { createPlaudClient } from "@/lib/plaud/client";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { serverKeyFromApiBase } from "@/lib/plaud/servers";
 
 /**
@@ -41,6 +41,7 @@ export async function GET(request: Request) {
         const client = await createPlaudClient(
             connection.bearerToken,
             connection.apiBase,
+            connection.workspaceId,
         );
 
         const startedAt = Date.now();
@@ -78,6 +79,13 @@ export async function GET(request: Request) {
                 apiBase: connection.apiBase,
                 server: serverKeyFromApiBase(connection.apiBase),
                 plaudEmail: connection.plaudEmail,
+                workspaceId: client.workspaceId ?? connection.workspaceId,
+                workspaceIdSource: connection.workspaceId
+                    ? "cache"
+                    : client.workspaceId
+                      ? "resolved"
+                      : "unresolved",
+                workspaceTokenFallback: client.usingUserTokenFallback,
                 createdAt: connection.createdAt,
                 updatedAt: connection.updatedAt,
             },

--- a/src/app/api/dev/plaud/info/route.ts
+++ b/src/app/api/dev/plaud/info/route.ts
@@ -80,11 +80,20 @@ export async function GET(request: Request) {
                 server: serverKeyFromApiBase(connection.apiBase),
                 plaudEmail: connection.plaudEmail,
                 workspaceId: client.workspaceId ?? connection.workspaceId,
-                workspaceIdSource: connection.workspaceId
-                    ? "cache"
-                    : client.workspaceId
-                      ? "resolved"
-                      : "unresolved",
+                // "cache"      = used the stored workspaceId as-is
+                // "resolved"   = client discovered or replaced it (cache empty
+                //                or stale-cache rescue picked a different id)
+                // "unresolved" = nothing stored and nothing resolved (the UT
+                //                fallback path)
+                workspaceIdSource:
+                    client.workspaceId &&
+                    client.workspaceId !== connection.workspaceId
+                        ? "resolved"
+                        : connection.workspaceId
+                          ? "cache"
+                          : client.workspaceId
+                            ? "resolved"
+                            : "unresolved",
                 workspaceTokenFallback: client.usingUserTokenFallback,
                 createdAt: connection.createdAt,
                 updatedAt: connection.updatedAt,

--- a/src/app/api/plaud/auth/verify/route.ts
+++ b/src/app/api/plaud/auth/verify/route.ts
@@ -7,7 +7,10 @@ import { encrypt } from "@/lib/encryption";
 import { plaudVerifyOtp } from "@/lib/plaud/auth";
 import { PlaudClient } from "@/lib/plaud/client";
 import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
-import { resolveWorkspaceToken } from "@/lib/plaud/workspace";
+import {
+    listPlaudWorkspaces,
+    pickPersonalWorkspaceId,
+} from "@/lib/plaud/workspace";
 
 /**
  * POST /api/plaud/auth/verify
@@ -65,46 +68,47 @@ export async function POST(request: Request) {
         // Verify OTP with Plaud → get the (long-lived) user token (UT)
         const { accessToken } = await plaudVerifyOtp(code, otpToken, apiBase);
 
-        // Resolve the personal workspace ID and mint a workspace token (WT)
-        // up front. This catches WT-mint failures at connect time rather than
-        // silently storing a UT that can't read recordings (issue #66).
+        // Discover the personal workspace ID up front so we can persist it
+        // alongside the connection. We deliberately don't mint a WT here —
+        // PlaudClient mints lazily on the listDevices() call below, which
+        // both validates end-to-end and gives us exactly one WT mint per
+        // verify (vs. minting once here and again inside the client).
         let resolvedWorkspaceId: string | null = null;
         try {
-            const { workspaceId } = await resolveWorkspaceToken(
-                accessToken,
-                apiBase,
-                null,
-            );
-            resolvedWorkspaceId = workspaceId;
+            const list = await listPlaudWorkspaces(accessToken, apiBase);
+            resolvedWorkspaceId = pickPersonalWorkspaceId(list);
         } catch (err) {
             // Don't fail the whole connect — fall through and let the client
             // fall back to the UT (preserves behavior for any server that
             // doesn't expose the workspace endpoints). Logged for diagnosis.
             console.warn(
-                "[plaud/verify] workspace token resolve failed:",
+                "[plaud/verify] workspace discovery failed:",
                 err instanceof Error ? err.message : err,
             );
         }
 
-        // Validate the token actually works against the recording endpoints
-        // we'll use during sync. With resolvedWorkspaceId in hand the client
-        // mints a WT internally; without it (rare fallback) it uses the UT.
+        // Validate the token works against a real recording endpoint. With
+        // resolvedWorkspaceId in hand the client mints a WT internally on
+        // first use; without it the client falls back to the UT.
         const client = new PlaudClient(
             accessToken,
             apiBase,
             resolvedWorkspaceId,
         );
-        const isValid = await client.testConnection();
 
-        if (!isValid) {
+        let deviceList: Awaited<ReturnType<typeof client.listDevices>>;
+        try {
+            deviceList = await client.listDevices();
+        } catch (err) {
+            console.warn(
+                "[plaud/verify] device list validation failed:",
+                err instanceof Error ? err.message : err,
+            );
             return NextResponse.json(
                 { error: "Login succeeded but token validation failed" },
                 { status: 400 },
             );
         }
-
-        // Fetch devices
-        const deviceList = await client.listDevices();
 
         const encryptedAccessToken = encrypt(accessToken);
 
@@ -116,6 +120,8 @@ export async function POST(request: Request) {
             .limit(1);
 
         if (existingConnection) {
+            // Always re-scope by userId on UPDATE/DELETE of user-owned rows
+            // (defense-in-depth alongside the userId-scoped lookup above).
             await db
                 .update(plaudConnections)
                 .set({
@@ -125,7 +131,12 @@ export async function POST(request: Request) {
                     workspaceId: resolvedWorkspaceId,
                     updatedAt: new Date(),
                 })
-                .where(eq(plaudConnections.id, existingConnection.id));
+                .where(
+                    and(
+                        eq(plaudConnections.id, existingConnection.id),
+                        eq(plaudConnections.userId, session.user.id),
+                    ),
+                );
         } else {
             await db.insert(plaudConnections).values({
                 userId: session.user.id,

--- a/src/app/api/plaud/auth/verify/route.ts
+++ b/src/app/api/plaud/auth/verify/route.ts
@@ -7,6 +7,7 @@ import { encrypt } from "@/lib/encryption";
 import { plaudVerifyOtp } from "@/lib/plaud/auth";
 import { PlaudClient } from "@/lib/plaud/client";
 import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
+import { resolveWorkspaceToken } from "@/lib/plaud/workspace";
 
 /**
  * POST /api/plaud/auth/verify
@@ -61,11 +62,38 @@ export async function POST(request: Request) {
                 ? email.trim().toLowerCase()
                 : null;
 
-        // Verify OTP with Plaud → get the (long-lived) access token
+        // Verify OTP with Plaud → get the (long-lived) user token (UT)
         const { accessToken } = await plaudVerifyOtp(code, otpToken, apiBase);
 
-        // Validate the token actually works
-        const client = new PlaudClient(accessToken, apiBase);
+        // Resolve the personal workspace ID and mint a workspace token (WT)
+        // up front. This catches WT-mint failures at connect time rather than
+        // silently storing a UT that can't read recordings (issue #66).
+        let resolvedWorkspaceId: string | null = null;
+        try {
+            const { workspaceId } = await resolveWorkspaceToken(
+                accessToken,
+                apiBase,
+                null,
+            );
+            resolvedWorkspaceId = workspaceId;
+        } catch (err) {
+            // Don't fail the whole connect — fall through and let the client
+            // fall back to the UT (preserves behavior for any server that
+            // doesn't expose the workspace endpoints). Logged for diagnosis.
+            console.warn(
+                "[plaud/verify] workspace token resolve failed:",
+                err instanceof Error ? err.message : err,
+            );
+        }
+
+        // Validate the token actually works against the recording endpoints
+        // we'll use during sync. With resolvedWorkspaceId in hand the client
+        // mints a WT internally; without it (rare fallback) it uses the UT.
+        const client = new PlaudClient(
+            accessToken,
+            apiBase,
+            resolvedWorkspaceId,
+        );
         const isValid = await client.testConnection();
 
         if (!isValid) {
@@ -94,6 +122,7 @@ export async function POST(request: Request) {
                     bearerToken: encryptedAccessToken,
                     apiBase,
                     plaudEmail,
+                    workspaceId: resolvedWorkspaceId,
                     updatedAt: new Date(),
                 })
                 .where(eq(plaudConnections.id, existingConnection.id));
@@ -103,6 +132,7 @@ export async function POST(request: Request) {
                 bearerToken: encryptedAccessToken,
                 apiBase,
                 plaudEmail,
+                workspaceId: resolvedWorkspaceId,
             });
         }
 

--- a/src/db/migrations/0015_glamorous_doomsday.sql
+++ b/src/db/migrations/0015_glamorous_doomsday.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "plaud_connections" ADD COLUMN "workspace_id" text;

--- a/src/db/migrations/meta/0015_snapshot.json
+++ b/src/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1372 @@
+{
+  "id": "0b235063-c327-4604-bf89-709c6ec01a5e",
+  "prevId": "c89227ef-bd67-4e6d-b3e7-860b4fa2785f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_plaud_file_id_unique": {
+          "name": "recordings_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776851422455,
       "tag": "0014_drop_plaud_refresh_token",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777644428223,
+      "tag": "0015_glamorous_doomsday",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -82,6 +82,13 @@ export const plaudConnections = pgTable("plaud_connections", {
     // Email of the linked Plaud account (captured during OTP flow). Null for
     // legacy connections created via the bearer-token paste flow.
     plaudEmail: text("plaud_email"),
+    // Plaud workspace ID (e.g. ws_xxxxxxxxxxxx) used to mint short-lived
+    // workspace tokens (WT) from the long-lived user token (UT). The WT is
+    // required by recording endpoints (/file/simple/web, /device/list, ...)
+    // on regional servers; without it those endpoints return empty lists.
+    // Null for connections created before this column existed; resolved and
+    // persisted lazily on next sync.
+    workspaceId: text("workspace_id"),
     lastSync: timestamp("last_sync"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/plaud/client-factory.ts
+++ b/src/lib/plaud/client-factory.ts
@@ -1,0 +1,23 @@
+import { decrypt } from "@/lib/encryption";
+import { DEFAULT_PLAUD_API_BASE, PlaudClient } from "./client";
+
+/**
+ * Create Plaud client from an encrypted bearer token stored in the DB.
+ *
+ * Pass the (possibly null) cached `workspaceId` from
+ * `plaud_connections.workspace_id` so the client can skip the
+ * /team-app/workspaces/list lookup on cache hits. After using the client,
+ * callers should compare `client.workspaceId` against what they passed in
+ * and persist back any difference.
+ *
+ * Lives in its own module so importing the PlaudClient class (e.g. from
+ * unit tests) doesn't transitively load encryption/env validation.
+ */
+export async function createPlaudClient(
+    encryptedToken: string,
+    apiBase: string = DEFAULT_PLAUD_API_BASE,
+    workspaceId?: string | null,
+): Promise<PlaudClient> {
+    const bearerToken = decrypt(encryptedToken);
+    return new PlaudClient(bearerToken, apiBase, workspaceId ?? undefined);
+}

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -5,6 +5,7 @@ import type {
     PlaudTempUrlResponse,
 } from "@/types/plaud";
 import { DEFAULT_SERVER_KEY, PLAUD_SERVERS } from "./servers";
+import { resolveWorkspaceToken } from "./workspace";
 
 export interface PlaudUpdateFilenameResponse {
     status: number;
@@ -27,18 +28,98 @@ function sleep(ms: number): Promise<void> {
  * Plaud API Client
  * Handles all communication with Plaud API.
  *
- * Note: Plaud's OTP login flow issues long-lived access tokens (~300 day
- * lifetime, per decoded JWT claims). There is no refresh token — when the
- * access token eventually expires, the user re-authenticates via the
- * "Switch/reconnect Plaud account" UI.
+ * Plaud uses a two-tier token model:
+ *   - **UT** (User Token, ~300 day lifetime): returned by /auth/otp-login,
+ *     stored encrypted in plaud_connections.bearer_token. Authenticates
+ *     /user/me and the workspace-token mint endpoints.
+ *   - **WT** (Workspace Token, 24h lifetime): minted from a UT, required by
+ *     recording endpoints (/file/simple/web, /device/list, /file/temp-url/*,
+ *     /filetag/, ...). On regional servers (EU, APAC) a UT sent to those
+ *     endpoints returns HTTP 200 with an empty list — i.e. it silently fails
+ *     open. That's the bug behind issue #66.
+ *
+ * The client takes a UT in its constructor and lazily mints a WT the first
+ * time an authenticated request is made. The WT is cached on the client
+ * instance for its lifetime; sync runs are short and the WT is good for 24h
+ * so no refresh logic is needed.
+ *
+ * If the WT mint fails entirely (e.g. global servers historically didn't
+ * require it), the client falls back to using the UT directly. This preserves
+ * pre-fix behavior for any server that still accepts the UT on recording
+ * endpoints.
  */
 export class PlaudClient {
-    private bearerToken: string;
-    private apiBase: string;
+    private readonly userToken: string;
+    private readonly apiBase: string;
+    private workspaceToken?: string;
+    private resolvedWorkspaceId?: string;
+    private workspaceFetchInFlight?: Promise<void>;
+    private workspaceFallbackToUt = false;
 
-    constructor(bearerToken: string, apiBase: string = DEFAULT_PLAUD_API_BASE) {
-        this.bearerToken = bearerToken;
+    constructor(
+        userToken: string,
+        apiBase: string = DEFAULT_PLAUD_API_BASE,
+        workspaceId?: string | null,
+    ) {
+        this.userToken = userToken;
         this.apiBase = apiBase;
+        this.resolvedWorkspaceId = workspaceId ?? undefined;
+    }
+
+    /**
+     * The currently-known workspace ID for this connection. Populated either
+     * by the constructor (cache hit) or after the first authenticated request
+     * (cache empty / cache stale). Callers persist this back to the DB when
+     * it differs from what they passed in.
+     */
+    get workspaceId(): string | undefined {
+        return this.resolvedWorkspaceId;
+    }
+
+    /**
+     * Whether this client fell back to using the UT directly because the WT
+     * mint failed. Useful for diagnostics.
+     */
+    get usingUserTokenFallback(): boolean {
+        return this.workspaceFallbackToUt;
+    }
+
+    /**
+     * Lazily ensure a workspace token is available. Concurrent callers share
+     * a single in-flight resolution so we don't mint multiple WTs per client.
+     */
+    private async ensureWorkspaceToken(): Promise<void> {
+        if (this.workspaceToken || this.workspaceFallbackToUt) return;
+        if (!this.workspaceFetchInFlight) {
+            this.workspaceFetchInFlight = this.fetchWorkspaceToken();
+        }
+        try {
+            await this.workspaceFetchInFlight;
+        } finally {
+            this.workspaceFetchInFlight = undefined;
+        }
+    }
+
+    private async fetchWorkspaceToken(): Promise<void> {
+        try {
+            const { workspaceToken, workspaceId } = await resolveWorkspaceToken(
+                this.userToken,
+                this.apiBase,
+                this.resolvedWorkspaceId,
+            );
+            this.workspaceToken = workspaceToken;
+            this.resolvedWorkspaceId = workspaceId;
+        } catch (err) {
+            // Last-resort fallback: use the UT directly. Preserves pre-fix
+            // behavior for any server / legacy account where the UT still
+            // works on recording endpoints. Logged so the dev info endpoint
+            // can surface it.
+            console.warn(
+                "[plaud] workspace token mint failed, falling back to user token:",
+                err instanceof Error ? err.message : err,
+            );
+            this.workspaceFallbackToUt = true;
+        }
     }
 
     /**
@@ -49,6 +130,9 @@ export class PlaudClient {
         options?: RequestInit,
         retryCount = 0,
     ): Promise<T> {
+        await this.ensureWorkspaceToken();
+
+        const bearer = this.workspaceToken ?? this.userToken;
         const url = `${this.apiBase}${endpoint}`;
 
         try {
@@ -56,7 +140,7 @@ export class PlaudClient {
                 ...options,
                 headers: {
                     ...options?.headers,
-                    Authorization: `Bearer ${this.bearerToken}`,
+                    Authorization: `Bearer ${bearer}`,
                     "Content-Type": "application/json",
                 },
             });
@@ -222,16 +306,9 @@ export class PlaudClient {
     }
 }
 
-/**
- * Create Plaud client from an encrypted bearer token stored in the DB.
- */
-export async function createPlaudClient(
-    encryptedToken: string,
-    apiBase: string = DEFAULT_PLAUD_API_BASE,
-): Promise<PlaudClient> {
-    const { decrypt } = await import("../encryption");
-    const bearerToken = decrypt(encryptedToken);
-    return new PlaudClient(bearerToken, apiBase);
-}
-
 export * from "./types";
+
+// Note: `createPlaudClient` (which decrypts a stored bearer token) lives in
+// ./client-factory so importing the PlaudClient class (e.g. from tests)
+// doesn't pull in the encryption / env validation chain. Production callers
+// import it from "@/lib/plaud/client-factory" directly.

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -23,6 +23,22 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
+import { isValidPlaudApiUrl } from "./servers";
+
+/**
+ * SSRF barrier. `apiBase` is user-influenced (originally chosen at OTP-send
+ * time via Plaud's regional -302 redirect, then round-tripped through the
+ * client and persisted in the DB). The verify route validates it before
+ * insert, but these helpers are also reachable from the sync path which
+ * reads apiBase from the DB — we revalidate here so a tampered DB row can't
+ * coerce the server into requesting an arbitrary URL, and so CodeQL can
+ * see the barrier.
+ */
+function assertSafeApiBase(apiBase: string): void {
+    if (!isValidPlaudApiUrl(apiBase)) {
+        throw new Error("Plaud API error: invalid API base");
+    }
+}
 
 /**
  * List all workspaces accessible to the user. Personal accounts always have
@@ -35,6 +51,7 @@ export async function listPlaudWorkspaces(
     userToken: string,
     apiBase: string,
 ): Promise<PlaudWorkspaceListResponse> {
+    assertSafeApiBase(apiBase);
     const res = await fetch(
         `${apiBase}/team-app/workspaces/list?need_personal_workspace=true`,
         {
@@ -89,6 +106,7 @@ export async function mintPlaudWorkspaceToken(
     workspaceId: string,
     apiBase: string,
 ): Promise<string> {
+    assertSafeApiBase(apiBase);
     const res = await fetch(
         `${apiBase}/user-app/auth/workspace/token/${encodeURIComponent(workspaceId)}`,
         {

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -130,33 +130,55 @@ export async function mintPlaudWorkspaceToken(
 
     if (!res.ok) {
         const status = res.status;
+        // 5xx is treated as transient (don't relist on a server hiccup);
+        // 4xx is treated as cache-stale (workspace gone, role revoked, ...).
+        const stale = status >= 400 && status < 500;
         throw new WorkspaceTokenError(
             `Plaud API error (${status}): failed to mint workspace token`,
-            status,
+            { httpStatus: status, stale },
         );
     }
 
     const body = (await res.json()) as PlaudWorkspaceTokenResponse;
     if (body.status !== 0 || !body.data?.workspace_token) {
+        // 2xx response with a business-level error (status != 0) most
+        // commonly means the workspace is no longer valid for this user
+        // (deleted, membership revoked, etc.). Mark as stale so the caller
+        // re-discovers via /team-app/workspaces/list rather than falling
+        // straight back to the UT and silently regressing the fix.
         throw new WorkspaceTokenError(
             `Plaud API error: ${body.msg || "failed to mint workspace token"}`,
+            { stale: true },
         );
     }
     return body.data.workspace_token;
 }
 
 /**
- * Thrown when the workspace-token mint fails. Carries the HTTP status when
- * available so callers can decide whether the cached workspaceId is stale
- * (4xx → invalidate and relist) vs. a transient server issue (5xx → bubble).
+ * Thrown when the workspace-token mint fails.
+ *
+ * `stale` indicates whether the failure looks like a cache-staleness issue
+ * (workspace gone, role revoked, ...) versus a transient server problem.
+ * `resolveWorkspaceToken` uses it to decide whether to relist+remint
+ * (stale) or propagate the error (transient).
+ *
+ * `httpStatus` carries the HTTP status when the failure was at the HTTP
+ * level rather than in a 2xx response body.
  */
+export interface WorkspaceTokenErrorOptions {
+    httpStatus?: number;
+    stale?: boolean;
+}
+
 export class WorkspaceTokenError extends Error {
-    constructor(
-        message: string,
-        public readonly httpStatus?: number,
-    ) {
+    public readonly httpStatus?: number;
+    public readonly stale: boolean;
+
+    constructor(message: string, opts: WorkspaceTokenErrorOptions = {}) {
         super(message);
         this.name = "WorkspaceTokenError";
+        this.httpStatus = opts.httpStatus;
+        this.stale = opts.stale ?? false;
     }
 }
 
@@ -181,13 +203,13 @@ export async function resolveWorkspaceToken(
             );
             return { workspaceToken, workspaceId: cachedWorkspaceId };
         } catch (err) {
-            // Stale cache (workspace deleted/moved) → fall through to relist.
-            // Anything else (5xx, network) → propagate.
-            const status =
-                err instanceof WorkspaceTokenError ? err.httpStatus : undefined;
-            const isStale =
-                typeof status === "number" && status >= 400 && status < 500;
-            if (!isStale) throw err;
+            // Stale cache (workspace deleted/moved/role revoked, including
+            // 2xx-with-status != 0 business errors) → fall through to relist.
+            // Transient failures (5xx, network) → propagate so the client
+            // falls back to the UT rather than burning an extra list call.
+            const stale =
+                err instanceof WorkspaceTokenError ? err.stale : false;
+            if (!stale) throw err;
         }
     }
 

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -23,21 +23,30 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
-import { isValidPlaudApiUrl } from "./servers";
 
 /**
  * SSRF barrier. `apiBase` is user-influenced (originally chosen at OTP-send
  * time via Plaud's regional -302 redirect, then round-tripped through the
  * client and persisted in the DB). The verify route validates it before
  * insert, but these helpers are also reachable from the sync path which
- * reads apiBase from the DB — we revalidate here so a tampered DB row can't
- * coerce the server into requesting an arbitrary URL, and so CodeQL can
- * see the barrier.
+ * reads apiBase from the DB — revalidate at the boundary so a tampered DB
+ * row can't coerce the server into requesting an arbitrary URL.
+ *
+ * Returns a freshly-constructed URL object whose hostname has been
+ * whitelist-checked against plaud.ai. Inlining the URL parse + hostname
+ * check (rather than delegating to a helper) is required for CodeQL's
+ * SSRF analysis to recognize this as a sanitizer.
  */
-function assertSafeApiBase(apiBase: string): void {
-    if (!isValidPlaudApiUrl(apiBase)) {
+function safePlaudUrl(apiBase: string, path: string): URL {
+    const parsed = new URL(path, apiBase);
+    if (
+        parsed.protocol !== "https:" ||
+        (parsed.hostname !== "plaud.ai" &&
+            !parsed.hostname.endsWith(".plaud.ai"))
+    ) {
         throw new Error("Plaud API error: invalid API base");
     }
+    return parsed;
 }
 
 /**
@@ -51,17 +60,17 @@ export async function listPlaudWorkspaces(
     userToken: string,
     apiBase: string,
 ): Promise<PlaudWorkspaceListResponse> {
-    assertSafeApiBase(apiBase);
-    const res = await fetch(
-        `${apiBase}/team-app/workspaces/list?need_personal_workspace=true`,
-        {
-            method: "GET",
-            headers: {
-                Authorization: `Bearer ${userToken}`,
-                "Content-Type": "application/json",
-            },
-        },
+    const url = safePlaudUrl(
+        apiBase,
+        "/team-app/workspaces/list?need_personal_workspace=true",
     );
+    const res = await fetch(url, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${userToken}`,
+            "Content-Type": "application/json",
+        },
+    });
 
     if (!res.ok) {
         throw new Error(
@@ -106,18 +115,18 @@ export async function mintPlaudWorkspaceToken(
     workspaceId: string,
     apiBase: string,
 ): Promise<string> {
-    assertSafeApiBase(apiBase);
-    const res = await fetch(
-        `${apiBase}/user-app/auth/workspace/token/${encodeURIComponent(workspaceId)}`,
-        {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${userToken}`,
-                "Content-Type": "application/json",
-            },
-            body: "{}",
-        },
+    const url = safePlaudUrl(
+        apiBase,
+        `/user-app/auth/workspace/token/${encodeURIComponent(workspaceId)}`,
     );
+    const res = await fetch(url, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${userToken}`,
+            "Content-Type": "application/json",
+        },
+        body: "{}",
+    });
 
     if (!res.ok) {
         const status = res.status;

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -1,0 +1,175 @@
+/**
+ * Plaud workspace token (WT) flow.
+ *
+ * Plaud issues two distinct JWTs:
+ *  - **UT** (User Token, typ="UT"): returned by POST /auth/otp-login, lifetime
+ *    ~300 days. Authenticates user-scoped endpoints (/user/me,
+ *    /team-app/workspaces/list, the workspace-token mint endpoint itself).
+ *  - **WT** (Workspace Token, typ="WT"): minted from a UT, lifetime 24h.
+ *    Required by recording endpoints (/file/simple/web, /device/list,
+ *    /file/temp-url/*, /filetag/, ...). On regional servers (EU, APAC) a UT
+ *    sent to /file/simple/web returns a 200 with an empty list — the request
+ *    silently fails open, which is the bug behind issue #66.
+ *
+ * We never persist the WT or its refresh_token; we mint a fresh WT from the
+ * stored UT on every PlaudClient instance. The WT lasts 24h, far longer than
+ * any sync run, so no in-flight refresh logic is needed.
+ *
+ * The workspaceId itself IS persisted in plaud_connections.workspace_id so we
+ * can skip the /team-app/workspaces/list lookup on subsequent syncs.
+ */
+
+import type {
+    PlaudWorkspaceListResponse,
+    PlaudWorkspaceTokenResponse,
+} from "@/types/plaud";
+
+/**
+ * List all workspaces accessible to the user. Personal accounts always have
+ * exactly one workspace with workspace_type="0" ("Personal"). Team accounts
+ * may have additional workspaces; we always pick the personal one.
+ *
+ * Auth: requires a valid UT.
+ */
+export async function listPlaudWorkspaces(
+    userToken: string,
+    apiBase: string,
+): Promise<PlaudWorkspaceListResponse> {
+    const res = await fetch(
+        `${apiBase}/team-app/workspaces/list?need_personal_workspace=true`,
+        {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${userToken}`,
+                "Content-Type": "application/json",
+            },
+        },
+    );
+
+    if (!res.ok) {
+        throw new Error(
+            `Plaud API error (${res.status}): failed to list workspaces`,
+        );
+    }
+
+    const body = (await res.json()) as PlaudWorkspaceListResponse;
+    if (body.status !== 0 || !body.data?.workspaces) {
+        throw new Error(
+            `Plaud API error: ${body.msg || "failed to list workspaces"}`,
+        );
+    }
+    return body;
+}
+
+/**
+ * Pick the personal workspace (workspace_type === "0") from a workspace list.
+ * Falls back to the first workspace if no personal one is found, since some
+ * accounts (e.g. team-only members) may not have one. Throws if the list is
+ * empty.
+ */
+export function pickPersonalWorkspaceId(
+    response: PlaudWorkspaceListResponse,
+): string {
+    const workspaces = response.data?.workspaces ?? [];
+    if (workspaces.length === 0) {
+        throw new Error("Plaud API error: no workspaces returned");
+    }
+    const personal = workspaces.find((w) => w.workspace_type === "0");
+    return (personal ?? workspaces[0]).workspace_id;
+}
+
+/**
+ * Mint a fresh workspace token (WT) for a given workspace.
+ *
+ * Auth: requires a valid UT. Body is `{}` — the workspace is identified by
+ * the URL path.
+ */
+export async function mintPlaudWorkspaceToken(
+    userToken: string,
+    workspaceId: string,
+    apiBase: string,
+): Promise<string> {
+    const res = await fetch(
+        `${apiBase}/user-app/auth/workspace/token/${encodeURIComponent(workspaceId)}`,
+        {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${userToken}`,
+                "Content-Type": "application/json",
+            },
+            body: "{}",
+        },
+    );
+
+    if (!res.ok) {
+        const status = res.status;
+        throw new WorkspaceTokenError(
+            `Plaud API error (${status}): failed to mint workspace token`,
+            status,
+        );
+    }
+
+    const body = (await res.json()) as PlaudWorkspaceTokenResponse;
+    if (body.status !== 0 || !body.data?.workspace_token) {
+        throw new WorkspaceTokenError(
+            `Plaud API error: ${body.msg || "failed to mint workspace token"}`,
+        );
+    }
+    return body.data.workspace_token;
+}
+
+/**
+ * Thrown when the workspace-token mint fails. Carries the HTTP status when
+ * available so callers can decide whether the cached workspaceId is stale
+ * (4xx → invalidate and relist) vs. a transient server issue (5xx → bubble).
+ */
+export class WorkspaceTokenError extends Error {
+    constructor(
+        message: string,
+        public readonly httpStatus?: number,
+    ) {
+        super(message);
+        this.name = "WorkspaceTokenError";
+    }
+}
+
+/**
+ * Resolve a usable WT given a UT. If a cached workspaceId is provided we try
+ * it first; on 4xx we invalidate and re-discover via /team-app/workspaces/list.
+ *
+ * Returns both the minted WT and the workspaceId that was actually used, so
+ * callers can persist the (possibly newly-discovered) workspaceId.
+ */
+export async function resolveWorkspaceToken(
+    userToken: string,
+    apiBase: string,
+    cachedWorkspaceId: string | null | undefined,
+): Promise<{ workspaceToken: string; workspaceId: string }> {
+    if (cachedWorkspaceId) {
+        try {
+            const workspaceToken = await mintPlaudWorkspaceToken(
+                userToken,
+                cachedWorkspaceId,
+                apiBase,
+            );
+            return { workspaceToken, workspaceId: cachedWorkspaceId };
+        } catch (err) {
+            // Stale cache (workspace deleted/moved) → fall through to relist.
+            // Anything else (5xx, network) → propagate.
+            const status =
+                err instanceof WorkspaceTokenError ? err.httpStatus : undefined;
+            const isStale =
+                typeof status === "number" && status >= 400 && status < 500;
+            if (!isStale) throw err;
+        }
+    }
+
+    const list = await listPlaudWorkspaces(userToken, apiBase);
+    const workspaceId = pickPersonalWorkspaceId(list);
+    const workspaceToken = await mintPlaudWorkspaceToken(
+        userToken,
+        workspaceId,
+        apiBase,
+    );
+    return { workspaceToken, workspaceId };
+}

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -356,6 +356,8 @@ export async function syncRecordingsForUser(
 
         // Update last sync time, plus the workspaceId if it was resolved or
         // changed during this run (cache-empty backfill or stale-cache rescue).
+        // Always scope user-owned UPDATEs by userId in addition to the
+        // primary key, per AGENTS.md "User-Scoped Queries" rule.
         const resolvedWorkspaceId = plaudClient.workspaceId;
         const workspaceIdChanged =
             !!resolvedWorkspaceId &&
@@ -368,7 +370,12 @@ export async function syncRecordingsForUser(
                     ? { workspaceId: resolvedWorkspaceId }
                     : {}),
             })
-            .where(eq(plaudConnections.id, connection.id));
+            .where(
+                and(
+                    eq(plaudConnections.id, connection.id),
+                    eq(plaudConnections.userId, userId),
+                ),
+            );
 
         // Send notifications
         if (

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -4,7 +4,7 @@ import { plaudConnections, recordings, userSettings, users } from "@/db/schema";
 import { env } from "@/lib/env";
 import { sendNewRecordingBarkNotification } from "@/lib/notifications/bark";
 import { sendNewRecordingEmail } from "@/lib/notifications/email";
-import { createPlaudClient } from "@/lib/plaud/client";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
 import type { PlaudRecording } from "@/types/plaud";
@@ -283,6 +283,7 @@ export async function syncRecordingsForUser(
         const plaudClient = await createPlaudClient(
             connection.bearerToken,
             connection.apiBase,
+            connection.workspaceId,
         );
         const storage = await createUserStorageProvider(userId);
         const allNewRecordingNames: string[] = [];
@@ -353,10 +354,20 @@ export async function syncRecordingsForUser(
             page++;
         }
 
-        // Update last sync time
+        // Update last sync time, plus the workspaceId if it was resolved or
+        // changed during this run (cache-empty backfill or stale-cache rescue).
+        const resolvedWorkspaceId = plaudClient.workspaceId;
+        const workspaceIdChanged =
+            !!resolvedWorkspaceId &&
+            resolvedWorkspaceId !== connection.workspaceId;
         await db
             .update(plaudConnections)
-            .set({ lastSync: new Date() })
+            .set({
+                lastSync: new Date(),
+                ...(workspaceIdChanged
+                    ? { workspaceId: resolvedWorkspaceId }
+                    : {}),
+            })
             .where(eq(plaudConnections.id, connection.id));
 
         // Send notifications

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -10,7 +10,7 @@ import {
 } from "@/db/schema";
 import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
 import { decrypt } from "@/lib/encryption";
-import { createPlaudClient } from "@/lib/plaud/client";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
 import {
     getResponseFormat,
@@ -161,11 +161,28 @@ export async function transcribeRecording(
                                 const plaudClient = await createPlaudClient(
                                     connection.bearerToken,
                                     connection.apiBase,
+                                    connection.workspaceId,
                                 );
                                 await plaudClient.updateFilename(
                                     recording.plaudFileId,
                                     generatedTitle,
                                 );
+                                // Backfill workspaceId if newly resolved.
+                                const resolved = plaudClient.workspaceId;
+                                if (
+                                    resolved &&
+                                    resolved !== connection.workspaceId
+                                ) {
+                                    await db
+                                        .update(plaudConnections)
+                                        .set({ workspaceId: resolved })
+                                        .where(
+                                            eq(
+                                                plaudConnections.id,
+                                                connection.id,
+                                            ),
+                                        );
+                                }
                             }
                         } catch (error) {
                             console.error(

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -168,6 +168,8 @@ export async function transcribeRecording(
                                     generatedTitle,
                                 );
                                 // Backfill workspaceId if newly resolved.
+                                // Always scope user-owned UPDATEs by userId
+                                // even when filtering by id (per AGENTS.md).
                                 const resolved = plaudClient.workspaceId;
                                 if (
                                     resolved &&
@@ -177,9 +179,15 @@ export async function transcribeRecording(
                                         .update(plaudConnections)
                                         .set({ workspaceId: resolved })
                                         .where(
-                                            eq(
-                                                plaudConnections.id,
-                                                connection.id,
+                                            and(
+                                                eq(
+                                                    plaudConnections.id,
+                                                    connection.id,
+                                                ),
+                                                eq(
+                                                    plaudConnections.userId,
+                                                    userId,
+                                                ),
                                             ),
                                         );
                                 }

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -34,7 +34,23 @@ describe("PlaudClient", () => {
 
     beforeEach(() => {
         client = new PlaudClient(mockBearerToken);
-        vi.clearAllMocks();
+        // mockReset wipes both call history AND queued one-shot returns,
+        // so leftover mocks from prior tests don't leak in. clearAllMocks
+        // (used previously) preserves queued returns, which breaks ordered
+        // assertions when a synchronous test doesn't consume them.
+        mockFetch.mockReset();
+        // Each authenticated request first attempts to mint a workspace
+        // token (WT) via /team-app/workspaces/list. For the endpoint-URL
+        // assertions in this suite we don't care about the WT flow — we
+        // queue a 500 so the client falls back to the user token, which
+        // is what these tests assert against. Tests that exercise the WT
+        // exchange explicitly live in regressions/66-eu-otp-permissions.
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            json: () => Promise.resolve({ status: 500, msg: "server error" }),
+        });
     });
 
     describe("constructor", () => {

--- a/src/tests/regressions/66-eu-otp-permissions.test.ts
+++ b/src/tests/regressions/66-eu-otp-permissions.test.ts
@@ -1,9 +1,9 @@
 /**
  * Regression test for issue #66:
- *   "Sync returns empty list for EU accounts \u2014 OTP token has insufficient
+ *   "Sync returns empty list for EU accounts -- OTP token has insufficient
  *   permissions"
  *
- * Plaud's regional servers (EU, APAC) require a *workspace token* (WT, JWT
+ * Plaud's regional servers (EU, APAC) require a workspace token (WT, JWT
  * typ="WT", 24h lifetime) on recording endpoints like /file/simple/web.
  * The user token (UT) returned by /auth/otp-login authenticates /user/me
  * and the workspace-token mint endpoints, but on /file/simple/web it
@@ -11,10 +11,10 @@
  * from the UT before hitting recording endpoints.
  *
  * These tests cover the four cache states for the persisted workspaceId:
- *   1. cache empty   \u2192 list workspaces \u2192 mint WT \u2192 expose new id
- *   2. cache hit     \u2192 mint WT directly (no list call)
- *   3. cache stale   \u2192 mint 4xx \u2192 invalidate \u2192 list \u2192 mint \u2192 expose new id
- *   4. mint fails    \u2192 fall back to UT (preserves pre-fix behavior)
+ *   1. cache empty -> list workspaces -> mint WT -> expose new id
+ *   2. cache hit   -> mint WT directly (no list call)
+ *   3. cache stale -> mint 4xx -> invalidate -> list -> mint -> expose new id
+ *   4. mint fails  -> fall back to UT (preserves pre-fix behavior)
  */
 
 import {
@@ -135,6 +135,16 @@ function authHeaderFromCall(call: unknown[]): string {
     return headers.Authorization ?? "";
 }
 
+/**
+ * Normalize the URL argument of a mockFetch invocation to a string. The
+ * PlaudClient passes a string; the workspace.ts helpers pass a URL object
+ * (built via `new URL(path, apiBase)` for SSRF sanitization).
+ */
+function urlFromCall(call: unknown[]): string {
+    const u = call[0];
+    return u instanceof URL ? u.href : String(u);
+}
+
 describe("issue #66: workspace token (WT) is required on EU recording endpoints", () => {
     it("cache empty: lists workspaces, mints WT, sends WT on /file/simple/web", async () => {
         // 1. workspaces/list   2. workspace/token mint   3. /file/simple/web
@@ -151,12 +161,12 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
 
         // First call hits the workspaces/list endpoint with the UT.
         const listCall = mockFetch.mock.calls[0];
-        expect(listCall[0]).toContain("/team-app/workspaces/list");
+        expect(urlFromCall(listCall)).toContain("/team-app/workspaces/list");
         expect(authHeaderFromCall(listCall)).toBe(`Bearer ${UT}`);
 
-        // Second call mints the WT \u2014 also authenticated with the UT.
+        // Second call mints the WT -- also authenticated with the UT.
         const mintCall = mockFetch.mock.calls[1];
-        expect(mintCall[0]).toContain(
+        expect(urlFromCall(mintCall)).toContain(
             `/user-app/auth/workspace/token/${WORKSPACE_ID}`,
         );
         expect(authHeaderFromCall(mintCall)).toBe(`Bearer ${UT}`);
@@ -165,7 +175,7 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
         // Third call (the actual recordings fetch) MUST use the WT, not UT.
         // This is the load-bearing assertion for the bug.
         const recCall = mockFetch.mock.calls[2];
-        expect(recCall[0]).toContain("/file/simple/web");
+        expect(urlFromCall(recCall)).toContain("/file/simple/web");
         expect(authHeaderFromCall(recCall)).toBe(`Bearer ${WT}`);
 
         // Resolved workspace id is now exposed for the caller to persist.
@@ -183,11 +193,13 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
 
         expect(mockFetch).toHaveBeenCalledTimes(2);
 
-        // No workspaces/list call \u2014 went straight to mint.
-        expect(mockFetch.mock.calls[0][0]).toContain(
+        // No workspaces/list call -- went straight to mint.
+        expect(urlFromCall(mockFetch.mock.calls[0])).toContain(
             `/user-app/auth/workspace/token/${WORKSPACE_ID}`,
         );
-        expect(mockFetch.mock.calls[1][0]).toContain("/file/simple/web");
+        expect(urlFromCall(mockFetch.mock.calls[1])).toContain(
+            "/file/simple/web",
+        );
         expect(authHeaderFromCall(mockFetch.mock.calls[1])).toBe(
             `Bearer ${WT}`,
         );
@@ -195,9 +207,9 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
     });
 
     it("cache stale: mint 4xx, invalidates, relists, exposes new workspaceId", async () => {
-        // 1. mint with stale id \u2192 404
-        // 2. workspaces/list \u2192 returns NEW workspace id
-        // 3. mint with new id \u2192 WT
+        // 1. mint with stale id -> 404
+        // 2. workspaces/list -> returns NEW workspace id
+        // 3. mint with new id -> WT
         // 4. /file/simple/web with WT
         mockFetch
             .mockResolvedValueOnce(
@@ -215,13 +227,13 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
         await client.getRecordings(0, 10);
 
         expect(mockFetch).toHaveBeenCalledTimes(4);
-        expect(mockFetch.mock.calls[0][0]).toContain(
+        expect(urlFromCall(mockFetch.mock.calls[0])).toContain(
             "/user-app/auth/workspace/token/ws_stale",
         );
-        expect(mockFetch.mock.calls[1][0]).toContain(
+        expect(urlFromCall(mockFetch.mock.calls[1])).toContain(
             "/team-app/workspaces/list",
         );
-        expect(mockFetch.mock.calls[2][0]).toContain(
+        expect(urlFromCall(mockFetch.mock.calls[2])).toContain(
             `/user-app/auth/workspace/token/${NEW_WORKSPACE_ID}`,
         );
         expect(authHeaderFromCall(mockFetch.mock.calls[3])).toBe(
@@ -233,7 +245,7 @@ describe("issue #66: workspace token (WT) is required on EU recording endpoints"
     });
 
     it("workspace mint fails entirely: falls back to UT (preserves global users)", async () => {
-        // workspaces/list \u2192 500. Client gives up on WT and uses UT directly.
+        // workspaces/list -> 500. Client gives up on WT and uses UT directly.
         mockFetch
             .mockResolvedValueOnce(
                 mockResponse({

--- a/src/tests/regressions/66-eu-otp-permissions.test.ts
+++ b/src/tests/regressions/66-eu-otp-permissions.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Regression test for issue #66:
+ *   "Sync returns empty list for EU accounts \u2014 OTP token has insufficient
+ *   permissions"
+ *
+ * Plaud's regional servers (EU, APAC) require a *workspace token* (WT, JWT
+ * typ="WT", 24h lifetime) on recording endpoints like /file/simple/web.
+ * The user token (UT) returned by /auth/otp-login authenticates /user/me
+ * and the workspace-token mint endpoints, but on /file/simple/web it
+ * silently returns HTTP 200 with an empty list. PlaudClient must mint a WT
+ * from the UT before hitting recording endpoints.
+ *
+ * These tests cover the four cache states for the persisted workspaceId:
+ *   1. cache empty   \u2192 list workspaces \u2192 mint WT \u2192 expose new id
+ *   2. cache hit     \u2192 mint WT directly (no list call)
+ *   3. cache stale   \u2192 mint 4xx \u2192 invalidate \u2192 list \u2192 mint \u2192 expose new id
+ *   4. mint fails    \u2192 fall back to UT (preserves pre-fix behavior)
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+import { PlaudClient } from "@/lib/plaud/client";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+beforeAll(() => {
+    mockFetch = vi.fn() as Mock;
+    global.fetch = mockFetch as typeof global.fetch;
+});
+
+afterAll(() => {
+    global.fetch = originalFetch;
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+const UT = "ut.user.token";
+const WT = "wt.workspace.token";
+const API_BASE = "https://api-euc1.plaud.ai";
+const WORKSPACE_ID = "ws_cKyt7F2Iec";
+const NEW_WORKSPACE_ID = "ws_newDiscovered";
+
+interface MockResponseInit {
+    ok?: boolean;
+    status?: number;
+    body: unknown;
+}
+
+function mockResponse({ ok = true, status = 200, body }: MockResponseInit): {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    headers: { get: () => null };
+    json: () => Promise<unknown>;
+} {
+    return {
+        ok,
+        status,
+        statusText: ok ? "OK" : "Error",
+        headers: { get: () => null },
+        json: () => Promise.resolve(body),
+    };
+}
+
+function workspaceListResponse(workspaceId: string) {
+    return mockResponse({
+        body: {
+            status: 0,
+            data: {
+                workspaces: [
+                    {
+                        workspace_id: workspaceId,
+                        member_id: "mem_x",
+                        name: "Personal",
+                        role: "admin",
+                        status: "active",
+                        workspace_type: "0",
+                    },
+                ],
+            },
+        },
+    });
+}
+
+function workspaceTokenResponse(workspaceToken: string) {
+    return mockResponse({
+        body: {
+            status: 0,
+            data: {
+                status: 0,
+                workspace_token: workspaceToken,
+                expires_in: 86400,
+                wt_expires_at: 0,
+                refresh_token: "refresh.token",
+                refresh_expires_in: 2592000,
+                refresh_expires_at: 0,
+                workspace_id: WORKSPACE_ID,
+                member_id: "mem_x",
+                role: "admin",
+            },
+        },
+    });
+}
+
+function recordingsResponse() {
+    return mockResponse({
+        body: {
+            status: 0,
+            msg: "success",
+            data_file_total: 1,
+            data_file_list: [{ id: "rec_1", filename: "test.mp3" }],
+        },
+    });
+}
+
+/**
+ * Pull the Authorization header off a mockFetch invocation.
+ * Our PlaudClient sends `Bearer <token>` (capital B); `fetch` is called as
+ * `fetch(url, { headers: { Authorization: ... } })`.
+ */
+function authHeaderFromCall(call: unknown[]): string {
+    const init = call[1] as RequestInit | undefined;
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    return headers.Authorization ?? "";
+}
+
+describe("issue #66: workspace token (WT) is required on EU recording endpoints", () => {
+    it("cache empty: lists workspaces, mints WT, sends WT on /file/simple/web", async () => {
+        // 1. workspaces/list   2. workspace/token mint   3. /file/simple/web
+        mockFetch
+            .mockResolvedValueOnce(workspaceListResponse(WORKSPACE_ID))
+            .mockResolvedValueOnce(workspaceTokenResponse(WT))
+            .mockResolvedValueOnce(recordingsResponse());
+
+        const client = new PlaudClient(UT, API_BASE);
+        const result = await client.getRecordings(0, 10);
+
+        expect(result.data_file_total).toBe(1);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+
+        // First call hits the workspaces/list endpoint with the UT.
+        const listCall = mockFetch.mock.calls[0];
+        expect(listCall[0]).toContain("/team-app/workspaces/list");
+        expect(authHeaderFromCall(listCall)).toBe(`Bearer ${UT}`);
+
+        // Second call mints the WT \u2014 also authenticated with the UT.
+        const mintCall = mockFetch.mock.calls[1];
+        expect(mintCall[0]).toContain(
+            `/user-app/auth/workspace/token/${WORKSPACE_ID}`,
+        );
+        expect(authHeaderFromCall(mintCall)).toBe(`Bearer ${UT}`);
+        expect((mintCall[1] as RequestInit).method).toBe("POST");
+
+        // Third call (the actual recordings fetch) MUST use the WT, not UT.
+        // This is the load-bearing assertion for the bug.
+        const recCall = mockFetch.mock.calls[2];
+        expect(recCall[0]).toContain("/file/simple/web");
+        expect(authHeaderFromCall(recCall)).toBe(`Bearer ${WT}`);
+
+        // Resolved workspace id is now exposed for the caller to persist.
+        expect(client.workspaceId).toBe(WORKSPACE_ID);
+        expect(client.usingUserTokenFallback).toBe(false);
+    });
+
+    it("cache hit: skips workspaces/list, mints WT directly", async () => {
+        mockFetch
+            .mockResolvedValueOnce(workspaceTokenResponse(WT))
+            .mockResolvedValueOnce(recordingsResponse());
+
+        const client = new PlaudClient(UT, API_BASE, WORKSPACE_ID);
+        await client.getRecordings(0, 10);
+
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        // No workspaces/list call \u2014 went straight to mint.
+        expect(mockFetch.mock.calls[0][0]).toContain(
+            `/user-app/auth/workspace/token/${WORKSPACE_ID}`,
+        );
+        expect(mockFetch.mock.calls[1][0]).toContain("/file/simple/web");
+        expect(authHeaderFromCall(mockFetch.mock.calls[1])).toBe(
+            `Bearer ${WT}`,
+        );
+        expect(client.workspaceId).toBe(WORKSPACE_ID);
+    });
+
+    it("cache stale: mint 4xx, invalidates, relists, exposes new workspaceId", async () => {
+        // 1. mint with stale id \u2192 404
+        // 2. workspaces/list \u2192 returns NEW workspace id
+        // 3. mint with new id \u2192 WT
+        // 4. /file/simple/web with WT
+        mockFetch
+            .mockResolvedValueOnce(
+                mockResponse({
+                    ok: false,
+                    status: 404,
+                    body: { status: 404, msg: "workspace not found" },
+                }),
+            )
+            .mockResolvedValueOnce(workspaceListResponse(NEW_WORKSPACE_ID))
+            .mockResolvedValueOnce(workspaceTokenResponse(WT))
+            .mockResolvedValueOnce(recordingsResponse());
+
+        const client = new PlaudClient(UT, API_BASE, "ws_stale");
+        await client.getRecordings(0, 10);
+
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+        expect(mockFetch.mock.calls[0][0]).toContain(
+            "/user-app/auth/workspace/token/ws_stale",
+        );
+        expect(mockFetch.mock.calls[1][0]).toContain(
+            "/team-app/workspaces/list",
+        );
+        expect(mockFetch.mock.calls[2][0]).toContain(
+            `/user-app/auth/workspace/token/${NEW_WORKSPACE_ID}`,
+        );
+        expect(authHeaderFromCall(mockFetch.mock.calls[3])).toBe(
+            `Bearer ${WT}`,
+        );
+
+        // Caller will persist this back to plaud_connections.workspace_id.
+        expect(client.workspaceId).toBe(NEW_WORKSPACE_ID);
+    });
+
+    it("workspace mint fails entirely: falls back to UT (preserves global users)", async () => {
+        // workspaces/list \u2192 500. Client gives up on WT and uses UT directly.
+        mockFetch
+            .mockResolvedValueOnce(
+                mockResponse({
+                    ok: false,
+                    status: 500,
+                    body: { status: 500, msg: "server error" },
+                }),
+            )
+            .mockResolvedValueOnce(recordingsResponse());
+
+        const client = new PlaudClient(UT, API_BASE);
+        await client.getRecordings(0, 10);
+
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        // Recording call uses UT, not WT.
+        expect(authHeaderFromCall(mockFetch.mock.calls[1])).toBe(
+            `Bearer ${UT}`,
+        );
+        expect(client.usingUserTokenFallback).toBe(true);
+        expect(client.workspaceId).toBeUndefined();
+    });
+
+    it("concurrent requests share a single WT mint", async () => {
+        // 1. workspaces/list   2. mint WT   3+4. two parallel /file/simple/web
+        mockFetch
+            .mockResolvedValueOnce(workspaceListResponse(WORKSPACE_ID))
+            .mockResolvedValueOnce(workspaceTokenResponse(WT))
+            .mockResolvedValueOnce(recordingsResponse())
+            .mockResolvedValueOnce(recordingsResponse());
+
+        const client = new PlaudClient(UT, API_BASE);
+        await Promise.all([
+            client.getRecordings(0, 10),
+            client.getRecordings(10, 10),
+        ]);
+
+        // 4 total calls: 1 list + 1 mint + 2 recordings (NOT 1+1+1+1+2 = 6).
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+        expect(authHeaderFromCall(mockFetch.mock.calls[2])).toBe(
+            `Bearer ${WT}`,
+        );
+        expect(authHeaderFromCall(mockFetch.mock.calls[3])).toBe(
+            `Bearer ${WT}`,
+        );
+    });
+});

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/db", () => ({
     },
 }));
 
-vi.mock("@/lib/plaud/client", () => ({
+vi.mock("@/lib/plaud/client-factory", () => ({
     createPlaudClient: vi.fn(),
 }));
 
@@ -40,7 +40,7 @@ vi.mock("@/lib/transcription/transcribe-recording", () => ({
 }));
 
 import { db } from "@/db";
-import { createPlaudClient } from "@/lib/plaud/client";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
 
 describe("Sync", () => {

--- a/src/types/plaud.ts
+++ b/src/types/plaud.ts
@@ -58,3 +58,56 @@ export interface PlaudApiError {
     status: number;
     msg: string;
 }
+
+/**
+ * Plaud workspace metadata returned by /team-app/workspaces/list.
+ * Personal accounts always have exactly one workspace with workspace_type="0".
+ */
+export interface PlaudWorkspace {
+    workspace_id: string;
+    member_id: string;
+    name: string;
+    role: string;
+    status: string;
+    workspace_type: string;
+    region?: string;
+    api_domain?: string;
+    created_at?: string;
+    creator_user_id?: string;
+}
+
+export interface PlaudWorkspaceListResponse {
+    status: number;
+    msg?: string;
+    data: {
+        workspaces: PlaudWorkspace[];
+    };
+    type?: string;
+}
+
+/**
+ * Plaud workspace token mint response from
+ * POST /user-app/auth/workspace/token/<workspace_id>.
+ *
+ * Note: the response wraps the actual payload in a nested `data` object that
+ * itself has `status: 0` mirroring the outer status. The workspace token (WT)
+ * has JWT typ="WT" and is required by recording endpoints. We mint a fresh WT
+ * from the UT on every PlaudClient instance; we don't persist it or its
+ * refresh_token.
+ */
+export interface PlaudWorkspaceTokenResponse {
+    status: number;
+    msg?: string;
+    data: {
+        status: number;
+        workspace_token: string;
+        expires_in: number;
+        wt_expires_at: number;
+        refresh_token: string;
+        refresh_expires_in: number;
+        refresh_expires_at: number;
+        workspace_id: string;
+        member_id: string;
+        role: string;
+    };
+}


### PR DESCRIPTION
## Description

Fixes the EU/APAC sync bug reported in #66 where `Sync Device` returns `{ newRecordings: 0 }` despite recordings existing on Plaud's cloud.

Root cause confirmed via HAR captures of the official Plaud web app on `api-euc1.plaud.ai`: Plaud issues two distinct JWTs.

- **UT** (User Token, JWT `typ: "UT"`, ~300 day lifetime) — returned by `/auth/otp-login`. Authenticates `/user/me`, `/team-app/workspaces/list`, and the workspace-token mint endpoint.
- **WT** (Workspace Token, JWT `typ: "WT"`, 24 h lifetime) — minted from a UT via `POST /user-app/auth/workspace/token/<workspace_id>`. Required by recording endpoints (`/file/simple/web`, `/device/list`, `/file/temp-url/*`, `/filetag/`, …).

We were storing and using the UT for everything. On regional servers, `/file/simple/web` accepts the UT but silently returns `data_file_total: 0` — i.e. fails open. The fix mints a WT from the stored UT before hitting recording endpoints, with the `workspace_id` cached in the DB so subsequent syncs skip the workspace-list lookup.

No re-auth required for affected users — their stored UT is fine, the new code mints a WT from it on the next sync.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #66

## Changes Made

- New `src/lib/plaud/workspace.ts` with `listPlaudWorkspaces`, `pickPersonalWorkspaceId`, `mintPlaudWorkspaceToken`, and `resolveWorkspaceToken` (with `WorkspaceTokenError` carrying HTTP status for 4xx-vs-5xx routing).
- `PlaudClient` accepts an optional cached `workspaceId`, lazily mints a WT on the first authenticated request, caches it for the client lifetime, exposes `workspaceId` and `usingUserTokenFallback` getters, and is concurrent-safe via a single in-flight resolution promise.
- Stale-cache self-heal: WT mint 4xx → invalidate → relist via `/team-app/workspaces/list` → remint → expose new `workspaceId` for the caller to persist.
- Hard-fallback to UT if the workspace endpoints are entirely unavailable (preserves pre-fix behavior for any server that still accepts UT on recording endpoints).
- New `workspace_id text` (nullable) column on `plaud_connections`. Resolved at OTP-verify time and persisted on insert/update; sync/transcribe call sites pass it in and persist back any newly-resolved value.
- `createPlaudClient` moved to `src/lib/plaud/client-factory.ts` so importing the `PlaudClient` class no longer transitively loads `encryption`/`env` validation (which previously broke unit tests that only construct the class).
- Dev diagnostics endpoint surfaces `workspaceId`, `workspaceIdSource` (`cache` / `resolved` / `unresolved`), and `workspaceTokenFallback` for debugging.
- New regression test `src/tests/regressions/66-eu-otp-permissions.test.ts` covers cache-empty, cache-hit, cache-stale, hard-fallback, and concurrent-share-mint paths.

## Testing

### Test Environment

- OS: macOS
- Node version: 20
- Browser: n/a (server-side)

### Test Steps

```
pnpm format-and-lint:fix    # 0 issues
pnpm type-check             # clean
pnpm test                   # 52 passed, 3 skipped (pre-existing integration tests)
```

End-to-end verification against a live EU account is recommended before merge — the fix has not been run against a real `api-euc1.plaud.ai` account in this branch (the original bug reporter offered to help test on theirs).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [x] I have generated a new migration (`pnpm db:generate`) — `0015_glamorous_doomsday.sql`: `ALTER TABLE plaud_connections ADD COLUMN workspace_id text;`
- [ ] I have tested the migration locally
- [x] I have included rollback instructions (if applicable) — purely additive nullable column; rollback is `ALTER TABLE plaud_connections DROP COLUMN workspace_id;`. Existing rows backfill themselves on next sync.

## Breaking Changes

None. Schema change is additive, public client API is unchanged (constructor gains an optional third parameter), and stored UTs continue to work.

## Additional Notes

What I deliberately did **not** include in this fix, despite seeing them in the HAR (kept the diff minimal and evidence-based; the reporter's curl test confirmed these are not required):

- Browser-style headers `x-pld-user`, `x-device-id`, `app-platform: web`, `edit-from: web`, `timezone`.
- Extra OTP request body fields `user_area`, `require_set_password`, `team_enabled`.
- Persisting the WT or its `refresh_token`. We mint fresh from the UT each time — simpler, no extra encryption surface.

## For Reviewers

- `src/lib/plaud/client.ts` — the lazy-mint + fallback flow in `request()` / `ensureWorkspaceToken()` / `fetchWorkspaceToken()`.
- `src/lib/plaud/workspace.ts` — the stale-cache routing in `resolveWorkspaceToken`.
- `src/app/api/plaud/auth/verify/route.ts` — fail-soft behavior when workspace resolve fails at connect time (we still save the UT and fall back at sync time, rather than failing the whole connect).
- `src/lib/sync/sync-recordings.ts` and `src/lib/transcription/transcribe-recording.ts` — write-back of newly-resolved `workspaceId`, scoped by `connection.id` (which is itself `userId`-scoped from the lookup above).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EU/APAC sync by minting a Plaud workspace token (WT) from the stored user token (UT) before calling recording endpoints. Adds an SSRF barrier, persists `workspace_id`, self-heals stale cache, improves verify flow, and tightens DB updates (fixes #66).

- **Bug Fixes**
  - `PlaudClient` lazily mints/caches a WT; concurrent calls share one mint; exposes `workspaceId` and `usingUserTokenFallback`; retains UT hard-fallback.
  - Verify now only discovers `workspace_id` (lists+picks) and lets the client mint WT on first real call; one mint per connect.
  - Stale-cache handling: WT mint 4xx or 2xx with `status != 0` → relist → remint; `dev/plaud/info` shows accurate `workspaceIdSource` and fallback flag.
  - SSRF barrier: workspace endpoints build a parsed URL and enforce an `*.plaud.ai` allowlist (recognized by CodeQL).
  - `createPlaudClient` moved to `src/lib/plaud/client-factory.ts`; tests updated; all `UPDATE plaud_connections` are scoped by both `id` and `userId`.

- **Migration**
  - Run the DB migration adding `workspace_id` to `plaud_connections`.
  - No re-auth needed; existing UTs mint WT on next sync and backfill `workspace_id` automatically.

<sup>Written for commit 56f6243e11918f827b970de9b882515edfc30d9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

