### PR TITLE
feat(recordings): add delete recording action in UI

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { Workstation } from "@/components/dashboard/workstation";
 import { db } from "@/db";
 import { recordings, transcriptions } from "@/db/schema";
@@ -18,7 +18,12 @@ export default async function DashboardPage() {
             deviceSn: recordings.deviceSn,
         })
         .from(recordings)
-        .where(eq(recordings.userId, session.user.id))
+        .where(
+            and(
+                eq(recordings.userId, session.user.id),
+                isNull(recordings.deletedAt),
+            ),
+        )
         .orderBy(desc(recordings.startTime));
 
     const userTranscriptions = await db

--- a/src/app/(app)/recordings/[id]/page.tsx
+++ b/src/app/(app)/recordings/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { RecordingWorkstation } from "@/components/recordings/recording-workstation";
 import { db } from "@/db";
@@ -21,7 +21,11 @@ export default async function RecordingDetailPage({
         .select()
         .from(recordings)
         .where(
-            and(eq(recordings.id, id), eq(recordings.userId, session.user.id)),
+            and(
+                eq(recordings.id, id),
+                eq(recordings.userId, session.user.id),
+                isNull(recordings.deletedAt),
+            ),
         )
         .limit(1);
 

--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings, transcriptions } from "@/db/schema";
@@ -22,7 +22,12 @@ export async function POST(request: Request) {
         const userRecordings = await db
             .select()
             .from(recordings)
-            .where(eq(recordings.userId, session.user.id));
+            .where(
+                and(
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            );
 
         // Get all transcriptions
         const recordingIds = userRecordings.map((r) => r.id);

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings, transcriptions, userSettings } from "@/db/schema";
@@ -34,7 +34,12 @@ export async function GET(request: Request) {
         const userRecordings = await db
             .select()
             .from(recordings)
-            .where(eq(recordings.userId, session.user.id));
+            .where(
+                and(
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            );
 
         // Get transcriptions for all recordings
         const recordingIds = userRecordings.map((r) => r.id);

--- a/src/app/api/recordings/[id]/audio/route.ts
+++ b/src/app/api/recordings/[id]/audio/route.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings } from "@/db/schema";
@@ -30,6 +30,7 @@ export async function GET(
                 and(
                     eq(recordings.id, id),
                     eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
                 ),
             )
             .limit(1);

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -63,15 +63,37 @@ export async function GET(
 }
 
 /**
+ * Storage providers throw on any deleteFile error including "object not
+ * present". Detect the not-found case so retries after a half-failed delete
+ * still tombstone cleanly. We match on common substrings rather than typed
+ * error classes so this works across the local-fs adapter (ENOENT) and the
+ * S3 adapter (NoSuchKey / NotFound / 404).
+ */
+function isStorageNotFoundError(error: unknown): boolean {
+    const message =
+        error instanceof Error ? error.message : String(error ?? "");
+    return /ENOENT|NoSuchKey|NotFound|\b404\b/i.test(message);
+}
+
+/**
  * Soft-delete a recording.
  *
- * - Hard-deletes the audio file from storage.
- * - Hard-deletes any transcription and AI-enhancement rows.
- * - Sets `recordings.deletedAt = now()` so sync does not resurrect the
- *   recording from Plaud on the next pull (sync is keyed on plaudFileId).
+ * Order of operations is important:
  *
- * This does NOT delete the recording on Plaud's servers. Plaud remains the
- * upstream source of truth; OpenPlaud just stops mirroring this file.
+ * 1. Hard-delete the audio file from storage. If the storage provider fails
+ *    for any reason other than "already gone", abort with 500 — we do NOT
+ *    tombstone, so the user can retry instead of being left with an orphan
+ *    blob that storage-usage stats can't see.
+ * 2. Run all DB writes (transcription rows, AI-enhancement rows, tombstone
+ *    update on `recordings.deletedAt`) inside a single transaction. Either
+ *    they all commit or none do, so a partial failure can't leave the user
+ *    with a half-deleted recording (e.g. transcript gone but row still
+ *    visible).
+ *
+ * The tombstone (instead of a hard delete) exists because sync is keyed on
+ * `recordings.plaudFileId`. Without it, the next pull from Plaud would
+ * resurrect the recording. This endpoint does NOT delete the file on
+ * Plaud's servers — Plaud remains the upstream source of truth.
  */
 export async function DELETE(
     request: Request,
@@ -90,6 +112,7 @@ export async function DELETE(
         }
 
         const { id } = await params;
+        const userId = session.user.id;
 
         const [recording] = await db
             .select()
@@ -97,7 +120,7 @@ export async function DELETE(
             .where(
                 and(
                     eq(recordings.id, id),
-                    eq(recordings.userId, session.user.id),
+                    eq(recordings.userId, userId),
                     isNull(recordings.deletedAt),
                 ),
             )
@@ -110,49 +133,58 @@ export async function DELETE(
             );
         }
 
-        // Best-effort storage delete. If the file is already gone (e.g. user
-        // deleted it out-of-band, or storage provider returns 404), continue
-        // with the DB tombstone so the row state is consistent.
+        // 1. Storage delete first. Treat "already gone" as success; surface
+        //    every other error so the user can retry.
         try {
-            const storage = await createUserStorageProvider(session.user.id);
+            const storage = await createUserStorageProvider(userId);
             await storage.deleteFile(recording.storagePath);
         } catch (storageError) {
-            console.error(
-                `Failed to delete storage file for recording ${id}:`,
-                storageError,
-            );
+            if (!isStorageNotFoundError(storageError)) {
+                console.error(
+                    `Failed to delete storage file for recording ${id}:`,
+                    storageError,
+                );
+                return NextResponse.json(
+                    {
+                        error: "Failed to delete recording audio. Please retry.",
+                    },
+                    { status: 500 },
+                );
+            }
+            // Object already absent — continue with tombstone.
         }
 
-        // Remove derived rows. These contain user content (transcript text,
-        // AI summary) that the user is asking to remove.
-        await db
-            .delete(transcriptions)
-            .where(
-                and(
-                    eq(transcriptions.recordingId, id),
-                    eq(transcriptions.userId, session.user.id),
-                ),
-            );
+        // 2. Atomic DB writes: child rows + tombstone in one transaction.
+        await db.transaction(async (tx) => {
+            await tx
+                .delete(transcriptions)
+                .where(
+                    and(
+                        eq(transcriptions.recordingId, id),
+                        eq(transcriptions.userId, userId),
+                    ),
+                );
 
-        await db
-            .delete(aiEnhancements)
-            .where(
-                and(
-                    eq(aiEnhancements.recordingId, id),
-                    eq(aiEnhancements.userId, session.user.id),
-                ),
-            );
+            await tx
+                .delete(aiEnhancements)
+                .where(
+                    and(
+                        eq(aiEnhancements.recordingId, id),
+                        eq(aiEnhancements.userId, userId),
+                    ),
+                );
 
-        // Soft-delete the recording row (tombstone for sync).
-        await db
-            .update(recordings)
-            .set({ deletedAt: new Date(), updatedAt: new Date() })
-            .where(
-                and(
-                    eq(recordings.id, id),
-                    eq(recordings.userId, session.user.id),
-                ),
-            );
+            await tx
+                .update(recordings)
+                .set({ deletedAt: new Date(), updatedAt: new Date() })
+                .where(
+                    and(
+                        eq(recordings.id, id),
+                        eq(recordings.userId, userId),
+                        isNull(recordings.deletedAt),
+                    ),
+                );
+        });
 
         return NextResponse.json({ success: true });
     } catch (error) {

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -1,8 +1,9 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { recordings, transcriptions } from "@/db/schema";
+import { aiEnhancements, recordings, transcriptions } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { createUserStorageProvider } from "@/lib/storage/factory";
 
 export async function GET(
     request: Request,
@@ -29,6 +30,7 @@ export async function GET(
                 and(
                     eq(recordings.id, id),
                     eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
                 ),
             )
             .limit(1);
@@ -55,6 +57,108 @@ export async function GET(
         console.error("Error fetching recording:", error);
         return NextResponse.json(
             { error: "Failed to fetch recording" },
+            { status: 500 },
+        );
+    }
+}
+
+/**
+ * Soft-delete a recording.
+ *
+ * - Hard-deletes the audio file from storage.
+ * - Hard-deletes any transcription and AI-enhancement rows.
+ * - Sets `recordings.deletedAt = now()` so sync does not resurrect the
+ *   recording from Plaud on the next pull (sync is keyed on plaudFileId).
+ *
+ * This does NOT delete the recording on Plaud's servers. Plaud remains the
+ * upstream source of truth; OpenPlaud just stops mirroring this file.
+ */
+export async function DELETE(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session?.user) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        const { id } = await params;
+
+        const [recording] = await db
+            .select()
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, id),
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            )
+            .limit(1);
+
+        if (!recording) {
+            return NextResponse.json(
+                { error: "Recording not found" },
+                { status: 404 },
+            );
+        }
+
+        // Best-effort storage delete. If the file is already gone (e.g. user
+        // deleted it out-of-band, or storage provider returns 404), continue
+        // with the DB tombstone so the row state is consistent.
+        try {
+            const storage = await createUserStorageProvider(session.user.id);
+            await storage.deleteFile(recording.storagePath);
+        } catch (storageError) {
+            console.error(
+                `Failed to delete storage file for recording ${id}:`,
+                storageError,
+            );
+        }
+
+        // Remove derived rows. These contain user content (transcript text,
+        // AI summary) that the user is asking to remove.
+        await db
+            .delete(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.recordingId, id),
+                    eq(transcriptions.userId, session.user.id),
+                ),
+            );
+
+        await db
+            .delete(aiEnhancements)
+            .where(
+                and(
+                    eq(aiEnhancements.recordingId, id),
+                    eq(aiEnhancements.userId, session.user.id),
+                ),
+            );
+
+        // Soft-delete the recording row (tombstone for sync).
+        await db
+            .update(recordings)
+            .set({ deletedAt: new Date(), updatedAt: new Date() })
+            .where(
+                and(
+                    eq(recordings.id, id),
+                    eq(recordings.userId, session.user.id),
+                ),
+            );
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error deleting recording:", error);
+        return NextResponse.json(
+            { error: "Failed to delete recording" },
             { status: 500 },
         );
     }

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -221,6 +221,29 @@ export async function POST(
             summary = rawContent;
         }
 
+        // Re-check tombstone status: the user may have deleted the
+        // recording while the (long-running) provider call was in flight.
+        // Without this guard we'd write a summary row for a recording the
+        // DELETE handler has already cleaned up, leaving an orphan that
+        // exposes content the user asked to remove. See PR #72.
+        const [stillActive] = await db
+            .select({ deletedAt: recordings.deletedAt })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, id),
+                    eq(recordings.userId, session.user.id),
+                ),
+            )
+            .limit(1);
+
+        if (!stillActive || stillActive.deletedAt) {
+            return NextResponse.json(
+                { error: "Recording was deleted" },
+                { status: 410 },
+            );
+        }
+
         // Upsert into aiEnhancements
         const [existing] = await db
             .select()

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { OpenAI } from "openai";
 import { db } from "@/db";
@@ -46,6 +46,7 @@ export async function POST(
                 and(
                     eq(recordings.id, id),
                     eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
                 ),
             )
             .limit(1);

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -221,62 +221,79 @@ export async function POST(
             summary = rawContent;
         }
 
-        // Re-check tombstone status: the user may have deleted the
-        // recording while the (long-running) provider call was in flight.
-        // Without this guard we'd write a summary row for a recording the
-        // DELETE handler has already cleaned up, leaving an orphan that
-        // exposes content the user asked to remove. See PR #72.
-        const [stillActive] = await db
-            .select({ deletedAt: recordings.deletedAt })
-            .from(recordings)
-            .where(
-                and(
-                    eq(recordings.id, id),
-                    eq(recordings.userId, session.user.id),
-                ),
-            )
-            .limit(1);
+        // Atomic tombstone re-check + upsert.
+        //
+        // The user may have deleted the recording while the (long-running)
+        // provider call was in flight. To prevent a delete that lands
+        // *between* our re-check and our upsert from being silently undone,
+        // we run both inside a single transaction that takes a row-level
+        // write lock (`FOR UPDATE`) on the recording. The DELETE handler's
+        // transaction acquires the same lock via its `UPDATE recordings`
+        // tombstone write, so the two transactions serialize: either we
+        // see `deletedAt` set and abort, or our upsert commits before
+        // DELETE runs and DELETE then cleans up our row inside its own tx.
+        // See PR #72.
+        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
+        try {
+            await db.transaction(async (tx) => {
+                const [stillActive] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, id),
+                            eq(recordings.userId, session.user.id),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
 
-        if (!stillActive || stillActive.deletedAt) {
-            return NextResponse.json(
-                { error: "Recording was deleted" },
-                { status: 410 },
-            );
-        }
+                if (!stillActive || stillActive.deletedAt) {
+                    throw RECORDING_TOMBSTONED;
+                }
 
-        // Upsert into aiEnhancements
-        const [existing] = await db
-            .select()
-            .from(aiEnhancements)
-            .where(
-                and(
-                    eq(aiEnhancements.recordingId, id),
-                    eq(aiEnhancements.userId, session.user.id),
-                ),
-            )
-            .limit(1);
+                const [existing] = await tx
+                    .select()
+                    .from(aiEnhancements)
+                    .where(
+                        and(
+                            eq(aiEnhancements.recordingId, id),
+                            eq(aiEnhancements.userId, session.user.id),
+                        ),
+                    )
+                    .limit(1);
 
-        if (existing) {
-            await db
-                .update(aiEnhancements)
-                .set({
-                    summary,
-                    keyPoints,
-                    actionItems,
-                    provider: credentials.provider,
-                    model,
-                })
-                .where(eq(aiEnhancements.id, existing.id));
-        } else {
-            await db.insert(aiEnhancements).values({
-                recordingId: id,
-                userId: session.user.id,
-                summary,
-                keyPoints,
-                actionItems,
-                provider: credentials.provider,
-                model,
+                if (existing) {
+                    await tx
+                        .update(aiEnhancements)
+                        .set({
+                            summary,
+                            keyPoints,
+                            actionItems,
+                            provider: credentials.provider,
+                            model,
+                        })
+                        .where(eq(aiEnhancements.id, existing.id));
+                } else {
+                    await tx.insert(aiEnhancements).values({
+                        recordingId: id,
+                        userId: session.user.id,
+                        summary,
+                        keyPoints,
+                        actionItems,
+                        provider: credentials.provider,
+                        model,
+                    });
+                }
             });
+        } catch (txError) {
+            if (txError === RECORDING_TOMBSTONED) {
+                return NextResponse.json(
+                    { error: "Recording was deleted" },
+                    { status: 410 },
+                );
+            }
+            throw txError;
         }
 
         return NextResponse.json({

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { OpenAI } from "openai";
 import { db } from "@/db";
@@ -39,6 +39,7 @@ export async function POST(
                 and(
                     eq(recordings.id, id),
                     eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
                 ),
             )
             .limit(1);

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -135,57 +135,74 @@ export async function POST(
         const { text: transcriptionText, detectedLanguage } =
             parseTranscriptionResponse(transcription, responseFormat);
 
-        // Re-check tombstone status: the user may have deleted the
-        // recording while the (long-running) provider call was in flight.
-        // Without this guard we'd write a fresh transcription row for a row
-        // the DELETE handler has already cleaned up, leaving an orphan that
-        // exposes transcript text the user asked to remove. See PR #72.
-        const [stillActive] = await db
-            .select({ deletedAt: recordings.deletedAt })
-            .from(recordings)
-            .where(
-                and(
-                    eq(recordings.id, id),
-                    eq(recordings.userId, session.user.id),
-                ),
-            )
-            .limit(1);
+        // Atomic tombstone re-check + transcription upsert.
+        //
+        // The user may have deleted the recording while the (long-running)
+        // provider call was in flight. To prevent a delete that lands
+        // *between* our re-check and our upsert from being silently undone,
+        // we run both inside a single transaction that takes a row-level
+        // write lock (`FOR UPDATE`) on the recording. The DELETE handler's
+        // transaction acquires the same lock via its `UPDATE recordings`
+        // tombstone write, so the two transactions serialize: either we
+        // see `deletedAt` set and abort, or our upsert commits before
+        // DELETE runs and DELETE then cleans up our row inside its own tx.
+        // See PR #72.
+        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
+        try {
+            await db.transaction(async (tx) => {
+                const [stillActive] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, id),
+                            eq(recordings.userId, session.user.id),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
 
-        if (!stillActive || stillActive.deletedAt) {
-            return NextResponse.json(
-                { error: "Recording was deleted" },
-                { status: 410 },
-            );
-        }
+                if (!stillActive || stillActive.deletedAt) {
+                    throw RECORDING_TOMBSTONED;
+                }
 
-        // Save transcription
-        const [existingTranscription] = await db
-            .select()
-            .from(transcriptions)
-            .where(eq(transcriptions.recordingId, id))
-            .limit(1);
+                const [existingTranscription] = await tx
+                    .select()
+                    .from(transcriptions)
+                    .where(eq(transcriptions.recordingId, id))
+                    .limit(1);
 
-        if (existingTranscription) {
-            await db
-                .update(transcriptions)
-                .set({
-                    text: transcriptionText,
-                    detectedLanguage,
-                    transcriptionType: "server",
-                    provider: credentials.provider,
-                    model,
-                })
-                .where(eq(transcriptions.id, existingTranscription.id));
-        } else {
-            await db.insert(transcriptions).values({
-                recordingId: id,
-                userId: session.user.id,
-                text: transcriptionText,
-                detectedLanguage,
-                transcriptionType: "server",
-                provider: credentials.provider,
-                model,
+                if (existingTranscription) {
+                    await tx
+                        .update(transcriptions)
+                        .set({
+                            text: transcriptionText,
+                            detectedLanguage,
+                            transcriptionType: "server",
+                            provider: credentials.provider,
+                            model,
+                        })
+                        .where(eq(transcriptions.id, existingTranscription.id));
+                } else {
+                    await tx.insert(transcriptions).values({
+                        recordingId: id,
+                        userId: session.user.id,
+                        text: transcriptionText,
+                        detectedLanguage,
+                        transcriptionType: "server",
+                        provider: credentials.provider,
+                        model,
+                    });
+                }
             });
+        } catch (txError) {
+            if (txError === RECORDING_TOMBSTONED) {
+                return NextResponse.json(
+                    { error: "Recording was deleted" },
+                    { status: 410 },
+                );
+            }
+            throw txError;
         }
 
         return NextResponse.json({

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -135,6 +135,29 @@ export async function POST(
         const { text: transcriptionText, detectedLanguage } =
             parseTranscriptionResponse(transcription, responseFormat);
 
+        // Re-check tombstone status: the user may have deleted the
+        // recording while the (long-running) provider call was in flight.
+        // Without this guard we'd write a fresh transcription row for a row
+        // the DELETE handler has already cleaned up, leaving an orphan that
+        // exposes transcript text the user asked to remove. See PR #72.
+        const [stillActive] = await db
+            .select({ deletedAt: recordings.deletedAt })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, id),
+                    eq(recordings.userId, session.user.id),
+                ),
+            )
+            .limit(1);
+
+        if (!stillActive || stillActive.deletedAt) {
+            return NextResponse.json(
+                { error: "Recording was deleted" },
+                { status: 410 },
+            );
+        }
+
         // Save transcription
         const [existingTranscription] = await db
             .select()

--- a/src/app/api/recordings/route.ts
+++ b/src/app/api/recordings/route.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings } from "@/db/schema";
@@ -20,7 +20,12 @@ export async function GET(request: Request) {
         const userRecordings = await db
             .select()
             .from(recordings)
-            .where(eq(recordings.userId, session.user.id))
+            .where(
+                and(
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            )
             .orderBy(desc(recordings.startTime));
 
         return NextResponse.json({ recordings: userRecordings });

--- a/src/app/api/settings/storage/route.ts
+++ b/src/app/api/settings/storage/route.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings, storageConfig } from "@/db/schema";
@@ -31,7 +31,12 @@ export async function GET(request: Request) {
         const userRecordings = await db
             .select({ filesize: recordings.filesize })
             .from(recordings)
-            .where(eq(recordings.userId, session.user.id));
+            .where(
+                and(
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            );
 
         const totalSize = userRecordings.reduce(
             (sum, r) => sum + r.filesize,

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -8,6 +8,14 @@ import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import { TranscriptionPanel } from "@/components/dashboard/transcription-panel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
 import type { Recording } from "@/types/recording";
 
 interface Transcription {
@@ -27,6 +35,8 @@ export function RecordingWorkstation({
 }: RecordingWorkstationProps) {
     const router = useRouter();
     const [isTranscribing, setIsTranscribing] = useState(false);
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
 
     const handleTranscribe = useCallback(async () => {
         setIsTranscribing(true);
@@ -52,6 +62,29 @@ export function RecordingWorkstation({
         }
     }, [recording.id, router]);
 
+    const handleDelete = useCallback(async () => {
+        setIsDeleting(true);
+        try {
+            const response = await fetch(`/api/recordings/${recording.id}`, {
+                method: "DELETE",
+            });
+
+            if (response.ok) {
+                toast.success("Recording deleted");
+                setDeleteDialogOpen(false);
+                router.push("/dashboard");
+                router.refresh();
+            } else {
+                const error = await response.json().catch(() => ({}));
+                toast.error(error.error || "Failed to delete recording");
+                setIsDeleting(false);
+            }
+        } catch {
+            toast.error("Failed to delete recording");
+            setIsDeleting(false);
+        }
+    }, [recording.id, router]);
+
     return (
         <div className="bg-background">
             <div className="container mx-auto px-4 py-6 max-w-4xl">
@@ -72,6 +105,15 @@ export function RecordingWorkstation({
                             {new Date(recording.startTime).toLocaleString()}
                         </p>
                     </div>
+                    <Button
+                        onClick={() => setDeleteDialogOpen(true)}
+                        variant="outline"
+                        size="icon"
+                        aria-label="Delete recording"
+                        title="Delete recording"
+                    >
+                        <Trash2 className="w-4 h-4" />
+                    </Button>
                 </div>
 
                 {/* Content */}
@@ -138,6 +180,48 @@ export function RecordingWorkstation({
                     </Card>
                 </div>
             </div>
+
+            <Dialog
+                open={deleteDialogOpen}
+                onOpenChange={(open) => {
+                    if (!isDeleting) setDeleteDialogOpen(open);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete this recording?</DialogTitle>
+                        <DialogDescription>
+                            This permanently removes the audio file,
+                            transcription, and AI summary from OpenPlaud. The
+                            recording on your Plaud account is not affected, but
+                            it will not be re-synced to OpenPlaud.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDeleteDialogOpen(false)}
+                            disabled={isDeleting}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={handleDelete}
+                            disabled={isDeleting}
+                        >
+                            {isDeleting ? (
+                                <>
+                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    Deleting…
+                                </>
+                            ) : (
+                                "Delete recording"
+                            )}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/src/db/migrations/0016_volatile_xavin.sql
+++ b/src/db/migrations/0016_volatile_xavin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "recordings" ADD COLUMN "deleted_at" timestamp;

--- a/src/db/migrations/meta/0016_snapshot.json
+++ b/src/db/migrations/meta/0016_snapshot.json
@@ -1,0 +1,1378 @@
+{
+  "id": "a58d32c4-11bb-4479-9145-de40733b8cab",
+  "prevId": "0b235063-c327-4604-bf89-709c6ec01a5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_plaud_file_id_unique": {
+          "name": "recordings_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777644428223,
       "tag": "0015_glamorous_doomsday",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777711166961,
+      "tag": "0016_volatile_xavin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -151,6 +151,12 @@ export const recordings = pgTable(
         zonemins: integer("zonemins"),
         scene: integer("scene"),
         isTrash: boolean("is_trash").notNull().default(false),
+        // Soft-delete tombstone. Set when the user deletes a recording from
+        // OpenPlaud's UI. Sync skips tombstoned rows so re-syncing from Plaud
+        // does not resurrect deleted recordings. The audio file is hard-deleted
+        // from storage at delete time; this row is retained only as a marker
+        // keyed by plaudFileId. See issue #56.
+        deletedAt: timestamp("deleted_at"),
         createdAt: timestamp("created_at").notNull().defaultNow(),
         updatedAt: timestamp("updated_at").notNull().defaultNow(),
     },

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -101,6 +101,13 @@ async function processRecording(
             return { status: "skipped" };
         }
 
+        // Tombstone: user soft-deleted this recording in OpenPlaud's UI.
+        // Do not re-download or update — sync is keyed on plaudFileId, and
+        // the row is retained specifically to suppress resurrection. See #56.
+        if (existingRecording?.deletedAt) {
+            return { status: "skipped" };
+        }
+
         // Download the audio file
         const audioBuffer = await plaudClient.downloadRecording(
             plaudRecording.id,

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { OpenAI } from "openai";
 import { db } from "@/db";
 import {
@@ -29,6 +29,12 @@ export async function transcribeRecording(
                 and(
                     eq(recordings.id, recordingId),
                     eq(recordings.userId, userId),
+                    // Skip tombstoned recordings. Without this filter the
+                    // post-sync auto-transcribe path would happily upload the
+                    // audio for a recording the user just deleted, recreate
+                    // its transcription row, and (if syncTitleToPlaud is on)
+                    // even push a generated title back to Plaud. See PR #72.
+                    isNull(recordings.deletedAt),
                 ),
             )
             .limit(1);
@@ -109,6 +115,27 @@ export async function transcribeRecording(
 
         const { text: transcriptionText, detectedLanguage } =
             parseTranscriptionResponse(transcription, responseFormat);
+
+        // Re-check tombstone after the provider call. The user may have
+        // deleted the recording while we were waiting on the transcription
+        // API; abort before writing so we don't recreate child rows the
+        // DELETE handler has already cleaned up.
+        const [stillActive] = await db
+            .select({ deletedAt: recordings.deletedAt })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, recordingId),
+                    eq(recordings.userId, userId),
+                ),
+            )
+            .limit(1);
+        if (!stillActive || stillActive.deletedAt) {
+            return {
+                success: false,
+                error: "Recording was deleted before transcription finished",
+            };
+        }
 
         if (existingTranscription) {
             await db

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -11,6 +11,11 @@
  * These tests cover:
  *   1. The sync worker skips tombstoned rows (no download, no DB write).
  *   2. The sync worker still updates a non-tombstoned row when versions differ.
+ *   3. DELETE /api/recordings/[id] enforces userId scope (404 for other users).
+ *   4. DELETE deletes the storage object, child rows, and tombstones the
+ *      recording row — in that order — inside a single DB transaction.
+ *   5. DELETE refuses to tombstone when the storage provider fails for any
+ *      reason other than "already gone", so retries don't leak orphan blobs.
  */
 
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -28,6 +33,16 @@ vi.mock("@/db", () => ({
         select: vi.fn(),
         insert: vi.fn(),
         update: vi.fn(),
+        delete: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
     },
 }));
 
@@ -193,5 +208,172 @@ describe("Issue #56 — delete recording tombstone", () => {
         expect(result.newRecordings).toBe(0);
         expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
         expect(db.update).toHaveBeenCalled();
+    });
+});
+
+// -----------------------------------------------------------------------
+// DELETE /api/recordings/[id]
+// -----------------------------------------------------------------------
+
+import { DELETE as deleteRecording } from "@/app/api/recordings/[id]/route";
+import {
+    aiEnhancements,
+    recordings as recordingsTable,
+    transcriptions as transcriptionsTable,
+} from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { createUserStorageProvider as createStorage } from "@/lib/storage/factory";
+
+describe("DELETE /api/recordings/[id]", () => {
+    const userId = "user-123";
+    const recordingId = "rec-1";
+    const storagePath = "user-123/Recording-1.mp3";
+
+    const params = Promise.resolve({ id: recordingId });
+    const makeRequest = () =>
+        new Request(`http://localhost/api/recordings/${recordingId}`, {
+            method: "DELETE",
+        });
+
+    let txCalls: Array<{ table: string; op: "delete" | "update" }>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        txCalls = [];
+
+        (auth.api.getSession as unknown as Mock).mockResolvedValue({
+            user: { id: userId },
+        });
+
+        // db.transaction: invoke callback with a tx object whose .delete /
+        // .update calls are recorded by table-reference identity so we can
+        // assert both the operation order and the target table.
+        const tableName = (t: unknown): string =>
+            t === transcriptionsTable
+                ? "transcriptions"
+                : t === aiEnhancements
+                  ? "ai_enhancements"
+                  : t === recordingsTable
+                    ? "recordings"
+                    : "unknown";
+
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (tx: unknown) => Promise<void>) => {
+                const tx = {
+                    delete: vi.fn((table: unknown) => ({
+                        where: vi.fn().mockImplementation(() => {
+                            txCalls.push({
+                                table: tableName(table),
+                                op: "delete",
+                            });
+                            return Promise.resolve(undefined);
+                        }),
+                    })),
+                    update: vi.fn((table: unknown) => ({
+                        set: vi.fn().mockReturnValue({
+                            where: vi.fn().mockImplementation(() => {
+                                txCalls.push({
+                                    table: tableName(table),
+                                    op: "update",
+                                });
+                                return Promise.resolve(undefined);
+                            }),
+                        }),
+                    })),
+                };
+                await cb(tx);
+            },
+        );
+    });
+
+    const stubRecordingLookup = (rows: unknown[]) => {
+        (db.select as Mock).mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue(rows),
+                }),
+            }),
+        });
+    };
+
+    it("returns 404 when the recording is not owned by the caller", async () => {
+        stubRecordingLookup([]); // userId scope filter excluded the row
+
+        const res = await deleteRecording(makeRequest(), { params });
+        expect(res.status).toBe(404);
+        expect(createStorage).not.toHaveBeenCalled();
+        expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it("deletes storage, then child rows + tombstone in one tx", async () => {
+        const deleteFile = vi.fn().mockResolvedValue(undefined);
+        (createStorage as Mock).mockResolvedValue({
+            uploadFile: vi.fn(),
+            downloadFile: vi.fn(),
+            deleteFile,
+        });
+        stubRecordingLookup([
+            { id: recordingId, userId, storagePath, deletedAt: null },
+        ]);
+
+        const res = await deleteRecording(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(deleteFile).toHaveBeenCalledWith(storagePath);
+        // Storage delete must happen before the DB transaction opens.
+        expect(deleteFile.mock.invocationCallOrder[0]).toBeLessThan(
+            (db.transaction as Mock).mock.invocationCallOrder[0],
+        );
+        // All three writes ran in the same transaction…
+        expect(txCalls).toHaveLength(3);
+        // …in this order: transcriptions → ai_enhancements → recordings.
+        expect(txCalls.map((c) => `${c.op}:${c.table}`)).toEqual([
+            "delete:transcriptions",
+            "delete:ai_enhancements",
+            "update:recordings",
+        ]);
+    });
+
+    it("refuses to tombstone when storage delete fails for a non-not-found reason", async () => {
+        const deleteFile = vi
+            .fn()
+            .mockRejectedValue(new Error("S3 internal error 503"));
+        (createStorage as Mock).mockResolvedValue({
+            uploadFile: vi.fn(),
+            downloadFile: vi.fn(),
+            deleteFile,
+        });
+        stubRecordingLookup([
+            { id: recordingId, userId, storagePath, deletedAt: null },
+        ]);
+
+        const res = await deleteRecording(makeRequest(), { params });
+        expect(res.status).toBe(500);
+        // No tombstone, no orphan: retry is safe.
+        expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it("still tombstones when storage reports the object is already gone", async () => {
+        const deleteFile = vi
+            .fn()
+            .mockRejectedValue(
+                new Error("Failed to delete file from local storage: ENOENT"),
+            );
+        (createStorage as Mock).mockResolvedValue({
+            uploadFile: vi.fn(),
+            downloadFile: vi.fn(),
+            deleteFile,
+        });
+        stubRecordingLookup([
+            { id: recordingId, userId, storagePath, deletedAt: null },
+        ]);
+
+        const res = await deleteRecording(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(db.transaction).toHaveBeenCalledTimes(1);
+        expect(txCalls.map((c) => `${c.op}:${c.table}`)).toEqual([
+            "delete:transcriptions",
+            "delete:ai_enhancements",
+            "update:recordings",
+        ]);
     });
 });

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression test for issue #56:
+ *   "Request for a delete recording option in the UI"
+ *
+ * Sync is keyed on `recordings.plaudFileId` (Plaud's file id). Hard-deleting
+ * a row would cause the next sync to treat the recording as new and
+ * re-download it. To make UI delete persistent across syncs, the row is
+ * retained as a tombstone via `recordings.deletedAt`, the audio file is
+ * removed from storage, and the transcription / AI rows are deleted.
+ *
+ * These tests cover:
+ *   1. The sync worker skips tombstoned rows (no download, no DB write).
+ *   2. The sync worker still updates a non-tombstoned row when versions differ.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        uploadFile: vi.fn().mockResolvedValue(undefined),
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("audio-data")),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+    }),
+}));
+
+vi.mock("@/lib/notifications/bark", () => ({
+    sendNewRecordingBarkNotification: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/notifications/email", () => ({
+    sendNewRecordingEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/transcription/transcribe-recording", () => ({
+    transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+import { db } from "@/db";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
+import { createUserStorageProvider } from "@/lib/storage/factory";
+import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
+
+describe("Issue #56 — delete recording tombstone", () => {
+    const mockUserId = "user-123";
+
+    const mockPlaudRecording = {
+        id: "plaud-1",
+        filename: "Recording 1.mp3",
+        duration: 60000,
+        start_time: "2024-01-01T10:00:00Z",
+        end_time: "2024-01-01T10:01:00Z",
+        filesize: 1024000,
+        file_md5: "abc123",
+        serial_number: "SN123",
+        // Bumped version forces sync to re-evaluate the existing row.
+        version_ms: 9999,
+        timezone: 0,
+        zonemins: 0,
+        scene: 0,
+        is_trash: false,
+    };
+
+    const mockConnection = {
+        id: "conn-1",
+        userId: mockUserId,
+        bearerToken: "encrypted-token",
+    };
+
+    const buildSelectChain = (results: unknown[][]) => {
+        const chain = (db.select as Mock).mockReset();
+        for (const result of results) {
+            chain.mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue(result),
+                    }),
+                }),
+            });
+        }
+    };
+
+    let storageMock: {
+        uploadFile: Mock;
+        downloadFile: Mock;
+        deleteFile: Mock;
+    };
+    let plaudClientMock: {
+        getRecordings: Mock;
+        downloadRecording: Mock;
+    };
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        storageMock = (await (createUserStorageProvider as Mock)(
+            mockUserId,
+        )) as typeof storageMock;
+        storageMock.uploadFile.mockClear();
+        storageMock.downloadFile.mockClear();
+        storageMock.deleteFile.mockClear();
+
+        plaudClientMock = {
+            getRecordings: vi.fn().mockResolvedValue({
+                data_file_list: [mockPlaudRecording],
+            }),
+            downloadRecording: vi.fn().mockResolvedValue(Buffer.from("audio")),
+        };
+        (createPlaudClient as Mock).mockResolvedValue(plaudClientMock);
+
+        (db.update as Mock).mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(undefined),
+            }),
+        });
+        (db.insert as Mock).mockReturnValue({
+            values: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: "new-rec" }]),
+            }),
+        });
+    });
+
+    it("skips tombstoned recordings without re-downloading", async () => {
+        const tombstoned = {
+            id: "local-rec-1",
+            plaudFileId: "plaud-1",
+            // Older version than the incoming Plaud record — without the
+            // tombstone check, sync would treat this as an update.
+            plaudVersion: "1000",
+            deletedAt: new Date("2024-02-01T00:00:00Z"),
+        };
+
+        buildSelectChain([
+            [mockConnection], // load Plaud connection
+            [{ id: "settings-1" }], // user settings
+            [{ email: "test@example.com" }], // user email lookup
+            [tombstoned], // existingRecording lookup in processRecording
+        ]);
+
+        const result = await syncRecordingsForUser(mockUserId);
+
+        expect(result.newRecordings).toBe(0);
+        expect(result.updatedRecordings).toBe(0);
+        expect(result.errors).toEqual([]);
+        // No audio download, no upload, no recording row insert for the
+        // tombstoned row. (db.update is still invoked once at the end of
+        // sync to bump plaudConnections.lastSync — we only care that the
+        // recordings table is untouched, which is reflected by the
+        // updatedRecordings counter staying at 0.)
+        expect(storageMock.uploadFile).not.toHaveBeenCalled();
+        expect(plaudClientMock.downloadRecording).not.toHaveBeenCalled();
+        expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it("still updates a non-tombstoned recording when versions differ", async () => {
+        const existing = {
+            id: "local-rec-1",
+            plaudFileId: "plaud-1",
+            plaudVersion: "1000",
+            deletedAt: null,
+        };
+
+        buildSelectChain([
+            [mockConnection],
+            [{ id: "settings-1" }],
+            [{ email: "test@example.com" }],
+            [existing],
+            // uniqueStorageKey lookup — empty so the candidate name is unique.
+            [],
+        ]);
+
+        const result = await syncRecordingsForUser(mockUserId);
+
+        expect(result.updatedRecordings).toBe(1);
+        expect(result.newRecordings).toBe(0);
+        expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
+        expect(db.update).toHaveBeenCalled();
+    });
+});

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -286,23 +286,83 @@ describe("DELETE /api/recordings/[id]", () => {
         );
     });
 
+    /**
+     * Capture the expression handed to `.where(...)` so individual tests
+     * can assert that the userId scope filter is actually present. Returns
+     * a `getWhereExpr()` accessor that reads the most-recent call argument.
+     */
     const stubRecordingLookup = (rows: unknown[]) => {
+        const whereSpy = vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(rows),
+        });
         (db.select as Mock).mockReturnValueOnce({
             from: vi.fn().mockReturnValue({
-                where: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue(rows),
-                }),
+                where: whereSpy,
             }),
         });
+        return {
+            getWhereExpr: () => whereSpy.mock.calls.at(-1)?.[0],
+        };
     };
 
-    it("returns 404 when the recording is not owned by the caller", async () => {
-        stubRecordingLookup([]); // userId scope filter excluded the row
+    /**
+     * Walk a Drizzle SQL/expression tree looking for a reference to the
+     * given column object. Drizzle composes `and(eq(a, b), ...)` into
+     * nested objects holding `queryChunks`, `left`, `right`, etc.; we
+     * recurse over the common shapes. Returns true iff `col` appears
+     * anywhere in the tree.
+     */
+    const exprReferencesColumn = (
+        expr: unknown,
+        col: unknown,
+        seen = new Set<unknown>(),
+    ): boolean => {
+        if (expr == null || typeof expr !== "object") return false;
+        if (expr === col) return true;
+        if (seen.has(expr)) return false;
+        seen.add(expr);
+        for (const key of [
+            "queryChunks",
+            "sql",
+            "left",
+            "right",
+            "value",
+            "args",
+            "chunks",
+            "expr",
+        ]) {
+            const v = (expr as Record<string, unknown>)[key];
+            if (Array.isArray(v)) {
+                if (v.some((x) => exprReferencesColumn(x, col, seen)))
+                    return true;
+            } else if (exprReferencesColumn(v, col, seen)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    it("scopes the recording lookup by userId (and returns 404 when no row matches)", async () => {
+        const lookup = stubRecordingLookup([]);
 
         const res = await deleteRecording(makeRequest(), { params });
         expect(res.status).toBe(404);
         expect(createStorage).not.toHaveBeenCalled();
         expect(db.transaction).not.toHaveBeenCalled();
+
+        // Critical: confirm the WHERE clause references `recordings.userId`.
+        // Without this assertion the test would still pass if the handler
+        // dropped the userId scope filter, since the mock returns [] for
+        // any query.
+        const whereExpr = lookup.getWhereExpr();
+        expect(whereExpr).toBeDefined();
+        expect(exprReferencesColumn(whereExpr, recordingsTable.userId)).toBe(
+            true,
+        );
+        expect(exprReferencesColumn(whereExpr, recordingsTable.id)).toBe(true);
+        expect(exprReferencesColumn(whereExpr, recordingsTable.deletedAt)).toBe(
+            true,
+        );
     });
 
     it("deletes storage, then child rows + tombstone in one tx", async () => {


### PR DESCRIPTION
## Description

Adds a delete recording option in the UI. The recording detail page now exposes a Trash button with a confirm dialog; confirming removes the audio file from storage, deletes the transcription and AI-enhancement rows, and soft-deletes the recording row via a new `deletedAt` tombstone.

The tombstone is required because sync is keyed on `recordings.plaudFileId` — a hard-delete would let the next pull from Plaud re-download the file. With the tombstone, `processRecording` skips the row on subsequent syncs and every user-facing read site filters `isNull(deletedAt)`.

OpenPlaud-side delete only. The recording on the user's Plaud account is not touched.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #56

## Changes Made

- Schema: nullable `recordings.deletedAt` + generated migration `0016_volatile_xavin.sql` (no hand-written SQL).
- New `DELETE /api/recordings/[id]`: auth + userId scope, best-effort `storage.deleteFile`, deletes `transcriptions` + `aiEnhancements` rows, sets `deletedAt`.
- Filter `isNull(deletedAt)` in all recording read sites: list endpoint, detail GET, audio stream, transcribe, summary, backup, export, dashboard page, detail page, settings storage usage.
- `processRecording` short-circuits to `skipped` when `existingRecording.deletedAt` is set, so re-pulls from Plaud do not resurrect deleted rows.
- UI: `Trash2` button in `RecordingWorkstation` header opens a confirm `Dialog`; on success toast + `router.push("/dashboard")` + `router.refresh()`.

## Testing

Commands run (full output, no piping):

- `pnpm db:generate` — clean, single `ALTER TABLE` migration emitted.
- `pnpm format-and-lint:fix` — clean.
- `pnpm type-check` — clean.
- `pnpm test` — 54 passed / 3 skipped (matches baseline). New regression suite `src/tests/regressions/56-delete-recording.test.ts` covers:
  - Tombstoned row is skipped: no audio download, no upload, no `recordings` insert.
  - Non-tombstoned row with newer `version_ms` still updates normally.

### Test Steps

1. Run a Plaud sync to populate at least one recording.
2. Open the recording detail page and click the trash icon.
3. Confirm the dialog. Toast appears, redirected to dashboard, recording is gone from the list.
4. Run sync again. The deleted recording does not reappear.
5. Verify the audio file is removed from storage (local filesystem or S3 bucket).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

- [x] I have generated a new migration (`pnpm db:generate`)
- [x] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

Migration is additive: `ALTER TABLE "recordings" ADD COLUMN "deleted_at" timestamp;` — nullable, no default, safe to apply on existing data. Rollback is `ALTER TABLE "recordings" DROP COLUMN "deleted_at";` (only safe before any rows are tombstoned, otherwise tombstoned recordings will reappear on the next sync).

## Breaking Changes

None. Schema change is additive; new column is nullable. No env var or `docker-compose.yml` changes.

## Additional Notes

- Intentionally OpenPlaud-side only. Plaud is the upstream source of truth; we do not call any Plaud trash endpoint. If a user wants the recording gone from Plaud too, they delete it in the Plaud app and our next sync update will reflect the new `is_trash` state on the row (independent of this tombstone).
- Storage delete is best-effort and logged — if the file is already gone, the DB tombstone still proceeds so state stays consistent.
- No bulk delete and no undelete UI in v1; both are easy follow-ups but not requested in the issue.

## For Reviewers

- `processRecording` tombstone short-circuit in `src/lib/sync/sync-recordings.ts` — placed after the version-equality skip and before any download.
- The audit of read sites in `src/app/api/**` and the two server pages — confirm nothing reads recordings without an `isNull(deletedAt)` filter.
- DELETE route ordering in `src/app/api/recordings/[id]/route.ts`: scope check → storage delete (best-effort) → child rows → tombstone update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a delete action to the recording page that removes the audio and related transcription/summary rows, then soft-deletes the recording to prevent sync from resurrecting it. Fixes #56.

- **New Features**
  - UI: Trash button with confirm; on success shows a toast, redirects to dashboard, and refreshes.
  - API: `DELETE /api/recordings/[id]` (user-scoped) removes the storage file, deletes `transcriptions`/`aiEnhancements`, and sets `deletedAt`.
  - All reads filter `deletedAt is null`; sync skips tombstoned rows. OpenPlaud-side only; Plaud is not touched.

- **Bug Fixes**
  - DELETE flow: deletes storage first; treats not-found as success; other storage errors return 500; child deletes + tombstone run in one DB transaction.
  - Transcribe/Summary: tombstone re-check + upsert run in a single DB transaction with `SELECT ... FOR UPDATE`; return 410 if deleted mid-flight. Auto-transcribe filters and re-checks before writing.
  - Tests: add coverage for userId scoping, storage→transaction ordering, operation order, and error handling.

<sup>Written for commit 863b6d0e9faa6b9fb4d428830044f58b78f6c59d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

