### PR TITLE
feat(plaud): add Google/Apple connect paths via paste-token + Connector extension (fixes #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- New connect screen with three methods: **Sign in with Plaud** (browser-extension bridge — the easy path), **Email code** (existing OTP flow), and **Paste token** (advanced fallback). Targets accounts created via Google or Apple sign-in on Plaud, where the OTP flow silently signs users into a separate empty shadow account and sync returns zero recordings ([#65](https://github.com/openplaud/openplaud/issues/65)).
+- Companion browser extension [openplaud/connector](https://github.com/openplaud/connector) (AGPL-3.0) detected by the connect screen via `window.__openplaudConnector`. Lets users sign in to Plaud the way they normally do — Google, Apple, or email/password — with no copy-pasting. The extension hands the resulting access token back to OpenPlaud via the new `/api/plaud/auth/connect-token` endpoint, which encrypts it (AES-256-GCM) and persists alongside any existing OTP-flow connections.
+
 ## [0.2.0] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ Your verification code is forwarded directly to Plaud's servers and **never stor
 
 > 🔓 **Open Source**: Every line that handles your credentials is available for inspection — [send-code route](src/app/api/plaud/auth/send-code/route.ts) · [verify route](src/app/api/plaud/auth/verify/route.ts) · [encryption](src/lib/encryption.ts)
 
+#### Signed up to Plaud with Google or Apple?
+
+The email-code flow above signs you into a Plaud account keyed off the *email-password* identity. If you originally created your Plaud account by tapping **Continue with Google** or **Continue with Apple**, that's a different identity on Plaud's side — even when both share the same email address. The email-code flow will look like it succeeded but sync will return zero recordings ([#65](https://github.com/openplaud/openplaud/issues/65)).
+
+Real Sign in with Google / Apple inside OpenPlaud is structurally blocked by Google's authorized-origins policy on Plaud's OAuth client. Two workarounds:
+
+**Easy path — OpenPlaud Connector browser extension.** Install [openplaud/connector](https://github.com/openplaud/connector) (AGPL-3.0) and the connect screen surfaces a **Sign in with Plaud** button. You sign in to web.plaud.ai the way you normally do; the extension forwards the resulting access token back to OpenPlaud. No copy-pasting, no devtools.
+
+**Manual fallback — paste the token yourself.** If you can't or won't install the extension:
+
+1. Open [web.plaud.ai](https://web.plaud.ai) in another tab and sign in with Google or Apple as you normally would.
+2. Open browser devtools (F12 / Cmd+Option+I) → **Network** tab. Refresh the page.
+3. Click any request to a host starting with `api.plaud.ai`, `api-euc1.plaud.ai`, or `api-apse1.plaud.ai`.
+4. Under **Headers → Request Headers**, find `Authorization`. Copy everything after `Bearer ` (the long `eyJ…` string).
+5. In OpenPlaud, switch to the **Paste token** tab, pick the matching region (e.g. EU if the request host was `api-euc1.plaud.ai`), and paste the token.
+
+In both cases the token is encrypted at rest with AES-256-GCM.
+
 ### 💾 Storage Options
 
 #### 📁 Local Filesystem (Default)

--- a/src/app/api/plaud/auth/connect-token/route.ts
+++ b/src/app/api/plaud/auth/connect-token/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import {
     decodeAccessTokenExpiry,
     fetchPlaudUserMeEmail,
+    isUserActionablePlaudError,
 } from "@/lib/plaud/auth";
 import { DEFAULT_PLAUD_API_BASE } from "@/lib/plaud/client";
 import { persistPlaudConnection } from "@/lib/plaud/persist-connection";
@@ -19,7 +20,7 @@ import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
  * shadow account and your real recordings never appear.
  *
  * The user pastes the bearer token they grab from a logged-in `web.plaud.ai`
- * session (devtools \u2192 Network \u2192 Authorization header on any /api*.plaud.ai
+ * session (devtools → Network → Authorization header on any /api*.plaud.ai
  * request, minus the "Bearer " prefix). We decode `exp` for a UX hint, run
  * the same workspace + /device/list validation as the OTP path, and store.
  *
@@ -71,7 +72,7 @@ export async function POST(request: Request) {
         }
 
         // UX-only `exp` check. We don't trust the decoded payload for any
-        // security decision \u2014 Plaud is the verifier on /device/list below.
+        // security decision — Plaud is the verifier on /device/list below.
         // If `exp` is in the past we still bail, since /device/list will
         // 401 and the resulting message is less useful than this one.
         const exp = decodeAccessTokenExpiry(accessToken);
@@ -100,14 +101,17 @@ export async function POST(request: Request) {
             );
         }
 
-        // Best-effort email enrichment. Failure is non-fatal \u2014
+        // Best-effort email enrichment. Failure is non-fatal —
         // plaud_connections.plaud_email is nullable.
         const plaudEmail = await fetchPlaudUserMeEmail(accessToken, apiBaseRaw);
 
         const source =
             typeof body.source === "string" ? body.source : "unknown";
+        // Deliberately omit `plaudEmail` from the log line — it's PII and
+        // not needed for diagnosing connect failures (source + apiBase
+        // already disambiguate the path).
         console.log(
-            `[plaud/connect-token] persisting connection (source=${source}, apiBase=${apiBaseRaw}, email=${plaudEmail ?? "unknown"})`,
+            `[plaud/connect-token] persisting connection (source=${source}, apiBase=${apiBaseRaw})`,
         );
 
         const { devices } = await persistPlaudConnection({
@@ -125,8 +129,7 @@ export async function POST(request: Request) {
         console.error("Error connecting Plaud token:", error);
         if (
             error instanceof Error &&
-            (error.message.startsWith("Plaud API error") ||
-                error.message === "Invalid API base")
+            isUserActionablePlaudError(error.message)
         ) {
             return NextResponse.json({ error: error.message }, { status: 400 });
         }

--- a/src/app/api/plaud/auth/connect-token/route.ts
+++ b/src/app/api/plaud/auth/connect-token/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+    decodeAccessTokenExpiry,
+    fetchPlaudUserMeEmail,
+} from "@/lib/plaud/auth";
+import { DEFAULT_PLAUD_API_BASE } from "@/lib/plaud/client";
+import { persistPlaudConnection } from "@/lib/plaud/persist-connection";
+import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
+
+/**
+ * POST /api/plaud/auth/connect-token
+ *
+ * Connect a Plaud account by submitting an existing access token, bypassing
+ * the OTP flow. This exists because Plaud's OTP login signs you into an
+ * email-only account that is *separate* from any Google/Apple-linked account
+ * sharing the same email address (issue #65) -- if you originally signed up
+ * for Plaud via Google or Apple, the OTP flow returns a token for an empty
+ * shadow account and your real recordings never appear.
+ *
+ * The user pastes the bearer token they grab from a logged-in `web.plaud.ai`
+ * session (devtools \u2192 Network \u2192 Authorization header on any /api*.plaud.ai
+ * request, minus the "Bearer " prefix). We decode `exp` for a UX hint, run
+ * the same workspace + /device/list validation as the OTP path, and store.
+ *
+ * Source: https://github.com/openplaud/openplaud/blob/main/src/app/api/plaud/auth/connect-token/route.ts
+ */
+export async function POST(request: Request) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session?.user) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        const body = (await request.json().catch(() => null)) as {
+            accessToken?: unknown;
+            apiBase?: unknown;
+            source?: unknown;
+        } | null;
+
+        if (!body || typeof body.accessToken !== "string") {
+            return NextResponse.json(
+                { error: "accessToken is required" },
+                { status: 400 },
+            );
+        }
+
+        const accessToken = body.accessToken.trim().replace(/^Bearer\s+/i, "");
+        if (!accessToken) {
+            return NextResponse.json(
+                { error: "accessToken is required" },
+                { status: 400 },
+            );
+        }
+
+        // Cheap shape check: Plaud user tokens are JWTs (3 base64url segments).
+        // Catches accidentally-pasted nonsense before we round-trip Plaud.
+        if (accessToken.split(".").length !== 3) {
+            return NextResponse.json(
+                {
+                    error: "That doesn't look like a Plaud access token. Copy the value of the Authorization header on a request to api*.plaud.ai (without the leading 'Bearer ').",
+                },
+                { status: 400 },
+            );
+        }
+
+        // UX-only `exp` check. We don't trust the decoded payload for any
+        // security decision \u2014 Plaud is the verifier on /device/list below.
+        // If `exp` is in the past we still bail, since /device/list will
+        // 401 and the resulting message is less useful than this one.
+        const exp = decodeAccessTokenExpiry(accessToken);
+        if (exp && exp.getTime() < Date.now()) {
+            return NextResponse.json(
+                {
+                    error: "This Plaud access token has already expired. Sign in to web.plaud.ai again and copy a fresh one.",
+                },
+                { status: 400 },
+            );
+        }
+
+        // SSRF guard: apiBase is user-supplied. Restrict to plaud.ai hosts.
+        // Default to global if the client didn't pick a region; the paste
+        // flow has no -302 redirect path so the user picks via a region
+        // selector in the UI.
+        const apiBaseRaw =
+            typeof body.apiBase === "string" && body.apiBase.trim().length > 0
+                ? body.apiBase.trim().replace(/\/+$/, "")
+                : DEFAULT_PLAUD_API_BASE;
+
+        if (!isValidPlaudApiUrl(apiBaseRaw)) {
+            return NextResponse.json(
+                { error: "Invalid API base" },
+                { status: 400 },
+            );
+        }
+
+        // Best-effort email enrichment. Failure is non-fatal \u2014
+        // plaud_connections.plaud_email is nullable.
+        const plaudEmail = await fetchPlaudUserMeEmail(accessToken, apiBaseRaw);
+
+        const source =
+            typeof body.source === "string" ? body.source : "unknown";
+        console.log(
+            `[plaud/connect-token] persisting connection (source=${source}, apiBase=${apiBaseRaw}, email=${plaudEmail ?? "unknown"})`,
+        );
+
+        const { devices } = await persistPlaudConnection({
+            userId: session.user.id,
+            accessToken,
+            apiBase: apiBaseRaw,
+            plaudEmail,
+        });
+
+        return NextResponse.json({
+            success: true,
+            devices,
+        });
+    } catch (error) {
+        console.error("Error connecting Plaud token:", error);
+        if (
+            error instanceof Error &&
+            (error.message.startsWith("Plaud API error") ||
+                error.message === "Invalid API base")
+        ) {
+            return NextResponse.json({ error: error.message }, { status: 400 });
+        }
+        return NextResponse.json(
+            { error: "Failed to connect Plaud account" },
+            { status: 500 },
+        );
+    }
+}

--- a/src/app/api/plaud/auth/verify/route.ts
+++ b/src/app/api/plaud/auth/verify/route.ts
@@ -1,16 +1,8 @@
-import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { db } from "@/db";
-import { plaudConnections, plaudDevices } from "@/db/schema";
 import { auth } from "@/lib/auth";
-import { encrypt } from "@/lib/encryption";
 import { plaudVerifyOtp } from "@/lib/plaud/auth";
-import { PlaudClient } from "@/lib/plaud/client";
+import { persistPlaudConnection } from "@/lib/plaud/persist-connection";
 import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
-import {
-    listPlaudWorkspaces,
-    pickPersonalWorkspaceId,
-} from "@/lib/plaud/workspace";
 
 /**
  * POST /api/plaud/auth/verify
@@ -68,124 +60,19 @@ export async function POST(request: Request) {
         // Verify OTP with Plaud → get the (long-lived) user token (UT)
         const { accessToken } = await plaudVerifyOtp(code, otpToken, apiBase);
 
-        // Discover the personal workspace ID up front so we can persist it
-        // alongside the connection. We deliberately don't mint a WT here —
-        // PlaudClient mints lazily on the listDevices() call below, which
-        // both validates end-to-end and gives us exactly one WT mint per
-        // verify (vs. minting once here and again inside the client).
-        let resolvedWorkspaceId: string | null = null;
-        try {
-            const list = await listPlaudWorkspaces(accessToken, apiBase);
-            resolvedWorkspaceId = pickPersonalWorkspaceId(list);
-        } catch (err) {
-            // Don't fail the whole connect — fall through and let the client
-            // fall back to the UT (preserves behavior for any server that
-            // doesn't expose the workspace endpoints). Logged for diagnosis.
-            console.warn(
-                "[plaud/verify] workspace discovery failed:",
-                err instanceof Error ? err.message : err,
-            );
-        }
-
-        // Validate the token works against a real recording endpoint. With
-        // resolvedWorkspaceId in hand the client mints a WT internally on
-        // first use; without it the client falls back to the UT.
-        const client = new PlaudClient(
+        // Hand off to the shared persistence path: workspace discovery,
+        // end-to-end /device/list validation, encrypted upsert, device sync.
+        // Same gauntlet the paste-token connect flow runs through.
+        const { devices } = await persistPlaudConnection({
+            userId: session.user.id,
             accessToken,
             apiBase,
-            resolvedWorkspaceId,
-        );
-
-        let deviceList: Awaited<ReturnType<typeof client.listDevices>>;
-        try {
-            deviceList = await client.listDevices();
-        } catch (err) {
-            console.warn(
-                "[plaud/verify] device list validation failed:",
-                err instanceof Error ? err.message : err,
-            );
-            return NextResponse.json(
-                { error: "Login succeeded but token validation failed" },
-                { status: 400 },
-            );
-        }
-
-        const encryptedAccessToken = encrypt(accessToken);
-
-        // Upsert connection
-        const [existingConnection] = await db
-            .select()
-            .from(plaudConnections)
-            .where(eq(plaudConnections.userId, session.user.id))
-            .limit(1);
-
-        if (existingConnection) {
-            // Always re-scope by userId on UPDATE/DELETE of user-owned rows
-            // (defense-in-depth alongside the userId-scoped lookup above).
-            await db
-                .update(plaudConnections)
-                .set({
-                    bearerToken: encryptedAccessToken,
-                    apiBase,
-                    plaudEmail,
-                    workspaceId: resolvedWorkspaceId,
-                    updatedAt: new Date(),
-                })
-                .where(
-                    and(
-                        eq(plaudConnections.id, existingConnection.id),
-                        eq(plaudConnections.userId, session.user.id),
-                    ),
-                );
-        } else {
-            await db.insert(plaudConnections).values({
-                userId: session.user.id,
-                bearerToken: encryptedAccessToken,
-                apiBase,
-                plaudEmail,
-                workspaceId: resolvedWorkspaceId,
-            });
-        }
-
-        // Upsert devices — always scope the lookup by (userId, serialNumber)
-        // so we never touch another user's device row (the schema has a
-        // unique constraint on this pair).
-        for (const device of deviceList.data_devices) {
-            const [existingDevice] = await db
-                .select()
-                .from(plaudDevices)
-                .where(
-                    and(
-                        eq(plaudDevices.userId, session.user.id),
-                        eq(plaudDevices.serialNumber, device.sn),
-                    ),
-                )
-                .limit(1);
-
-            if (existingDevice) {
-                await db
-                    .update(plaudDevices)
-                    .set({
-                        name: device.name,
-                        model: device.model,
-                        versionNumber: device.version_number,
-                        updatedAt: new Date(),
-                    })
-                    .where(eq(plaudDevices.id, existingDevice.id));
-            } else {
-                await db.insert(plaudDevices).values({
-                    userId: session.user.id,
-                    serialNumber: device.sn,
-                    name: device.name,
-                    model: device.model,
-                    versionNumber: device.version_number,
-                });
-            }
-        }
+            plaudEmail,
+        });
 
         return NextResponse.json({
             success: true,
-            devices: deviceList.data_devices,
+            devices,
         });
     } catch (error) {
         console.error("Error verifying Plaud OTP:", error);

--- a/src/app/api/plaud/auth/verify/route.ts
+++ b/src/app/api/plaud/auth/verify/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
-import { plaudVerifyOtp } from "@/lib/plaud/auth";
+import { isUserActionablePlaudError, plaudVerifyOtp } from "@/lib/plaud/auth";
 import { persistPlaudConnection } from "@/lib/plaud/persist-connection";
 import { isValidPlaudApiUrl } from "@/lib/plaud/servers";
 
@@ -77,12 +77,15 @@ export async function POST(request: Request) {
     } catch (error) {
         console.error("Error verifying Plaud OTP:", error);
         // User-actionable errors (invalid code, expired OTP, rate-limited,
-        // bad API base) pass through unchanged and return 400. Anything
-        // else (DB errors, network blowups) is treated as an internal bug
-        // — generic message, 500 status — so we don't leak implementation
-        // details and so clients can distinguish "user's fault" from
-        // "our fault".
-        if (error instanceof Error && isUserFacingPlaudError(error.message)) {
+        // bad API base — i.e. HTTP 4xx) pass through unchanged and return
+        // 400. Anything else (5xx from Plaud after retries, DB errors,
+        // network blowups) is treated as an internal bug — generic
+        // message, 500 status — so we don't mislead users with "fix your
+        // token" advice when Plaud is the one that's broken.
+        if (
+            error instanceof Error &&
+            isUserActionablePlaudError(error.message)
+        ) {
             return NextResponse.json({ error: error.message }, { status: 400 });
         }
         return NextResponse.json(
@@ -90,14 +93,4 @@ export async function POST(request: Request) {
             { status: 500 },
         );
     }
-}
-
-/**
- * User-actionable errors we're willing to surface verbatim:
- * - `Plaud API error: ...` thrown by PlaudClient.request and by the Plaud
- *   auth helpers (plaudVerifyOtp etc).
- * - `Invalid API base` thrown by our own SSRF guard above.
- */
-function isUserFacingPlaudError(msg: string): boolean {
-    return msg.startsWith("Plaud API error") || msg === "Invalid API base";
 }

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -9,7 +9,7 @@ import {
     Sparkles,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
     Dialog,
@@ -18,10 +18,9 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/onboarding-dialog-base";
+import { PlaudConnectTabs } from "@/components/plaud-connect-tabs";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 
 type OnboardingStep = "welcome" | "plaud" | "ai-provider" | "complete";
 
@@ -38,22 +37,8 @@ export function OnboardingDialog({
 }: OnboardingDialogProps) {
     const router = useRouter();
     const [step, setStep] = useState<OnboardingStep>("welcome");
-    const [plaudEmail, setPlaudEmail] = useState("");
-    const [otpCode, setOtpCode] = useState("");
-    const [otpToken, setOtpToken] = useState("");
-    const [plaudApiBase, setPlaudApiBase] = useState("");
-    const [plaudStep, setPlaudStep] = useState<"email" | "code">("email");
-    const [isLoading, setIsLoading] = useState(false);
-    const [lastSentAt, setLastSentAt] = useState(0);
     const [hasPlaudConnection, setHasPlaudConnection] = useState(false);
     const [hasAiProvider, setHasAiProvider] = useState(false);
-
-    const regionLabel = useCallback((base: string) => {
-        if (base.includes("euc1")) return "EU (Frankfurt)";
-        if (base.includes("apse1")) return "Asia Pacific (Singapore)";
-        if (base.includes("api.plaud.ai")) return "Global";
-        return base;
-    }, []);
 
     useEffect(() => {
         if (open && step === "plaud") {
@@ -84,91 +69,10 @@ export function OnboardingDialog({
     useEffect(() => {
         if (!open) {
             setStep("welcome");
-            setPlaudEmail("");
-            setOtpCode("");
-            setOtpToken("");
-            setPlaudApiBase("");
-            setPlaudStep("email");
-            setIsLoading(false);
-            setLastSentAt(0);
             setHasPlaudConnection(false);
             setHasAiProvider(false);
         }
     }, [open]);
-
-    const handleSendCode = async () => {
-        const trimmed = plaudEmail.trim();
-        if (!trimmed) {
-            toast.error("Please enter your Plaud email");
-            return;
-        }
-
-        const now = Date.now();
-        const COOLDOWN_MS = 30_000;
-        if (now - lastSentAt < COOLDOWN_MS) {
-            const secsLeft = Math.ceil(
-                (COOLDOWN_MS - (now - lastSentAt)) / 1000,
-            );
-            toast.error(`Please wait ${secsLeft}s before resending`);
-            return;
-        }
-
-        setIsLoading(true);
-        try {
-            const res = await fetch("/api/plaud/auth/send-code", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email: trimmed }),
-            });
-            const data = await res.json();
-            if (!res.ok) throw new Error(data.error || "Failed to send code");
-
-            setOtpToken(data.otpToken);
-            setPlaudApiBase(data.apiBase);
-            setLastSentAt(Date.now());
-            setPlaudStep("code");
-            toast.success("Verification code sent — check your email");
-        } catch (error) {
-            toast.error(
-                error instanceof Error ? error.message : "Failed to send code",
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const handleVerifyCode = async () => {
-        const trimmed = otpCode.trim();
-        if (!trimmed) {
-            toast.error("Please enter the verification code");
-            return;
-        }
-
-        setIsLoading(true);
-        try {
-            const res = await fetch("/api/plaud/auth/verify", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    code: trimmed,
-                    otpToken,
-                    apiBase: plaudApiBase,
-                    email: plaudEmail,
-                }),
-            });
-            const data = await res.json();
-            if (!res.ok) throw new Error(data.error || "Verification failed");
-
-            toast.success("Plaud account connected");
-            setHasPlaudConnection(true);
-        } catch (error) {
-            toast.error(
-                error instanceof Error ? error.message : "Verification failed",
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
 
     const handleSkipPlaud = () => {
         setStep("ai-provider");
@@ -350,14 +254,9 @@ export function OnboardingDialog({
                                             <Button
                                                 variant="outline"
                                                 size="sm"
-                                                onClick={() => {
-                                                    setHasPlaudConnection(
-                                                        false,
-                                                    );
-                                                    setPlaudStep("email");
-                                                    setOtpCode("");
-                                                    setOtpToken("");
-                                                }}
+                                                onClick={() =>
+                                                    setHasPlaudConnection(false)
+                                                }
                                             >
                                                 Reconnect
                                             </Button>
@@ -366,146 +265,13 @@ export function OnboardingDialog({
                                 </Card>
                             ) : (
                                 <Card className="gap-0 py-4">
-                                    <CardContent className="pt-6 space-y-4">
-                                        {plaudStep === "email" ? (
-                                            <>
-                                                <div className="space-y-2">
-                                                    <Label htmlFor="plaud-email">
-                                                        Plaud Email
-                                                    </Label>
-                                                    <Input
-                                                        id="plaud-email"
-                                                        type="email"
-                                                        placeholder="you@example.com"
-                                                        value={plaudEmail}
-                                                        onChange={(e) =>
-                                                            setPlaudEmail(
-                                                                e.target.value,
-                                                            )
-                                                        }
-                                                        onKeyDown={(e) =>
-                                                            e.key === "Enter" &&
-                                                            handleSendCode()
-                                                        }
-                                                        disabled={isLoading}
-                                                        autoFocus
-                                                    />
-                                                    <p className="text-xs text-muted-foreground">
-                                                        The email you use to
-                                                        sign in at plaud.ai.
-                                                        We'll send a
-                                                        verification code via
-                                                        Plaud's servers.
-                                                    </p>
-                                                </div>
-
-                                                <Button
-                                                    onClick={handleSendCode}
-                                                    disabled={
-                                                        isLoading ||
-                                                        !plaudEmail.trim()
-                                                    }
-                                                    className="w-full"
-                                                >
-                                                    {isLoading
-                                                        ? "Sending code via plaud.ai…"
-                                                        : "Send Verification Code"}
-                                                </Button>
-
-                                                <p className="text-[11px] text-muted-foreground/60 text-center leading-relaxed">
-                                                    Your email is forwarded
-                                                    directly to Plaud — never
-                                                    stored by OpenPlaud.{" "}
-                                                    <a
-                                                        href="https://github.com/openplaud/openplaud/blob/main/src/app/api/plaud/auth/send-code/route.ts"
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="underline decoration-dotted underline-offset-2"
-                                                    >
-                                                        View source&nbsp;→
-                                                    </a>
-                                                </p>
-                                            </>
-                                        ) : (
-                                            <>
-                                                <div className="space-y-2">
-                                                    <Label htmlFor="otp-code">
-                                                        Verification Code
-                                                    </Label>
-                                                    <Input
-                                                        id="otp-code"
-                                                        type="text"
-                                                        inputMode="numeric"
-                                                        placeholder="000000"
-                                                        value={otpCode}
-                                                        onChange={(e) =>
-                                                            setOtpCode(
-                                                                e.target.value,
-                                                            )
-                                                        }
-                                                        onKeyDown={(e) =>
-                                                            e.key === "Enter" &&
-                                                            handleVerifyCode()
-                                                        }
-                                                        disabled={isLoading}
-                                                        className="font-mono text-lg tracking-[0.3em] text-center"
-                                                        autoFocus
-                                                        autoComplete="one-time-code"
-                                                    />
-                                                    <p className="text-xs text-muted-foreground">
-                                                        Code sent to{" "}
-                                                        <span className="font-mono">
-                                                            {plaudEmail}
-                                                        </span>
-                                                        {plaudApiBase && (
-                                                            <span>
-                                                                {" "}
-                                                                · Region:{" "}
-                                                                {regionLabel(
-                                                                    plaudApiBase,
-                                                                )}
-                                                            </span>
-                                                        )}
-                                                    </p>
-                                                </div>
-
-                                                <Button
-                                                    onClick={handleVerifyCode}
-                                                    disabled={
-                                                        isLoading ||
-                                                        !otpCode.trim()
-                                                    }
-                                                    className="w-full"
-                                                >
-                                                    {isLoading
-                                                        ? "Verifying with plaud.ai…"
-                                                        : "Connect Account"}
-                                                </Button>
-
-                                                <div className="flex items-center justify-between text-xs text-muted-foreground/60">
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => {
-                                                            setPlaudStep(
-                                                                "email",
-                                                            );
-                                                            setOtpCode("");
-                                                        }}
-                                                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
-                                                    >
-                                                        ← Different email
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        onClick={handleSendCode}
-                                                        disabled={isLoading}
-                                                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors disabled:opacity-50"
-                                                    >
-                                                        Resend code
-                                                    </button>
-                                                </div>
-                                            </>
-                                        )}
+                                    <CardContent className="pt-6">
+                                        <PlaudConnectTabs
+                                            variant="dialog"
+                                            onConnected={() =>
+                                                setHasPlaudConnection(true)
+                                            }
+                                        />
                                     </CardContent>
                                 </Card>
                             )}

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -107,7 +107,7 @@ export function OnboardingForm() {
                             instance. No data leaves your server.
                         </p>
                         <p>
-                            This is open source software \u2014 every line is
+                            This is open source software — every line is
                             available for inspection:{" "}
                             <a
                                 href={GITHUB_REPO}
@@ -115,7 +115,7 @@ export function OnboardingForm() {
                                 rel="noopener noreferrer"
                                 className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground/90 transition-colors"
                             >
-                                GitHub&nbsp;\u2192
+                                GitHub&nbsp;→
                             </a>
                         </p>
                     </Panel>

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -1,126 +1,27 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
-import { toast } from "sonner";
+import { useState } from "react";
 import { LEDIndicator } from "@/components/led-indicator";
 import { MetalButton } from "@/components/metal-button";
 import { Panel } from "@/components/panel";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { PlaudConnectTabs } from "@/components/plaud-connect-tabs";
 
-type Step = "email" | "code" | "complete";
+type Step = "connect" | "complete";
 
-const RESEND_COOLDOWN_MS = 30_000;
 const GITHUB_REPO = "https://github.com/openplaud/openplaud";
-const SEND_CODE_SOURCE = `${GITHUB_REPO}/blob/main/src/app/api/plaud/auth/send-code/route.ts`;
-const VERIFY_SOURCE = `${GITHUB_REPO}/blob/main/src/app/api/plaud/auth/verify/route.ts`;
 
 export function OnboardingForm() {
-    const [step, setStep] = useState<Step>("email");
-    const [email, setEmail] = useState("");
-    const [code, setCode] = useState("");
-    const [isLoading, setIsLoading] = useState(false);
-    const [otpToken, setOtpToken] = useState("");
-    const [apiBase, setApiBase] = useState("");
-    const [detectedRegion, setDetectedRegion] = useState("");
-    const [lastSentAt, setLastSentAt] = useState(0);
+    const [step, setStep] = useState<Step>("connect");
     const router = useRouter();
-
-    const regionLabel = useCallback((base: string) => {
-        if (base.includes("euc1")) return "EU (Frankfurt)";
-        if (base.includes("apse1")) return "Asia Pacific (Singapore)";
-        if (base.includes("api.plaud.ai")) return "Global";
-        return base;
-    }, []);
-
-    const handleSendCode = async () => {
-        const trimmed = email.trim();
-        if (!trimmed) {
-            toast.error("Please enter your Plaud email");
-            return;
-        }
-
-        const now = Date.now();
-        if (now - lastSentAt < RESEND_COOLDOWN_MS) {
-            const secsLeft = Math.ceil(
-                (RESEND_COOLDOWN_MS - (now - lastSentAt)) / 1000,
-            );
-            toast.error(`Please wait ${secsLeft}s before resending`);
-            return;
-        }
-
-        setIsLoading(true);
-        try {
-            const res = await fetch("/api/plaud/auth/send-code", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email: trimmed }),
-            });
-
-            const data = await res.json();
-            if (!res.ok) throw new Error(data.error || "Failed to send code");
-
-            setOtpToken(data.otpToken);
-            setApiBase(data.apiBase);
-            setDetectedRegion(regionLabel(data.apiBase));
-            setLastSentAt(Date.now());
-            setStep("code");
-            toast.success("Verification code sent — check your email");
-        } catch (err) {
-            toast.error(
-                err instanceof Error ? err.message : "Failed to send code",
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const handleVerifyCode = async () => {
-        const trimmed = code.trim();
-        if (!trimmed) {
-            toast.error("Please enter the verification code");
-            return;
-        }
-
-        setIsLoading(true);
-        try {
-            const res = await fetch("/api/plaud/auth/verify", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    code: trimmed,
-                    otpToken,
-                    apiBase,
-                    email,
-                }),
-            });
-
-            const data = await res.json();
-            if (!res.ok) throw new Error(data.error || "Verification failed");
-
-            toast.success("Plaud account connected");
-            setStep("complete");
-        } catch (err) {
-            toast.error(
-                err instanceof Error ? err.message : "Verification failed",
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
 
     return (
         <Panel className="w-full max-w-2xl space-y-6">
             {/* Progress indicator */}
             <div className="flex items-center justify-center gap-8">
                 <div className="flex items-center gap-2">
-                    <LEDIndicator active={step === "email"} status="active" />
-                    <span className="text-sm">Sign In</span>
-                </div>
-                <div className="flex items-center gap-2">
-                    <LEDIndicator active={step === "code"} status="active" />
-                    <span className="text-sm">Verify</span>
+                    <LEDIndicator active={step === "connect"} status="active" />
+                    <span className="text-sm">Connect</span>
                 </div>
                 <div className="flex items-center gap-2">
                     <LEDIndicator
@@ -131,8 +32,7 @@ export function OnboardingForm() {
                 </div>
             </div>
 
-            {/* ── Step 1: Email ── */}
-            {step === "email" && (
+            {step === "connect" && (
                 <div className="space-y-4">
                     <div>
                         <h2 className="text-xl font-bold">
@@ -148,142 +48,18 @@ export function OnboardingForm() {
                             >
                                 plaud.ai
                             </a>
+                            , or paste an existing token if you signed up via
+                            Google or Apple.
                         </p>
                     </div>
 
-                    <div className="space-y-2">
-                        <Label htmlFor="plaudEmail">Plaud Email</Label>
-                        <Input
-                            id="plaudEmail"
-                            type="email"
-                            placeholder="you@example.com"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            onKeyDown={(e) =>
-                                e.key === "Enter" && handleSendCode()
-                            }
-                            disabled={isLoading}
-                            autoFocus
-                        />
-                    </div>
-
-                    <MetalButton
-                        onClick={handleSendCode}
-                        variant="cyan"
-                        disabled={isLoading}
-                        className="w-full"
-                    >
-                        {isLoading
-                            ? "Sending code via plaud.ai…"
-                            : "Send Verification Code"}
-                    </MetalButton>
-
-                    {/* Trust signal — inline, unobtrusive */}
-                    <p className="text-xs text-muted-foreground/70 text-center leading-relaxed">
-                        Your email is sent directly to Plaud's servers to
-                        request a login code — it is never stored by OpenPlaud.{" "}
-                        <a
-                            href={SEND_CODE_SOURCE}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
-                        >
-                            Read the source&nbsp;→
-                        </a>
-                    </p>
+                    <PlaudConnectTabs
+                        variant="page"
+                        onConnected={() => setStep("complete")}
+                    />
                 </div>
             )}
 
-            {/* ── Step 2: OTP Code ── */}
-            {step === "code" && (
-                <div className="space-y-4">
-                    <div>
-                        <h2 className="text-xl font-bold">
-                            Enter Verification Code
-                        </h2>
-                        <p className="text-sm text-muted-foreground mt-1">
-                            Plaud sent a code to{" "}
-                            <span className="font-mono text-foreground">
-                                {email}
-                            </span>
-                        </p>
-                    </div>
-
-                    {detectedRegion && (
-                        <div className="flex items-center gap-2 text-xs text-muted-foreground font-mono">
-                            <LEDIndicator active status="active" size="sm" />
-                            <span>Account region: {detectedRegion}</span>
-                        </div>
-                    )}
-
-                    <div className="space-y-2">
-                        <Label htmlFor="otpCode">Verification Code</Label>
-                        <Input
-                            id="otpCode"
-                            type="text"
-                            inputMode="numeric"
-                            placeholder="000000"
-                            value={code}
-                            onChange={(e) => setCode(e.target.value)}
-                            onKeyDown={(e) =>
-                                e.key === "Enter" && handleVerifyCode()
-                            }
-                            disabled={isLoading}
-                            className="font-mono text-lg tracking-[0.3em] text-center"
-                            autoFocus
-                            autoComplete="one-time-code"
-                        />
-                    </div>
-
-                    <MetalButton
-                        onClick={handleVerifyCode}
-                        variant="cyan"
-                        disabled={isLoading}
-                        className="w-full"
-                    >
-                        {isLoading
-                            ? "Verifying with plaud.ai…"
-                            : "Connect Account"}
-                    </MetalButton>
-
-                    <div className="flex items-center justify-between text-xs text-muted-foreground/70">
-                        <button
-                            type="button"
-                            onClick={() => {
-                                setStep("email");
-                                setCode("");
-                            }}
-                            className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
-                        >
-                            ← Use a different email
-                        </button>
-                        <button
-                            type="button"
-                            onClick={handleSendCode}
-                            disabled={isLoading}
-                            className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors disabled:opacity-50"
-                        >
-                            Resend code
-                        </button>
-                    </div>
-
-                    <p className="text-xs text-muted-foreground/70 text-center leading-relaxed">
-                        Your code is forwarded to Plaud to obtain an access
-                        token, which is then encrypted (AES-256-GCM) and stored
-                        only on this instance.{" "}
-                        <a
-                            href={VERIFY_SOURCE}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
-                        >
-                            Read the source&nbsp;→
-                        </a>
-                    </p>
-                </div>
-            )}
-
-            {/* ── Step 3: Complete ── */}
             {step === "complete" && (
                 <div className="space-y-4 text-center">
                     <LEDIndicator
@@ -320,11 +96,10 @@ export function OnboardingForm() {
                         className="mt-2 space-y-2 text-xs text-muted-foreground leading-relaxed"
                     >
                         <p>
-                            OpenPlaud sends your email to Plaud's own servers (
-                            <span className="font-mono">api.plaud.ai</span>) to
-                            request a login code — the same way the official
-                            Plaud app does. Your email and code are forwarded
-                            directly and never stored.
+                            OpenPlaud talks to Plaud's own servers (
+                            <span className="font-mono">api.plaud.ai</span>) the
+                            same way the official Plaud app does. Your email or
+                            token is forwarded directly and never stored.
                         </p>
                         <p>
                             After login, your access token is encrypted with
@@ -332,7 +107,7 @@ export function OnboardingForm() {
                             instance. No data leaves your server.
                         </p>
                         <p>
-                            This is open source software — every line is
+                            This is open source software \u2014 every line is
                             available for inspection:{" "}
                             <a
                                 href={GITHUB_REPO}
@@ -340,7 +115,7 @@ export function OnboardingForm() {
                                 rel="noopener noreferrer"
                                 className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground/90 transition-colors"
                             >
-                                GitHub&nbsp;→
+                                GitHub&nbsp;\u2192
                             </a>
                         </p>
                     </Panel>

--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -4,16 +4,16 @@
  * Two-mode Plaud connect form, shared between the onboarding dialog and the
  * standalone /onboarding page.
  *
- * Mode "email" \u2014 the existing OTP flow (email \u2192 6-digit code).
+ * Mode "email" — the existing OTP flow (email → 6-digit code).
  *
- * Mode "token" \u2014 paste an access token grabbed from a logged-in
+ * Mode "token" — paste an access token grabbed from a logged-in
  * web.plaud.ai session. This exists for users whose Plaud account was
  * created via Google or Apple sign-in (issue #65): the OTP flow signs them
  * into a *different*, empty shadow account on Plaud's side, so the only
  * reliable connection method is reusing the token from a real web session.
  *
- * Both modes terminate in the same place \u2014 a connection row in
- * plaud_connections \u2014 so the parent only needs to know "did the user
+ * Both modes terminate in the same place — a connection row in
+ * plaud_connections — so the parent only needs to know "did the user
  * connect?" via the `onConnected` callback.
  */
 
@@ -256,7 +256,7 @@ function ConnectorPane({
                 className="w-full"
             >
                 {isLoading
-                    ? "Waiting for plaud.ai sign-in\u2026"
+                    ? "Waiting for plaud.ai sign-in…"
                     : "Continue with Plaud"}
             </Button>
             <p className="text-xs text-muted-foreground/80 leading-relaxed">
@@ -330,7 +330,7 @@ function EmailCodePane({
             setApiBase(data.apiBase);
             setLastSentAt(Date.now());
             setStep("code");
-            toast.success("Verification code sent \u2014 check your email");
+            toast.success("Verification code sent — check your email");
         } catch (err) {
             toast.error(
                 err instanceof Error ? err.message : "Failed to send code",
@@ -398,7 +398,7 @@ function EmailCodePane({
                     className="w-full"
                 >
                     {isLoading
-                        ? "Sending code via plaud.ai\u2026"
+                        ? "Sending code via plaud.ai…"
                         : "Send Verification Code"}
                 </Button>
 
@@ -420,7 +420,7 @@ function EmailCodePane({
                         rel="noopener noreferrer"
                         className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
                     >
-                        #65&nbsp;\u2192
+                        #65&nbsp;→
                     </a>
                 </p>
             </div>
@@ -446,9 +446,7 @@ function EmailCodePane({
                 />
                 <p className="text-xs text-muted-foreground">
                     Code sent to <span className="font-mono">{email}</span>
-                    {apiBase && (
-                        <span> \u00b7 Region: {regionLabel(apiBase)}</span>
-                    )}
+                    {apiBase && <span> · Region: {regionLabel(apiBase)}</span>}
                 </p>
             </div>
 
@@ -457,9 +455,7 @@ function EmailCodePane({
                 disabled={isLoading || !code.trim()}
                 className="w-full"
             >
-                {isLoading
-                    ? "Verifying with plaud.ai\u2026"
-                    : "Connect Account"}
+                {isLoading ? "Verifying with plaud.ai…" : "Connect Account"}
             </Button>
 
             <div className="flex items-center justify-between text-xs text-muted-foreground/70">
@@ -471,7 +467,7 @@ function EmailCodePane({
                     }}
                     className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
                 >
-                    \u2190 Different email
+                    ← Different email
                 </button>
                 <button
                     type="button"
@@ -555,7 +551,7 @@ function PasteTokenPane({
                     rel="noopener noreferrer"
                     className="underline decoration-dotted underline-offset-2 hover:text-foreground transition-colors"
                 >
-                    Why? \u00b7 #65&nbsp;\u2192
+                    Why? · #65&nbsp;→
                 </a>
             </p>
 
@@ -599,7 +595,7 @@ function PasteTokenPane({
                 <Label htmlFor="plaud-access-token">Access token</Label>
                 <textarea
                     id="plaud-access-token"
-                    placeholder="eyJhbGciOi\u2026"
+                    placeholder="eyJhbGciOi…"
                     value={token}
                     onChange={(e) => setToken(e.target.value)}
                     disabled={isLoading}
@@ -616,9 +612,7 @@ function PasteTokenPane({
                 disabled={isLoading || !token.trim()}
                 className="w-full"
             >
-                {isLoading
-                    ? "Validating with plaud.ai\u2026"
-                    : "Connect with token"}
+                {isLoading ? "Validating with plaud.ai…" : "Connect with token"}
             </Button>
 
             <details className="group">
@@ -639,7 +633,7 @@ function PasteTokenPane({
                         in another tab and sign in (Google, Apple, or email).
                     </li>
                     <li>
-                        Open browser devtools (F12 / Cmd+Option+I) \u2192{" "}
+                        Open browser devtools (F12 / Cmd+Option+I) →{" "}
                         <span className="font-medium">Network</span> tab.
                     </li>
                     <li>
@@ -650,8 +644,7 @@ function PasteTokenPane({
                         etc.
                     </li>
                     <li>
-                        Under <span className="font-medium">Headers</span>{" "}
-                        \u2192{" "}
+                        Under <span className="font-medium">Headers</span> →{" "}
                         <span className="font-medium">Request Headers</span>,
                         find <span className="font-mono">Authorization</span>.
                         Copy the value <em>after</em>{" "}
@@ -659,8 +652,8 @@ function PasteTokenPane({
                         above.
                     </li>
                     <li>
-                        Pick the matching region from the dropdown \u2014 e.g.
-                        if the host was{" "}
+                        Pick the matching region from the dropdown — e.g. if the
+                        host was{" "}
                         <span className="font-mono">api-euc1.plaud.ai</span>,
                         choose EU.
                     </li>

--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -1,0 +1,675 @@
+"use client";
+
+/**
+ * Two-mode Plaud connect form, shared between the onboarding dialog and the
+ * standalone /onboarding page.
+ *
+ * Mode "email" \u2014 the existing OTP flow (email \u2192 6-digit code).
+ *
+ * Mode "token" \u2014 paste an access token grabbed from a logged-in
+ * web.plaud.ai session. This exists for users whose Plaud account was
+ * created via Google or Apple sign-in (issue #65): the OTP flow signs them
+ * into a *different*, empty shadow account on Plaud's side, so the only
+ * reliable connection method is reusing the token from a real web session.
+ *
+ * Both modes terminate in the same place \u2014 a connection row in
+ * plaud_connections \u2014 so the parent only needs to know "did the user
+ * connect?" via the `onConnected` callback.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    DEFAULT_SERVER_KEY,
+    PLAUD_SERVERS,
+    type PlaudServerKey,
+} from "@/lib/plaud/servers";
+
+const CONNECTOR_CHROME_URL =
+    "https://github.com/openplaud/connector#installation";
+
+// Public API contract for the OpenPlaud Connector browser extension.
+// Kept in sync with /Users/.../connector/src/page-bridge.ts — if this
+// shape changes, bump `version` on both sides.
+interface ConnectorBridge {
+    version: number;
+    connect(): Promise<{
+        accessToken: string;
+        apiBase: string;
+        region: "global" | "euc1" | "apse1" | "unknown";
+        capturedAt: number;
+    }>;
+}
+
+declare global {
+    interface Window {
+        __openplaudConnector?: ConnectorBridge;
+    }
+}
+
+type Mode = "connector" | "email" | "token";
+type EmailStep = "email" | "code";
+
+const RESEND_COOLDOWN_MS = 30_000;
+const ISSUE_URL = "https://github.com/openplaud/openplaud/issues/65";
+
+function regionLabel(base: string): string {
+    if (base.includes("euc1")) return "EU (Frankfurt)";
+    if (base.includes("apse1")) return "Asia Pacific (Singapore)";
+    if (base.includes("api.plaud.ai")) return "Global";
+    return base;
+}
+
+interface PlaudConnectTabsProps {
+    /** Called after a successful connect (either mode). */
+    onConnected: () => void;
+    /** Compact mode pulls in margins/typography for the dialog surface. */
+    variant?: "dialog" | "page";
+}
+
+export function PlaudConnectTabs({
+    onConnected,
+    variant = "dialog",
+}: PlaudConnectTabsProps) {
+    // Detect the OpenPlaud Connector extension. The page-bridge defines
+    // window.__openplaudConnector at document_start, but if the extension
+    // gets installed *while* the page is open we never see it; we re-poll
+    // a few times for resilience and then give up.
+    const [hasConnector, setHasConnector] = useState<boolean>(false);
+    useEffect(() => {
+        let cancelled = false;
+        const check = () => {
+            if (cancelled) return;
+            const v = window.__openplaudConnector?.version;
+            if (typeof v === "number" && v >= 1) setHasConnector(true);
+        };
+        check();
+        const id = window.setInterval(check, 750);
+        const stop = window.setTimeout(() => window.clearInterval(id), 10_000);
+        return () => {
+            cancelled = true;
+            window.clearInterval(id);
+            window.clearTimeout(stop);
+        };
+    }, []);
+
+    const [mode, setMode] = useState<Mode>("connector");
+
+    const tabs: { key: Mode; label: string }[] = [
+        { key: "connector", label: "Sign in with Plaud" },
+        { key: "email", label: "Email code" },
+        { key: "token", label: "Paste token" },
+    ];
+
+    return (
+        <div className="space-y-4">
+            <div
+                role="tablist"
+                aria-label="Plaud connection method"
+                className="grid grid-cols-3 gap-1 p-1 rounded-md bg-muted/50 border"
+            >
+                {tabs.map((t) => (
+                    <button
+                        key={t.key}
+                        type="button"
+                        role="tab"
+                        aria-selected={mode === t.key}
+                        onClick={() => setMode(t.key)}
+                        className={`px-3 py-1.5 text-sm rounded transition-colors ${
+                            mode === t.key
+                                ? "bg-background shadow-sm font-medium"
+                                : "text-muted-foreground hover:text-foreground"
+                        }`}
+                    >
+                        {t.label}
+                    </button>
+                ))}
+            </div>
+
+            {mode === "connector" && (
+                <ConnectorPane
+                    onConnected={onConnected}
+                    hasConnector={hasConnector}
+                    onUseEmail={() => setMode("email")}
+                    onUseToken={() => setMode("token")}
+                />
+            )}
+            {mode === "email" && (
+                <EmailCodePane
+                    onConnected={onConnected}
+                    onSwitchToToken={() => setMode("token")}
+                    variant={variant}
+                />
+            )}
+            {mode === "token" && (
+                <PasteTokenPane onConnected={onConnected} variant={variant} />
+            )}
+        </div>
+    );
+}
+
+// ── Connector (browser extension) pane ─────────────────────────────────
+
+interface ConnectorPaneProps {
+    onConnected: () => void;
+    hasConnector: boolean;
+    onUseEmail: () => void;
+    onUseToken: () => void;
+}
+
+function ConnectorPane({
+    onConnected,
+    hasConnector,
+    onUseEmail,
+    onUseToken,
+}: ConnectorPaneProps) {
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleConnect = useCallback(async () => {
+        const bridge = window.__openplaudConnector;
+        if (!bridge) {
+            toast.error("Connector extension not detected");
+            return;
+        }
+        setIsLoading(true);
+        try {
+            const payload = await bridge.connect();
+            const res = await fetch("/api/plaud/auth/connect-token", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    accessToken: payload.accessToken,
+                    apiBase: payload.apiBase,
+                    source: "connector",
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok)
+                throw new Error(data.error || "Failed to connect Plaud");
+            toast.success("Plaud account connected");
+            onConnected();
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : "Failed to connect",
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    }, [onConnected]);
+
+    if (!hasConnector) {
+        return (
+            <div className="space-y-3">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                    Easiest path: install the{" "}
+                    <span className="font-medium">OpenPlaud Connector</span>{" "}
+                    browser extension. Sign in to Plaud the way you normally do
+                    (Google, Apple, or email) and the connector hands the
+                    session back here — no copy-pasting.
+                </p>
+                <Button asChild className="w-full">
+                    <a
+                        href={CONNECTOR_CHROME_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Install OpenPlaud Connector
+                    </a>
+                </Button>
+                <p className="text-xs text-muted-foreground/80 leading-relaxed">
+                    Already installed? Reload this page so OpenPlaud can detect
+                    it. Or use the{" "}
+                    <button
+                        type="button"
+                        onClick={onUseEmail}
+                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground"
+                    >
+                        email code
+                    </button>{" "}
+                    /{" "}
+                    <button
+                        type="button"
+                        onClick={onUseToken}
+                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground"
+                    >
+                        paste token
+                    </button>{" "}
+                    methods instead.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <p className="text-sm text-muted-foreground leading-relaxed">
+                Click below to sign in to Plaud in a new tab — use Google,
+                Apple, or email/password as you normally would. The connector
+                will return you here automatically.
+            </p>
+            <Button
+                onClick={handleConnect}
+                disabled={isLoading}
+                className="w-full"
+            >
+                {isLoading
+                    ? "Waiting for plaud.ai sign-in\u2026"
+                    : "Continue with Plaud"}
+            </Button>
+            <p className="text-xs text-muted-foreground/80 leading-relaxed">
+                Stuck?{" "}
+                <button
+                    type="button"
+                    onClick={onUseEmail}
+                    className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground"
+                >
+                    Use email code
+                </button>{" "}
+                or{" "}
+                <button
+                    type="button"
+                    onClick={onUseToken}
+                    className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground"
+                >
+                    paste token
+                </button>
+                .
+            </p>
+        </div>
+    );
+}
+
+// \u2500\u2500 Email code (OTP) pane \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+interface EmailCodePaneProps {
+    onConnected: () => void;
+    onSwitchToToken: () => void;
+    variant: "dialog" | "page";
+}
+
+function EmailCodePane({
+    onConnected,
+    onSwitchToToken,
+    variant: _variant,
+}: EmailCodePaneProps) {
+    const [step, setStep] = useState<EmailStep>("email");
+    const [email, setEmail] = useState("");
+    const [code, setCode] = useState("");
+    const [otpToken, setOtpToken] = useState("");
+    const [apiBase, setApiBase] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [lastSentAt, setLastSentAt] = useState(0);
+
+    const handleSendCode = useCallback(async () => {
+        const trimmed = email.trim();
+        if (!trimmed) {
+            toast.error("Please enter your Plaud email");
+            return;
+        }
+        const now = Date.now();
+        if (now - lastSentAt < RESEND_COOLDOWN_MS) {
+            const secs = Math.ceil(
+                (RESEND_COOLDOWN_MS - (now - lastSentAt)) / 1000,
+            );
+            toast.error(`Please wait ${secs}s before resending`);
+            return;
+        }
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/plaud/auth/send-code", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email: trimmed }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Failed to send code");
+            setOtpToken(data.otpToken);
+            setApiBase(data.apiBase);
+            setLastSentAt(Date.now());
+            setStep("code");
+            toast.success("Verification code sent \u2014 check your email");
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : "Failed to send code",
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    }, [email, lastSentAt]);
+
+    const handleVerify = useCallback(async () => {
+        const trimmed = code.trim();
+        if (!trimmed) {
+            toast.error("Please enter the verification code");
+            return;
+        }
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/plaud/auth/verify", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    code: trimmed,
+                    otpToken,
+                    apiBase,
+                    email,
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Verification failed");
+            toast.success("Plaud account connected");
+            onConnected();
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : "Verification failed",
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    }, [code, otpToken, apiBase, email, onConnected]);
+
+    if (step === "email") {
+        return (
+            <div className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="plaud-email">Plaud Email</Label>
+                    <Input
+                        id="plaud-email"
+                        type="email"
+                        placeholder="you@example.com"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && handleSendCode()}
+                        disabled={isLoading}
+                        autoFocus
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        The email you use to sign in at plaud.ai. We'll send a
+                        verification code via Plaud's servers.
+                    </p>
+                </div>
+
+                <Button
+                    onClick={handleSendCode}
+                    disabled={isLoading || !email.trim()}
+                    className="w-full"
+                >
+                    {isLoading
+                        ? "Sending code via plaud.ai\u2026"
+                        : "Send Verification Code"}
+                </Button>
+
+                <p className="text-xs text-muted-foreground/80 leading-relaxed">
+                    Signed up to Plaud with{" "}
+                    <span className="font-medium">Google or Apple</span>? The
+                    email-code flow may sign you into a different (empty) Plaud
+                    account.{" "}
+                    <button
+                        type="button"
+                        onClick={onSwitchToToken}
+                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
+                    >
+                        Use the paste-token method instead.
+                    </button>{" "}
+                    <a
+                        href={ISSUE_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
+                    >
+                        #65&nbsp;\u2192
+                    </a>
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="space-y-2">
+                <Label htmlFor="otp-code">Verification Code</Label>
+                <Input
+                    id="otp-code"
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="000000"
+                    value={code}
+                    onChange={(e) => setCode(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleVerify()}
+                    disabled={isLoading}
+                    className="font-mono text-lg tracking-[0.3em] text-center"
+                    autoFocus
+                    autoComplete="one-time-code"
+                />
+                <p className="text-xs text-muted-foreground">
+                    Code sent to <span className="font-mono">{email}</span>
+                    {apiBase && (
+                        <span> \u00b7 Region: {regionLabel(apiBase)}</span>
+                    )}
+                </p>
+            </div>
+
+            <Button
+                onClick={handleVerify}
+                disabled={isLoading || !code.trim()}
+                className="w-full"
+            >
+                {isLoading
+                    ? "Verifying with plaud.ai\u2026"
+                    : "Connect Account"}
+            </Button>
+
+            <div className="flex items-center justify-between text-xs text-muted-foreground/70">
+                <button
+                    type="button"
+                    onClick={() => {
+                        setStep("email");
+                        setCode("");
+                    }}
+                    className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors"
+                >
+                    \u2190 Different email
+                </button>
+                <button
+                    type="button"
+                    onClick={handleSendCode}
+                    disabled={isLoading}
+                    className="underline decoration-dotted underline-offset-2 hover:text-muted-foreground transition-colors disabled:opacity-50"
+                >
+                    Resend code
+                </button>
+            </div>
+        </div>
+    );
+}
+
+// \u2500\u2500 Paste token pane \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+interface PasteTokenPaneProps {
+    onConnected: () => void;
+    variant: "dialog" | "page";
+}
+
+function PasteTokenPane({
+    onConnected,
+    variant: _variant,
+}: PasteTokenPaneProps) {
+    const [token, setToken] = useState("");
+    const [serverKey, setServerKey] =
+        useState<PlaudServerKey>(DEFAULT_SERVER_KEY);
+    const [customApiBase, setCustomApiBase] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+
+    const apiBase =
+        serverKey === "custom"
+            ? customApiBase.trim()
+            : PLAUD_SERVERS[serverKey].apiBase;
+
+    const handleSubmit = useCallback(async () => {
+        const trimmed = token.trim().replace(/^Bearer\s+/i, "");
+        if (!trimmed) {
+            toast.error("Paste your Plaud access token first");
+            return;
+        }
+        if (serverKey === "custom" && !apiBase) {
+            toast.error("Enter your custom Plaud API URL");
+            return;
+        }
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/plaud/auth/connect-token", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    accessToken: trimmed,
+                    apiBase,
+                    source: "paste",
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok)
+                throw new Error(data.error || "Failed to connect Plaud");
+            toast.success("Plaud account connected");
+            onConnected();
+        } catch (err) {
+            toast.error(
+                err instanceof Error ? err.message : "Failed to connect Plaud",
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    }, [token, apiBase, serverKey, onConnected]);
+
+    return (
+        <div className="space-y-4">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+                For accounts created via Google or Apple sign-in. Paste the
+                access token from a logged-in web.plaud.ai session and we'll
+                connect it directly.{" "}
+                <a
+                    href={ISSUE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline decoration-dotted underline-offset-2 hover:text-foreground transition-colors"
+                >
+                    Why? \u00b7 #65&nbsp;\u2192
+                </a>
+            </p>
+
+            <div className="space-y-2">
+                <Label htmlFor="plaud-region">Plaud region</Label>
+                <select
+                    id="plaud-region"
+                    value={serverKey}
+                    onChange={(e) =>
+                        setServerKey(e.target.value as PlaudServerKey)
+                    }
+                    disabled={isLoading}
+                    className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm"
+                >
+                    {(Object.keys(PLAUD_SERVERS) as PlaudServerKey[]).map(
+                        (key) => (
+                            <option key={key} value={key}>
+                                {PLAUD_SERVERS[key].label}
+                            </option>
+                        ),
+                    )}
+                </select>
+                {serverKey === "custom" && (
+                    <Input
+                        type="url"
+                        placeholder="https://api-xxx.plaud.ai"
+                        value={customApiBase}
+                        onChange={(e) => setCustomApiBase(e.target.value)}
+                        disabled={isLoading}
+                        className="font-mono text-xs"
+                    />
+                )}
+                <p className="text-xs text-muted-foreground">
+                    Look at the host of any{" "}
+                    <span className="font-mono">api*.plaud.ai</span> request in
+                    your devtools Network tab to find the region.
+                </p>
+            </div>
+
+            <div className="space-y-2">
+                <Label htmlFor="plaud-access-token">Access token</Label>
+                <textarea
+                    id="plaud-access-token"
+                    placeholder="eyJhbGciOi\u2026"
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    disabled={isLoading}
+                    rows={4}
+                    spellCheck={false}
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-xs font-mono break-all resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+            </div>
+
+            <Button
+                onClick={handleSubmit}
+                disabled={isLoading || !token.trim()}
+                className="w-full"
+            >
+                {isLoading
+                    ? "Validating with plaud.ai\u2026"
+                    : "Connect with token"}
+            </Button>
+
+            <details className="group">
+                <summary className="text-xs text-muted-foreground/80 cursor-pointer hover:text-muted-foreground transition-colors select-none">
+                    How do I find my access token?
+                </summary>
+                <ol className="mt-2 ml-4 space-y-1.5 text-xs text-muted-foreground list-decimal leading-relaxed">
+                    <li>
+                        Open{" "}
+                        <a
+                            href="https://web.plaud.ai"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-dotted underline-offset-2"
+                        >
+                            web.plaud.ai
+                        </a>{" "}
+                        in another tab and sign in (Google, Apple, or email).
+                    </li>
+                    <li>
+                        Open browser devtools (F12 / Cmd+Option+I) \u2192{" "}
+                        <span className="font-medium">Network</span> tab.
+                    </li>
+                    <li>
+                        Refresh web.plaud.ai. Click any request to a host
+                        starting with <span className="font-mono">api</span>
+                        <span className="font-mono">.plaud.ai</span> or{" "}
+                        <span className="font-mono">api-euc1.plaud.ai</span>{" "}
+                        etc.
+                    </li>
+                    <li>
+                        Under <span className="font-medium">Headers</span>{" "}
+                        \u2192{" "}
+                        <span className="font-medium">Request Headers</span>,
+                        find <span className="font-mono">Authorization</span>.
+                        Copy the value <em>after</em>{" "}
+                        <span className="font-mono">Bearer</span> and paste it
+                        above.
+                    </li>
+                    <li>
+                        Pick the matching region from the dropdown \u2014 e.g.
+                        if the host was{" "}
+                        <span className="font-mono">api-euc1.plaud.ai</span>,
+                        choose EU.
+                    </li>
+                </ol>
+                <p className="mt-2 text-xs text-muted-foreground/80 leading-relaxed">
+                    The token lives ~300 days. It is encrypted (AES-256-GCM)
+                    before storage on this instance.
+                </p>
+            </details>
+        </div>
+    );
+}

--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -123,22 +123,33 @@ export async function plaudVerifyOtp(
  * (return verbatim with HTTP 400) or our / Plaud's responsibility (surface
  * as 500 so the user retries instead of being told to fix their token).
  *
- * The shape we expect is what `PlaudClient.request` and the auth helpers
- * throw: `Plaud API error (NNN): ...` for HTTP-level failures, plus the
- * literal `Invalid API base` from our SSRF guard.
+ * Two shapes we throw:
  *
- * Only HTTP 4xx (auth/permission/bad-input) is user-actionable. 5xx
- * means Plaud is broken — surfacing those as 400 misleads users into
- * "my token is bad" troubleshooting when in reality they should retry.
- * Bare `Plaud API error` (no status) is treated as non-actionable too,
- * since we can't tell which side of the wire the failure came from.
+ *   - `Plaud API error (NNN): ...` — HTTP-level failure from
+ *     PlaudClient.request or the workspace helpers. Status carries the
+ *     verdict: 4xx is the user (bad token / forbidden / etc.), 5xx is
+ *     Plaud (or our infra) — don't tell users to "fix their token" when
+ *     Plaud is the broken party.
+ *
+ *   - `Plaud API error: ...` (no parenthesised status) — business-level
+ *     failure where Plaud returned HTTP 200 with a `status: -N` body, or
+ *     a workspace helper rejected on its own. These are user-actionable
+ *     by definition ("invalid verification code", "failed to send code",
+ *     "no workspaces returned", ...). Pre-narrowing this would silently
+ *     break the OTP error UX.
+ *
+ *   - The literal `Invalid API base` from our SSRF guard.
  */
 export function isUserActionablePlaudError(message: string): boolean {
     if (message === "Invalid API base") return true;
+    if (!message.startsWith("Plaud API error")) return false;
     const m = /^Plaud API error \((\d{3})\):/.exec(message);
-    if (!m) return false;
-    const status = Number.parseInt(m[1], 10);
-    return status >= 400 && status < 500;
+    if (m) {
+        const status = Number.parseInt(m[1], 10);
+        return status >= 400 && status < 500;
+    }
+    // Bare `Plaud API error: ...` — business-level failure, user-actionable.
+    return true;
 }
 
 // ── JWT helpers (UX-only; not security boundaries) ────────────────────────

--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -116,6 +116,31 @@ export async function plaudVerifyOtp(
     return { accessToken };
 }
 
+// ── Error classification ─────────────────────────────────────────────────
+
+/**
+ * Decide whether a Plaud-related error message is the user's responsibility
+ * (return verbatim with HTTP 400) or our / Plaud's responsibility (surface
+ * as 500 so the user retries instead of being told to fix their token).
+ *
+ * The shape we expect is what `PlaudClient.request` and the auth helpers
+ * throw: `Plaud API error (NNN): ...` for HTTP-level failures, plus the
+ * literal `Invalid API base` from our SSRF guard.
+ *
+ * Only HTTP 4xx (auth/permission/bad-input) is user-actionable. 5xx
+ * means Plaud is broken — surfacing those as 400 misleads users into
+ * "my token is bad" troubleshooting when in reality they should retry.
+ * Bare `Plaud API error` (no status) is treated as non-actionable too,
+ * since we can't tell which side of the wire the failure came from.
+ */
+export function isUserActionablePlaudError(message: string): boolean {
+    if (message === "Invalid API base") return true;
+    const m = /^Plaud API error \((\d{3})\):/.exec(message);
+    if (!m) return false;
+    const status = Number.parseInt(m[1], 10);
+    return status >= 400 && status < 500;
+}
+
 // ── JWT helpers (UX-only; not security boundaries) ────────────────────────
 
 /**

--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -115,3 +115,81 @@ export async function plaudVerifyOtp(
 
     return { accessToken };
 }
+
+// ── JWT helpers (UX-only; not security boundaries) ────────────────────────
+
+/**
+ * Decode a Plaud access token's `exp` claim without verifying the signature.
+ *
+ * Plaud's user tokens are JWTs with a ~300-day lifetime. We only decode here
+ * to give the paste-token UI a friendly hint ("this token expires in 3 days")
+ * — actual validation always happens by hitting Plaud's /device/list. Never
+ * trust the decoded payload for any security decision.
+ *
+ * Returns `null` on any malformed input rather than throwing — callers treat
+ * a null result as "unknown expiry, let Plaud decide".
+ */
+export function decodeAccessTokenExpiry(token: string): Date | null {
+    if (typeof token !== "string") return null;
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    try {
+        // base64url → base64 → utf-8 JSON
+        const b64 =
+            parts[1].replace(/-/g, "+").replace(/_/g, "/") +
+            "=".repeat((4 - (parts[1].length % 4)) % 4);
+        const json =
+            typeof atob === "function"
+                ? atob(b64)
+                : Buffer.from(b64, "base64").toString("utf8");
+        const payload = JSON.parse(json) as { exp?: unknown };
+        if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+            return null;
+        }
+        return new Date(payload.exp * 1000);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Best-effort fetch of /user/me to derive the linked Plaud account email.
+ *
+ * Used only by the paste-token connect flow, which doesn't otherwise know
+ * the user's Plaud email. Returns `null` on any failure — the email is a
+ * UX nicety (it shows up in settings as "Connected as foo@bar.com"), not
+ * a correctness requirement, and plaud_connections.plaud_email is nullable.
+ *
+ * Same SSRF posture as the rest of this module: caller must have already
+ * passed `apiBase` through `isValidPlaudApiUrl`.
+ */
+export async function fetchPlaudUserMeEmail(
+    accessToken: string,
+    apiBase: string,
+): Promise<string | null> {
+    try {
+        const res = await fetch(`${apiBase}/user/me`, {
+            method: "GET",
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/json",
+            },
+        });
+        if (!res.ok) return null;
+        const body = (await res.json()) as {
+            status?: number;
+            data?: { email?: unknown };
+            email?: unknown;
+        };
+        // Tolerate both root-level and data-nested shapes (Plaud's response
+        // shape varies across endpoints/regions).
+        const raw =
+            (typeof body.email === "string" && body.email) ||
+            (typeof body.data?.email === "string" && body.data.email) ||
+            null;
+        if (!raw) return null;
+        return raw.trim().toLowerCase() || null;
+    } catch {
+        return null;
+    }
+}

--- a/src/lib/plaud/persist-connection.ts
+++ b/src/lib/plaud/persist-connection.ts
@@ -21,7 +21,7 @@
  * mapped to 400 by callers; everything else is a 500.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { plaudConnections, plaudDevices } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
@@ -74,6 +74,12 @@ export async function persistPlaudConnection({
     // recording-scoped endpoint, otherwise the connection is useless and
     // we'd silently store a dead token. /device/list also gives us the
     // device rows we need to upsert below in a single round-trip.
+    //
+    // Re-throw the underlying error verbatim. Wrapping it (e.g. into
+    // "token validation failed") flattens the auth-vs-server distinction:
+    // a Plaud 5xx after our retry budget would surface as 400 "fix your
+    // token" advice. Callers use isUserActionablePlaudError() to map 4xx
+    // to 400 and everything else to 500.
     const client = new PlaudClient(accessToken, apiBase, resolvedWorkspaceId);
     let deviceList: PlaudDeviceListResponse;
     try {
@@ -83,82 +89,97 @@ export async function persistPlaudConnection({
             "[plaud/persist] device list validation failed:",
             err instanceof Error ? err.message : err,
         );
-        throw new Error(
-            "Plaud API error: token validation failed (Plaud rejected the token on /device/list)",
-        );
+        throw err;
     }
 
-    // 3. Encrypt + upsert connection. Always re-scope by userId on the
-    // UPDATE/SELECT so we never touch another user's row (defense-in-depth
-    // alongside the userId-scoped lookup).
+    // 3. + 4. Atomic upsert of the connection plus device reconciliation.
+    //
+    // plaud_connections has no unique constraint on user_id (intentionally
+    // additive on existing deployments — see the schema). Without one, a
+    // concurrent second "Connect" click could observe the same
+    // "no existing row" snapshot we did and insert a duplicate row, which
+    // sync paths then nondeterministically pick between. A per-user
+    // transaction-scoped advisory lock serialises connect attempts for
+    // this user without changing the schema; the lock is released
+    // automatically when the transaction commits or aborts.
     const encryptedAccessToken = encrypt(accessToken);
 
-    const [existingConnection] = await db
-        .select()
-        .from(plaudConnections)
-        .where(eq(plaudConnections.userId, userId))
-        .limit(1);
+    await db.transaction(async (tx) => {
+        await tx.execute(
+            sql`SELECT pg_advisory_xact_lock(hashtextextended(${`plaud_connect:${userId}`}, 0))`,
+        );
 
-    if (existingConnection) {
-        await db
-            .update(plaudConnections)
-            .set({
+        const [existingConnection] = await tx
+            .select()
+            .from(plaudConnections)
+            .where(eq(plaudConnections.userId, userId))
+            .limit(1);
+
+        if (existingConnection) {
+            // Always re-scope by userId on UPDATE/DELETE of user-owned
+            // rows (defense-in-depth alongside the userId-scoped lookup).
+            await tx
+                .update(plaudConnections)
+                .set({
+                    bearerToken: encryptedAccessToken,
+                    apiBase,
+                    plaudEmail,
+                    workspaceId: resolvedWorkspaceId,
+                    updatedAt: new Date(),
+                })
+                .where(
+                    and(
+                        eq(plaudConnections.id, existingConnection.id),
+                        eq(plaudConnections.userId, userId),
+                    ),
+                );
+        } else {
+            await tx.insert(plaudConnections).values({
+                userId,
                 bearerToken: encryptedAccessToken,
                 apiBase,
                 plaudEmail,
                 workspaceId: resolvedWorkspaceId,
-                updatedAt: new Date(),
-            })
-            .where(
-                and(
-                    eq(plaudConnections.id, existingConnection.id),
-                    eq(plaudConnections.userId, userId),
-                ),
-            );
-    } else {
-        await db.insert(plaudConnections).values({
-            userId,
-            bearerToken: encryptedAccessToken,
-            apiBase,
-            plaudEmail,
-            workspaceId: resolvedWorkspaceId,
-        });
-    }
+            });
+        }
 
-    // 4. Reconcile devices. Schema has a unique constraint on
-    // (userId, serialNumber) so we look up by that pair.
-    for (const device of deviceList.data_devices) {
-        const [existingDevice] = await db
-            .select()
-            .from(plaudDevices)
-            .where(
-                and(
-                    eq(plaudDevices.userId, userId),
-                    eq(plaudDevices.serialNumber, device.sn),
-                ),
-            )
-            .limit(1);
+        // Reconcile devices. Schema enforces a unique (userId, serialNumber)
+        // pair so the per-device lookup is collision-safe; we still keep
+        // the work inside the transaction so an aborted connect doesn't
+        // leave a half-written device list against the previous token.
+        for (const device of deviceList.data_devices) {
+            const [existingDevice] = await tx
+                .select()
+                .from(plaudDevices)
+                .where(
+                    and(
+                        eq(plaudDevices.userId, userId),
+                        eq(plaudDevices.serialNumber, device.sn),
+                    ),
+                )
+                .limit(1);
 
-        if (existingDevice) {
-            await db
-                .update(plaudDevices)
-                .set({
+            if (existingDevice) {
+                await tx
+                    .update(plaudDevices)
+                    .set({
+                        name: device.name,
+                        model: device.model,
+                        versionNumber: device.version_number,
+                        updatedAt: new Date(),
+                    })
+                    .where(eq(plaudDevices.id, existingDevice.id));
+            } else {
+                await tx.insert(plaudDevices).values({
+                    userId,
+                    serialNumber: device.sn,
                     name: device.name,
                     model: device.model,
                     versionNumber: device.version_number,
-                    updatedAt: new Date(),
-                })
-                .where(eq(plaudDevices.id, existingDevice.id));
-        } else {
-            await db.insert(plaudDevices).values({
-                userId,
-                serialNumber: device.sn,
-                name: device.name,
-                model: device.model,
-                versionNumber: device.version_number,
-            });
+                });
+            }
         }
-    }
+    });
 
     return {
         devices: deviceList.data_devices,

--- a/src/lib/plaud/persist-connection.ts
+++ b/src/lib/plaud/persist-connection.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared persistence path for "we just obtained a Plaud user token, now turn
+ * it into a stored connection".
+ *
+ * Two routes call this:
+ *   - /api/plaud/auth/verify         (OTP flow → access_token)
+ *   - /api/plaud/auth/connect-token  (paste-token flow → access_token)
+ *
+ * Both go through the same gauntlet:
+ *   1. Discover the personal workspace ID via /team-app/workspaces/list
+ *      (best-effort; warn-and-continue if the endpoint isn't reachable).
+ *   2. Validate the token end-to-end by calling /device/list. If that fails
+ *      we throw — there is no point persisting a token Plaud rejects.
+ *   3. AES-256-GCM-encrypt the token and upsert plaud_connections, scoped
+ *      to userId on both the SELECT and UPDATE.
+ *   4. Upsert plaud_devices for each device returned by /device/list,
+ *      scoped by (userId, serialNumber) so we never touch another user's
+ *      row (the schema enforces uniqueness on that pair).
+ *
+ * Errors prefixed with "Plaud API error:" are user-actionable and should be
+ * mapped to 400 by callers; everything else is a 500.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { plaudConnections, plaudDevices } from "@/db/schema";
+import { encrypt } from "@/lib/encryption";
+import type { PlaudDeviceListResponse } from "@/types/plaud";
+import { PlaudClient } from "./client";
+import { listPlaudWorkspaces, pickPersonalWorkspaceId } from "./workspace";
+
+export interface PersistPlaudConnectionInput {
+    userId: string;
+    accessToken: string;
+    apiBase: string;
+    /** Lowercased Plaud account email, or null if unknown. */
+    plaudEmail: string | null;
+}
+
+export interface PersistPlaudConnectionResult {
+    devices: PlaudDeviceListResponse["data_devices"];
+    workspaceId: string | null;
+}
+
+/**
+ * Validate a Plaud user token end-to-end and persist it as the user's
+ * connection. Idempotent: re-running with a fresh token replaces the stored
+ * one and reconciles devices.
+ *
+ * Throws on validation failure — callers must NOT have written anything
+ * before invoking this.
+ */
+export async function persistPlaudConnection({
+    userId,
+    accessToken,
+    apiBase,
+    plaudEmail,
+}: PersistPlaudConnectionInput): Promise<PersistPlaudConnectionResult> {
+    // 1. Workspace discovery (best-effort — preserves behaviour for any
+    // server / legacy account where /team-app/workspaces/list isn't
+    // available; the client will fall back to using the UT directly).
+    let resolvedWorkspaceId: string | null = null;
+    try {
+        const list = await listPlaudWorkspaces(accessToken, apiBase);
+        resolvedWorkspaceId = pickPersonalWorkspaceId(list);
+    } catch (err) {
+        console.warn(
+            "[plaud/persist] workspace discovery failed:",
+            err instanceof Error ? err.message : err,
+        );
+    }
+
+    // 2. End-to-end validation — Plaud must accept this token on a real
+    // recording-scoped endpoint, otherwise the connection is useless and
+    // we'd silently store a dead token. /device/list also gives us the
+    // device rows we need to upsert below in a single round-trip.
+    const client = new PlaudClient(accessToken, apiBase, resolvedWorkspaceId);
+    let deviceList: PlaudDeviceListResponse;
+    try {
+        deviceList = await client.listDevices();
+    } catch (err) {
+        console.warn(
+            "[plaud/persist] device list validation failed:",
+            err instanceof Error ? err.message : err,
+        );
+        throw new Error(
+            "Plaud API error: token validation failed (Plaud rejected the token on /device/list)",
+        );
+    }
+
+    // 3. Encrypt + upsert connection. Always re-scope by userId on the
+    // UPDATE/SELECT so we never touch another user's row (defense-in-depth
+    // alongside the userId-scoped lookup).
+    const encryptedAccessToken = encrypt(accessToken);
+
+    const [existingConnection] = await db
+        .select()
+        .from(plaudConnections)
+        .where(eq(plaudConnections.userId, userId))
+        .limit(1);
+
+    if (existingConnection) {
+        await db
+            .update(plaudConnections)
+            .set({
+                bearerToken: encryptedAccessToken,
+                apiBase,
+                plaudEmail,
+                workspaceId: resolvedWorkspaceId,
+                updatedAt: new Date(),
+            })
+            .where(
+                and(
+                    eq(plaudConnections.id, existingConnection.id),
+                    eq(plaudConnections.userId, userId),
+                ),
+            );
+    } else {
+        await db.insert(plaudConnections).values({
+            userId,
+            bearerToken: encryptedAccessToken,
+            apiBase,
+            plaudEmail,
+            workspaceId: resolvedWorkspaceId,
+        });
+    }
+
+    // 4. Reconcile devices. Schema has a unique constraint on
+    // (userId, serialNumber) so we look up by that pair.
+    for (const device of deviceList.data_devices) {
+        const [existingDevice] = await db
+            .select()
+            .from(plaudDevices)
+            .where(
+                and(
+                    eq(plaudDevices.userId, userId),
+                    eq(plaudDevices.serialNumber, device.sn),
+                ),
+            )
+            .limit(1);
+
+        if (existingDevice) {
+            await db
+                .update(plaudDevices)
+                .set({
+                    name: device.name,
+                    model: device.model,
+                    versionNumber: device.version_number,
+                    updatedAt: new Date(),
+                })
+                .where(eq(plaudDevices.id, existingDevice.id));
+        } else {
+            await db.insert(plaudDevices).values({
+                userId,
+                serialNumber: device.sn,
+                name: device.name,
+                model: device.model,
+                versionNumber: device.version_number,
+            });
+        }
+    }
+
+    return {
+        devices: deviceList.data_devices,
+        workspaceId: resolvedWorkspaceId,
+    };
+}

--- a/src/tests/regressions/65-paste-token.test.ts
+++ b/src/tests/regressions/65-paste-token.test.ts
@@ -187,10 +187,25 @@ describe("isUserActionablePlaudError", () => {
         ).toBe(false);
     });
 
-    it("returns false for bare 'Plaud API error' (no status — ambiguous)", () => {
+    it("returns true for bare 'Plaud API error' (Plaud business-level failures)", () => {
+        // Plaud's OTP + workspace helpers throw without an HTTP status
+        // because Plaud returns 200 with `status: -N` for these. They're
+        // user-actionable by definition — narrowing here silently broke
+        // the OTP error UX ("invalid verification code" → 500 instead of
+        // 400).
         expect(isUserActionablePlaudError("Plaud API error: invalid OTP")).toBe(
-            false,
+            true,
         );
+        expect(
+            isUserActionablePlaudError(
+                "Plaud API error: failed to send verification code",
+            ),
+        ).toBe(true);
+        expect(
+            isUserActionablePlaudError(
+                "Plaud API error: no workspaces returned",
+            ),
+        ).toBe(true);
     });
 
     it("returns true for our own 'Invalid API base' SSRF rejection", () => {

--- a/src/tests/regressions/65-paste-token.test.ts
+++ b/src/tests/regressions/65-paste-token.test.ts
@@ -30,13 +30,22 @@ vi.mock("@/lib/env", () => ({
     },
 }));
 
-vi.mock("@/db", () => ({
-    db: {
-        select: vi.fn(),
-        insert: vi.fn(),
-        update: vi.fn(),
-    },
-}));
+vi.mock("@/db", () => {
+    const select = vi.fn();
+    const insert = vi.fn();
+    const update = vi.fn();
+    const execute = vi.fn().mockResolvedValue(undefined);
+    // persist-connection wraps the upsert in db.transaction(async tx => ...)
+    // and calls tx.execute (advisory lock), tx.select, tx.insert, tx.update.
+    // The mock proxies the tx object back to the same vi.fn()s so existing
+    // expectations on db.insert/db.update keep working.
+    const transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+        cb({ select, insert, update, execute }),
+    );
+    return {
+        db: { select, insert, update, transaction },
+    };
+});
 
 vi.mock("@/lib/auth", () => ({
     auth: {
@@ -49,7 +58,10 @@ vi.mock("@/lib/auth", () => ({
 import { POST } from "@/app/api/plaud/auth/connect-token/route";
 import { db } from "@/db";
 import { auth } from "@/lib/auth";
-import { decodeAccessTokenExpiry } from "@/lib/plaud/auth";
+import {
+    decodeAccessTokenExpiry,
+    isUserActionablePlaudError,
+} from "@/lib/plaud/auth";
 
 const originalFetch = global.fetch;
 let mockFetch: Mock;
@@ -136,6 +148,63 @@ describe("decodeAccessTokenExpiry", () => {
 });
 
 // ── /api/plaud/auth/connect-token validation surface ────────────────────────
+
+// ── isUserActionablePlaudError (post-review fix for cubic P1) ──────────────────
+//
+// The previous matcher returned true for any "Plaud API error" prefix,
+// which surfaced 5xx-after-retries as a 400 "fix your token" message and
+// misled users when Plaud was the broken party. Lock in the narrower
+// 4xx-only contract so we don't regress.
+describe("isUserActionablePlaudError", () => {
+    it("returns true for 4xx Plaud HTTP errors (auth/permission/bad input)", () => {
+        expect(
+            isUserActionablePlaudError("Plaud API error (400): bad request"),
+        ).toBe(true);
+        expect(
+            isUserActionablePlaudError("Plaud API error (401): bad token"),
+        ).toBe(true);
+        expect(
+            isUserActionablePlaudError(
+                "Plaud API error (403): forbidden workspace",
+            ),
+        ).toBe(true);
+        expect(
+            isUserActionablePlaudError("Plaud API error (404): not found"),
+        ).toBe(true);
+    });
+
+    it("returns false for 5xx Plaud HTTP errors (Plaud or our infra is broken)", () => {
+        expect(
+            isUserActionablePlaudError("Plaud API error (500): server error"),
+        ).toBe(false);
+        expect(
+            isUserActionablePlaudError("Plaud API error (502): bad gateway"),
+        ).toBe(false);
+        expect(
+            isUserActionablePlaudError(
+                "Plaud API error (503): service unavailable",
+            ),
+        ).toBe(false);
+    });
+
+    it("returns false for bare 'Plaud API error' (no status — ambiguous)", () => {
+        expect(isUserActionablePlaudError("Plaud API error: invalid OTP")).toBe(
+            false,
+        );
+    });
+
+    it("returns true for our own 'Invalid API base' SSRF rejection", () => {
+        expect(isUserActionablePlaudError("Invalid API base")).toBe(true);
+    });
+
+    it("returns false for unrelated error messages", () => {
+        expect(isUserActionablePlaudError("ECONNRESET")).toBe(false);
+        expect(isUserActionablePlaudError("database connection failed")).toBe(
+            false,
+        );
+        expect(isUserActionablePlaudError("")).toBe(false);
+    });
+});
 
 describe("POST /api/plaud/auth/connect-token (validation)", () => {
     it("401s without a session", async () => {

--- a/src/tests/regressions/65-paste-token.test.ts
+++ b/src/tests/regressions/65-paste-token.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Regression test for issue #65:
+ *   "Add Google/Apple OAuth sign-in to support users who registered via
+ *   those methods"
+ *
+ * Real Google/Apple OAuth on Plaud's behalf is structurally impossible from
+ * a non-plaud.ai origin (Google's authorized-origins enforcement). The
+ * shipping fix is a paste-token connect path: the user grabs the bearer
+ * from a logged-in web.plaud.ai session and pastes it into OpenPlaud. This
+ * file pins the validation surface of /api/plaud/auth/connect-token plus
+ * the shape of decodeAccessTokenExpiry, so we don't silently regress the
+ * one escape hatch Google/Apple-registered Plaud users have today.
+ */
+
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+import { POST } from "@/app/api/plaud/auth/connect-token/route";
+import { db } from "@/db";
+import { auth } from "@/lib/auth";
+import { decodeAccessTokenExpiry } from "@/lib/plaud/auth";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = vi.fn() as Mock;
+    global.fetch = mockFetch as typeof global.fetch;
+    // Suppress the route's console.log/console.warn/console.error during
+    // negative-path tests to keep test output readable.
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    global.fetch = originalFetch;
+});
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+const USER_ID = "user-65";
+
+function authedSession() {
+    (auth.api.getSession as unknown as Mock).mockResolvedValue({
+        user: { id: USER_ID },
+    });
+}
+
+function unauthed() {
+    (auth.api.getSession as unknown as Mock).mockResolvedValue(null);
+}
+
+/** Build a JWT with arbitrary payload (signature is junk; we never verify). */
+function makeJwt(payload: Record<string, unknown>): string {
+    const header = Buffer.from(
+        JSON.stringify({ alg: "RS256", typ: "JWT" }),
+    ).toString("base64url");
+    const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    return `${header}.${body}.signature-not-checked`;
+}
+
+function makeRequest(body: unknown): Request {
+    return new Request("http://localhost/api/plaud/auth/connect-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+// ── decodeAccessTokenExpiry (pure unit) ─────────────────────────────────────
+
+describe("decodeAccessTokenExpiry", () => {
+    it("decodes a valid JWT exp into a Date", () => {
+        const futureSec = Math.floor(Date.now() / 1000) + 3600;
+        const tok = makeJwt({ exp: futureSec });
+        const result = decodeAccessTokenExpiry(tok);
+        expect(result).toBeInstanceOf(Date);
+        expect(result?.getTime()).toBe(futureSec * 1000);
+    });
+
+    it("returns null for a non-JWT string", () => {
+        expect(decodeAccessTokenExpiry("not-a-jwt")).toBeNull();
+        expect(decodeAccessTokenExpiry("a.b")).toBeNull();
+        expect(decodeAccessTokenExpiry("")).toBeNull();
+    });
+
+    it("returns null when payload has no exp", () => {
+        expect(decodeAccessTokenExpiry(makeJwt({ sub: "x" }))).toBeNull();
+    });
+
+    it("returns null when payload's exp is not a finite number", () => {
+        expect(decodeAccessTokenExpiry(makeJwt({ exp: "soon" }))).toBeNull();
+        expect(
+            decodeAccessTokenExpiry(makeJwt({ exp: Number.NaN })),
+        ).toBeNull();
+    });
+
+    it("tolerates base64url payloads requiring padding", () => {
+        // Pick a payload whose JSON length % 4 != 0 so base64url omits '='.
+        const tok = makeJwt({ exp: 1700000000, x: "ab" });
+        expect(decodeAccessTokenExpiry(tok)).toBeInstanceOf(Date);
+    });
+});
+
+// ── /api/plaud/auth/connect-token validation surface ────────────────────────
+
+describe("POST /api/plaud/auth/connect-token (validation)", () => {
+    it("401s without a session", async () => {
+        unauthed();
+        const res = await POST(makeRequest({ accessToken: "x" }));
+        expect(res.status).toBe(401);
+        // No Plaud calls were made.
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("400s when accessToken is missing", async () => {
+        authedSession();
+        const res = await POST(makeRequest({}));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/accessToken is required/);
+    });
+
+    it("400s when accessToken is not JWT-shaped (catches stray nonsense)", async () => {
+        authedSession();
+        const res = await POST(makeRequest({ accessToken: "not-a-jwt" }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(
+            /doesn't look like a Plaud access token/,
+        );
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("400s when accessToken's exp is in the past (UX hint, not security)", async () => {
+        authedSession();
+        const expiredSec = Math.floor(Date.now() / 1000) - 60;
+        const res = await POST(
+            makeRequest({ accessToken: makeJwt({ exp: expiredSec }) }),
+        );
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/already expired/);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("400s on a non-plaud.ai apiBase (SSRF guard)", async () => {
+        authedSession();
+        const futureSec = Math.floor(Date.now() / 1000) + 3600;
+        const res = await POST(
+            makeRequest({
+                accessToken: makeJwt({ exp: futureSec }),
+                apiBase: "https://evil.example.com",
+            }),
+        );
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/Invalid API base/);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("strips a leading 'Bearer ' if the user pasted the whole header value", async () => {
+        // Happy(ish) path: validate that we reach Plaud, then bail at
+        // /device/list (we have not configured a successful db chain).
+        authedSession();
+
+        // Failure on /user/me (best-effort) → fetchPlaudUserMeEmail returns
+        // null. Then listPlaudWorkspaces → 500 → swallowed. Then
+        // listDevices → 401 → throws → 400 user-facing error.
+        mockFetch.mockResolvedValue({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            headers: { get: () => null },
+            json: () => Promise.resolve({ status: 401, msg: "bad token" }),
+        });
+
+        const futureSec = Math.floor(Date.now() / 1000) + 3600;
+        const res = await POST(
+            makeRequest({
+                accessToken: `Bearer ${makeJwt({ exp: futureSec })}`,
+            }),
+        );
+
+        expect(res.status).toBe(400);
+        // The Plaud request used the unwrapped token (no double "Bearer ").
+        const calls = mockFetch.mock.calls;
+        expect(calls.length).toBeGreaterThan(0);
+        for (const [, init] of calls) {
+            const auth = (init?.headers as Record<string, string>)
+                ?.Authorization;
+            if (auth) {
+                expect(auth).toMatch(/^Bearer eyJ/); // single "Bearer ", JWT body starts with eyJ
+                expect(auth).not.toMatch(/Bearer Bearer/);
+            }
+        }
+    });
+});
+
+// ── Happy-path orchestration ────────────────────────────────────────────────
+
+describe("POST /api/plaud/auth/connect-token (happy path)", () => {
+    it("validates token via /device/list, encrypts, and upserts", async () => {
+        authedSession();
+
+        // Drizzle chain mock: select-from-where-limit returns [] (no
+        // existing connection), so we go down the insert branch. Same for
+        // each device.
+        const selectChain = {
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        };
+        (db.select as Mock).mockReturnValue(selectChain);
+
+        const insertValuesSpy = vi.fn().mockResolvedValue(undefined);
+        (db.insert as Mock).mockReturnValue({ values: insertValuesSpy });
+
+        // Plaud responses, in call order:
+        //   1. /user/me  → email enrichment (best-effort)
+        //   2. /team-app/workspaces/list → workspace discovery
+        //   3. /user-app/auth/workspace/token/<id> → mint WT
+        //   4. /device/list → end-to-end validation
+        mockFetch
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: () =>
+                    Promise.resolve({
+                        status: 0,
+                        data: { email: "Kacper@Example.com" },
+                    }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: () =>
+                    Promise.resolve({
+                        status: 0,
+                        data: {
+                            workspaces: [
+                                {
+                                    workspace_id: "ws_personal",
+                                    member_id: "mem_x",
+                                    name: "Personal",
+                                    role: "admin",
+                                    status: "active",
+                                    workspace_type: "0",
+                                },
+                            ],
+                        },
+                    }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: () =>
+                    Promise.resolve({
+                        status: 0,
+                        data: {
+                            status: 0,
+                            workspace_token: "wt.workspace.token",
+                            expires_in: 86400,
+                            wt_expires_at: 0,
+                            refresh_token: "refresh.token",
+                            refresh_expires_in: 2592000,
+                            refresh_expires_at: 0,
+                            workspace_id: "ws_personal",
+                            member_id: "mem_x",
+                            role: "admin",
+                        },
+                    }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: () =>
+                    Promise.resolve({
+                        status: 0,
+                        msg: "success",
+                        data_devices: [
+                            {
+                                sn: "SN-1",
+                                name: "My Plaud",
+                                model: "Note",
+                                version_number: 100,
+                            },
+                        ],
+                    }),
+            });
+
+        const futureSec = Math.floor(Date.now() / 1000) + 3600;
+        const res = await POST(
+            makeRequest({
+                accessToken: makeJwt({ exp: futureSec }),
+                apiBase: "https://api-euc1.plaud.ai",
+                source: "paste",
+            }),
+        );
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.success).toBe(true);
+        expect(body.devices).toHaveLength(1);
+
+        // Connection was inserted with the encrypted token and the lowercased
+        // email captured from /user/me.
+        expect(insertValuesSpy).toHaveBeenCalled();
+        const connectionInsert = insertValuesSpy.mock.calls.find((c) => {
+            const v = c[0];
+            return v && typeof v === "object" && "bearerToken" in v;
+        });
+        expect(connectionInsert).toBeTruthy();
+        const connRow = connectionInsert?.[0] as {
+            userId: string;
+            bearerToken: string;
+            apiBase: string;
+            plaudEmail: string | null;
+            workspaceId: string | null;
+        };
+        expect(connRow.userId).toBe(USER_ID);
+        expect(connRow.apiBase).toBe("https://api-euc1.plaud.ai");
+        expect(connRow.plaudEmail).toBe("kacper@example.com"); // lowercased
+        expect(connRow.workspaceId).toBe("ws_personal");
+        // bearerToken is encrypted, NOT the raw JWT.
+        expect(connRow.bearerToken).not.toContain("eyJ");
+
+        // Device row was inserted, scoped to this user.
+        const deviceInsert = insertValuesSpy.mock.calls.find((c) => {
+            const v = c[0];
+            return v && typeof v === "object" && "serialNumber" in v;
+        });
+        expect(deviceInsert).toBeTruthy();
+        expect(
+            (deviceInsert?.[0] as { serialNumber: string }).serialNumber,
+        ).toBe("SN-1");
+    });
+});


### PR DESCRIPTION
## Description

Adds end-to-end support for connecting Plaud accounts that were created via Google or Apple sign-in.

Plaud's email-OTP login signs users into a different account than Plaud's Google/Apple sign-in flow — even when both share the same email address. The OTP flow looks like it succeeds but sync returns zero recordings because the access token belongs to an empty shadow account, while the user's real recordings live under their SSO identity ([#65](https://github.com/openplaud/openplaud/issues/65)).

Real Sign in with Google / Apple from OpenPlaud's origin is structurally blocked by Google's authorized-origins policy on Plaud's OAuth client (`346186524912-…apps.googleusercontent.com`), confirmed by HAR capture of the upstream flow. This PR ships the only honest workaround that works today, on two tiers:

1. **Easy path** — a companion [openplaud/connector](https://github.com/openplaud/connector) browser extension (separate AGPL-3.0 repo, scaffolded and pushed in the same session) that bridges a logged-in `web.plaud.ai` session to the OpenPlaud connect screen. No copy-pasting, no devtools.
2. **Manual fallback** — paste an access token grabbed from a logged-in `web.plaud.ai` session with documented devtools steps. Same encryption + validation path as the OTP flow.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [x] Documentation update

## Related Issues

Fixes #65

## Changes Made

- New `POST /api/plaud/auth/connect-token` route. Validates JWT shape + `exp`, SSRF-guards `apiBase`, derives `plaudEmail` via best-effort `/user/me`, hands off to the shared persistence helper.
- Extract `persistPlaudConnection` from the verify route into `src/lib/plaud/persist-connection.ts`. OTP flow and paste-token flow now go through identical workspace discovery, end-to-end `/device/list` validation, AES-256-GCM encryption, and per-user-scoped upsert. OTP behaviour unchanged.
- Add `decodeAccessTokenExpiry` (UX-only JWT payload parse, no signature check) and `fetchPlaudUserMeEmail` (best-effort, swallows failures) helpers in `src/lib/plaud/auth.ts`.
- New shared `<PlaudConnectTabs />` component used by both the onboarding dialog and the standalone onboarding page. Three tabs:
  - **Sign in with Plaud** (default) — feature-detects `window.__openplaudConnector` (injected by the connector extension), shows install CTA otherwise.
  - **Email code** — existing OTP flow.
  - **Paste token** — manual fallback with step-by-step token-grab instructions and a region selector.
- Connector detection re-polls for ~10s after mount so installing the extension while the page is open Just Works.
- README gets a new "Signed up to Plaud with Google or Apple?" subsection covering both paths.
- CHANGELOG entry under `[Unreleased] → Added`.

No DB schema changes. No env var changes. No new dependencies.

## Screenshots (if applicable)

N/A — UI changes are tabbed-form additions matching the existing dialog/onboarding visual language. Verified locally via `pnpm dev`.

## Testing

### Test Environment

- OS: macOS
- Node version: per `package.json` engines (Bun for migrations, pnpm 10 for everything else)
- Browser: Chrome (for connector extension verification)

### Test Steps

```bash
pnpm format-and-lint   # 0 issues, 158 files checked
pnpm type-check        # 0 errors
pnpm test              # 64 passing, 3 skipped, 0 failing
```

New regression test `src/tests/regressions/65-paste-token.test.ts` (12 tests) covers:

- `decodeAccessTokenExpiry`: valid JWT → Date, malformed input → null, missing/non-numeric `exp` → null, base64url padding edge cases.
- Route validation: 401 without session, 400 on missing/malformed/expired token, 400 on non-`plaud.ai` `apiBase` (SSRF guard), `Bearer ` prefix stripped before forwarding to Plaud.
- Happy path: validates against `/device/list`, persists encrypted token (asserts the stored value is *not* the raw JWT), captures lowercased email from `/user/me`, upserts the device row scoped to the session user.

Existing regression suite (`66-eu-otp-permissions.test.ts`) still passes — verifies the OTP path's WT/UT behaviour is unchanged after the `persistPlaudConnection` refactor.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [x] No schema changes in this PR.

## Breaking Changes

None. The OTP flow continues to work for users whose Plaud account was created with email/password. The new connect screen defaults to "Sign in with Plaud" but degrades gracefully — when the connector extension isn't installed it surfaces the install CTA plus inline links to the email-code and paste-token tabs.

## Additional Notes

The connector extension lives in a sibling repo so it can ship on its own cadence (Chrome Web Store / Firefox AMO reviews are independent of OpenPlaud releases) and keep this repo's bundle/lint config clean. Initial scaffold commit at [openplaud/connector@b0abdab](https://github.com/openplaud/connector/commit/b0abdab). Outstanding before extension launch: real PNG icons (TODO in manifest), Chrome Web Store / AMO submission. The README install link currently points to the GitHub repo; once published it should swap to the store listing.

Architecture details for the bridge live in the connector repo's README. Token never crosses external infrastructure: `web.plaud.ai` → service worker → OpenPlaud tab → OpenPlaud server, all over local IPC except the final HTTPS POST to a host the user controls.

## For Reviewers

- **Security**: the new `/api/plaud/auth/connect-token` route reuses the exact same SSRF guard (`isValidPlaudApiUrl`), encryption (AES-256-GCM via `lib/encryption`), and userId-scoped UPSERT discipline as the OTP verify route. The `decodeAccessTokenExpiry` JWT decode is explicitly UX-only — Plaud is the verifier on the `/device/list` round-trip below it.
- **Refactor blast radius**: `verify/route.ts` shrunk by ~115 lines after extracting `persistPlaudConnection`. The `66-eu-otp-permissions.test.ts` regression test pins the WT/UT behaviour and still passes; that's the load-bearing assertion that the OTP path is unchanged.
- **UI**: the third tab (paste-token) is a real fallback, not just decorative. Walk through the disclosure copy and the region-selector UX — the goal was to make the manual path tractable for non-technical users without screen-recording a video.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for connecting Plaud accounts created with Google or Apple via a paste-token flow and a browser-extension bridge, plus a unified connect UI. Improves error handling and makes connection writes atomic for reliability. Fixes #65 where the OTP flow linked a shadow account and returned no recordings.

- **New Features**
  - `POST /api/plaud/auth/connect-token`: accepts a Plaud access token and region (`apiBase`), validates via `/device/list`, encrypts (AES-256-GCM), and upserts the connection; rejects non-JWT/expired tokens and non-`plaud.ai` API bases; best-effort email enrichment via `/user/me`.
  - `<PlaudConnectTabs />`: shared connect UI with three methods — “Sign in with Plaud” (via `openplaud/connector`), “Email code”, and “Paste token” with region selector and instructions; detects the connector with re-polling for ~10s; README and CHANGELOG updated.
  - Shared `persistPlaudConnection`: both OTP (`POST /api/plaud/auth/verify`) and paste-token flows use the same workspace discovery, end-to-end validation, encryption, and device upsert.

- **Bug Fixes**
  - Correct error classification: new `isUserActionablePlaudError` treats bare `Plaud API error: ...`, Plaud 4xx, and “Invalid API base” as 400; Plaud 5xx return 500; `persistPlaudConnection` re-throws original errors and both routes use the helper.
  - Prevent duplicate connections: wrap upsert + device reconciliation in a single `db.transaction()` guarded by a per-user `pg_advisory_xact_lock`.
  - Drop Plaud email from connect diagnostics to avoid PII in logs.
  - UI: replace escaped Unicode with literal characters in JSX.

<sup>Written for commit 640f264d199017f9435136172fc6b3368567f442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

