### PR TITLE
fix(storage): show instance storage type from env in Settings (fixes #77)

### DIFF
--- a/src/app/api/settings/storage/route.ts
+++ b/src/app/api/settings/storage/route.ts
@@ -1,8 +1,9 @@
 import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { recordings, storageConfig } from "@/db/schema";
+import { recordings } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { env } from "@/lib/env";
 
 // GET - Get storage usage and info
 export async function GET(request: Request) {
@@ -18,14 +19,7 @@ export async function GET(request: Request) {
             );
         }
 
-        // Get storage config
-        const [config] = await db
-            .select()
-            .from(storageConfig)
-            .where(eq(storageConfig.userId, session.user.id))
-            .limit(1);
-
-        const storageType = config?.storageType || "local";
+        const storageType = env.DEFAULT_STORAGE_TYPE;
 
         // Calculate storage usage
         const userRecordings = await db


### PR DESCRIPTION
## Summary

- Settings > Storage was always showing "Local" even when `DEFAULT_STORAGE_TYPE=s3` and recordings were going to S3/R2.
- `/api/settings/storage` was reading `storageType` from the per-user `storageConfig` table (legacy) and falling back to `"local"` when no row existed.
- Source it from `env.DEFAULT_STORAGE_TYPE` instead, matching the storage factory and the UI's "configured at the instance level" helper text.

Fixes #77

## Test plan

- [ ] Self-host with `DEFAULT_STORAGE_TYPE=s3` and valid S3/R2 creds; open Settings > Storage and confirm Type shows `s3`.
- [ ] Self-host with `DEFAULT_STORAGE_TYPE=local` (or unset); confirm Type shows `local`.
- [ ] Confirm storage usage (Total Size, Recordings) still renders correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settings > Storage now reads the instance storage type from `env.DEFAULT_STORAGE_TYPE` instead of the legacy per-user `storageConfig`, so S3/R2 setups display correctly. Fixes #77.

<sup>Written for commit e637fcc653aec157b105d8c30a3554ba154fa3bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

