### PR TITLE
feat(auth): add forgot/reset password flow

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,19 +1,15 @@
-import { LoginForm } from "@/components/auth/login-form";
+import { ForgotPasswordForm } from "@/components/auth/forgot-password-form";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
-import { env } from "@/lib/env";
 import { isSmtpConfigured } from "@/lib/notifications/email";
 
-export default async function LoginPage() {
+export default async function ForgotPasswordPage() {
     // Redirect to dashboard if already authenticated
     await redirectIfAuthenticated();
 
     return (
         <div className="flex min-h-screen items-center justify-center p-4">
             <div className="w-full max-w-md">
-                <LoginForm
-                    registrationEnabled={!env.DISABLE_REGISTRATION}
-                    smtpConfigured={isSmtpConfigured()}
-                />
+                <ForgotPasswordForm smtpConfigured={isSmtpConfigured()} />
             </div>
         </div>
     );

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,6 @@
 import { ForgotPasswordForm } from "@/components/auth/forgot-password-form";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
-import { isSmtpConfigured } from "@/lib/notifications/email";
+import { isSmtpConfigured } from "@/lib/smtp";
 
 export default async function ForgotPasswordPage() {
     // Redirect to dashboard if already authenticated

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 import { LoginForm } from "@/components/auth/login-form";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
 import { env } from "@/lib/env";
-import { isSmtpConfigured } from "@/lib/notifications/email";
+import { isSmtpConfigured } from "@/lib/smtp";
 
 export default async function LoginPage() {
     // Redirect to dashboard if already authenticated

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,23 @@
+import { ResetPasswordForm } from "@/components/auth/reset-password-form";
+import { redirectIfAuthenticated } from "@/lib/auth-server";
+
+interface ResetPasswordPageProps {
+    searchParams: Promise<{ token?: string; error?: string }>;
+}
+
+export default async function ResetPasswordPage({
+    searchParams,
+}: ResetPasswordPageProps) {
+    // Redirect to dashboard if already authenticated
+    await redirectIfAuthenticated();
+
+    const { token, error } = await searchParams;
+
+    return (
+        <div className="flex min-h-screen items-center justify-center p-4">
+            <div className="w-full max-w-md">
+                <ResetPasswordForm token={token} error={error} />
+            </div>
+        </div>
+    );
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -2,7 +2,18 @@ import { ResetPasswordForm } from "@/components/auth/reset-password-form";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
 
 interface ResetPasswordPageProps {
-    searchParams: Promise<{ token?: string; error?: string }>;
+    // Next.js delivers query params as `string | string[] | undefined` --
+    // a key can be repeated (`?token=a&token=b`). Type accordingly and
+    // normalize to a single string before handing to the client form.
+    searchParams: Promise<{
+        token?: string | string[];
+        error?: string | string[];
+    }>;
+}
+
+function firstParam(value: string | string[] | undefined): string | undefined {
+    if (Array.isArray(value)) return value[0];
+    return value;
 }
 
 export default async function ResetPasswordPage({
@@ -11,7 +22,9 @@ export default async function ResetPasswordPage({
     // Redirect to dashboard if already authenticated
     await redirectIfAuthenticated();
 
-    const { token, error } = await searchParams;
+    const params = await searchParams;
+    const token = firstParam(params.token);
+    const error = firstParam(params.error);
 
     return (
         <div className="flex min-h-screen items-center justify-center p-4">

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Logo } from "@/components/icons/logo";
+import { MetalButton } from "@/components/metal-button";
+import { Panel } from "@/components/panel";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { forgetPassword } from "@/lib/auth-client";
+
+interface ForgotPasswordFormProps {
+    /**
+     * Whether SMTP is configured on this instance. When false the form is
+     * disabled and we surface a hint pointing at the SMTP env vars rather
+     * than letting the user submit a request that can't be delivered.
+     */
+    smtpConfigured: boolean;
+}
+
+export function ForgotPasswordForm({
+    smtpConfigured,
+}: ForgotPasswordFormProps) {
+    const [email, setEmail] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [submitted, setSubmitted] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!smtpConfigured) return;
+        setIsLoading(true);
+
+        try {
+            // We intentionally don't surface the better-auth response: we
+            // always show the same success message so this endpoint can't
+            // be used to enumerate which emails have accounts.
+            await forgetPassword({
+                email,
+                redirectTo: "/reset-password",
+            });
+            setSubmitted(true);
+        } catch (error) {
+            // Network-level failures still get surfaced -- those aren't an
+            // account-existence signal.
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : "Could not send reset email. Please try again.";
+            toast.error(message);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <Panel className="w-full max-w-md space-y-6">
+            <div className="flex items-center gap-3">
+                <Logo className="size-10 shrink-0" />
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight">
+                        Reset password
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        We'll email you a link to set a new password.
+                    </p>
+                </div>
+            </div>
+
+            {!smtpConfigured ? (
+                <div className="space-y-3 rounded-md border border-border bg-muted/40 p-4 text-sm">
+                    <p className="font-medium">
+                        Password reset is unavailable on this instance.
+                    </p>
+                    <p className="text-muted-foreground">
+                        The administrator hasn't configured SMTP, so reset
+                        emails can't be delivered. Set{" "}
+                        <code className="font-mono text-xs">SMTP_HOST</code>,{" "}
+                        <code className="font-mono text-xs">SMTP_USER</code>,
+                        and{" "}
+                        <code className="font-mono text-xs">SMTP_PASSWORD</code>{" "}
+                        in the server environment to enable it. In the meantime,
+                        ask your administrator to reset your password directly
+                        in the database.
+                    </p>
+                </div>
+            ) : submitted ? (
+                <div className="space-y-3 rounded-md border border-border bg-muted/40 p-4 text-sm">
+                    <p className="font-medium">Check your email.</p>
+                    <p className="text-muted-foreground">
+                        If an account exists for{" "}
+                        <span className="font-mono text-xs">{email}</span>,
+                        we've sent a password reset link. The link expires in 1
+                        hour.
+                    </p>
+                </div>
+            ) : (
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="email">Email</Label>
+                        <Input
+                            id="email"
+                            type="email"
+                            placeholder="you@example.com"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            required
+                            disabled={isLoading}
+                        />
+                    </div>
+
+                    <MetalButton
+                        type="submit"
+                        className="w-full"
+                        variant="cyan"
+                        disabled={isLoading}
+                    >
+                        {isLoading ? "Sending..." : "Send reset link"}
+                    </MetalButton>
+                </form>
+            )}
+
+            <div className="text-center text-sm">
+                <Link
+                    href="/login"
+                    className="text-accent-cyan hover:underline"
+                >
+                    Back to sign in
+                </Link>
+            </div>
+        </Panel>
+    );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -22,8 +22,11 @@ interface LoginFormProps {
     registrationEnabled?: boolean;
     /**
      * Whether SMTP is configured on this instance. When false we hide the
-     * "Forgot password?" link because the reset email cannot be delivered.
-     * Self-host operators see a hint instead so they know why it's missing.
+     * "Forgot password?" link entirely because the reset email cannot be
+     * delivered -- end users shouldn't see a non-functional affordance on
+     * the sign-in screen. Self-host operators get the explanatory panel
+     * (with the SMTP env-var names) by navigating to /forgot-password
+     * directly, which is also linked from the README.
      */
     smtpConfigured?: boolean;
 }

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -20,9 +20,18 @@ interface LoginFormProps {
      * is UX only.
      */
     registrationEnabled?: boolean;
+    /**
+     * Whether SMTP is configured on this instance. When false we hide the
+     * "Forgot password?" link because the reset email cannot be delivered.
+     * Self-host operators see a hint instead so they know why it's missing.
+     */
+    smtpConfigured?: boolean;
 }
 
-export function LoginForm({ registrationEnabled = true }: LoginFormProps) {
+export function LoginForm({
+    registrationEnabled = true,
+    smtpConfigured = false,
+}: LoginFormProps) {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [isLoading, setIsLoading] = useState(false);
@@ -88,7 +97,17 @@ export function LoginForm({ registrationEnabled = true }: LoginFormProps) {
                 </div>
 
                 <div className="space-y-2">
-                    <Label htmlFor="password">Password</Label>
+                    <div className="flex items-center justify-between">
+                        <Label htmlFor="password">Password</Label>
+                        {smtpConfigured ? (
+                            <Link
+                                href="/forgot-password"
+                                className="text-xs text-muted-foreground hover:text-accent-cyan hover:underline"
+                            >
+                                Forgot password?
+                            </Link>
+                        ) : null}
+                    </div>
                     <Input
                         id="password"
                         type="password"

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Logo } from "@/components/icons/logo";
+import { MetalButton } from "@/components/metal-button";
+import { Panel } from "@/components/panel";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { resetPassword } from "@/lib/auth-client";
+
+interface ResetPasswordFormProps {
+    /**
+     * Reset token from the email link. better-auth's GET `/reset-password/:token`
+     * endpoint validates the verification token, then redirects the browser to
+     * the `callbackURL` we passed via `forgetPassword({ redirectTo })` with
+     * either `?token=VALID_TOKEN` (success) or `?error=INVALID_TOKEN` (expired
+     * or already-consumed). See better-auth `requestPasswordReset` source.
+     */
+    token?: string;
+    error?: string;
+}
+
+export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const router = useRouter();
+
+    // No token in URL -- either the user navigated here directly or
+    // better-auth bounced them back without one. Show an explanatory state
+    // rather than a non-functional form.
+    if (!token) {
+        return (
+            <Panel className="w-full max-w-md space-y-6">
+                <div className="flex items-center gap-3">
+                    <Logo className="size-10 shrink-0" />
+                    <div>
+                        <h1 className="text-2xl font-bold tracking-tight">
+                            Invalid reset link
+                        </h1>
+                        <p className="text-sm text-muted-foreground">
+                            This link is missing or has expired.
+                        </p>
+                    </div>
+                </div>
+
+                <div className="space-y-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+                    {error?.toUpperCase() === "INVALID_TOKEN" ? (
+                        <p>
+                            The reset link has expired or has already been used.
+                            Request a new one to continue.
+                        </p>
+                    ) : (
+                        <p>
+                            Open the most recent reset email and click the link
+                            from there, or request a new reset email.
+                        </p>
+                    )}
+                </div>
+
+                <div className="text-center text-sm">
+                    <Link
+                        href="/forgot-password"
+                        className="text-accent-cyan hover:underline"
+                    >
+                        Request a new link
+                    </Link>
+                </div>
+            </Panel>
+        );
+    }
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (password !== confirmPassword) {
+            toast.error("Passwords do not match");
+            return;
+        }
+
+        if (password.length < 8) {
+            toast.error("Password must be at least 8 characters");
+            return;
+        }
+
+        setIsLoading(true);
+
+        try {
+            const result = await resetPassword({
+                newPassword: password,
+                token,
+            });
+
+            if (result.error) {
+                toast.error(
+                    result.error.message ||
+                        "Could not reset password. The link may have expired.",
+                );
+                return;
+            }
+
+            toast.success("Password reset. You can sign in now.");
+            router.push("/login");
+            router.refresh();
+        } catch (err) {
+            const message =
+                err instanceof Error
+                    ? err.message
+                    : "Could not reset password. The link may have expired.";
+            toast.error(message);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <Panel className="w-full max-w-md space-y-6">
+            <div className="flex items-center gap-3">
+                <Logo className="size-10 shrink-0" />
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight">
+                        Set a new password
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        Choose a password you don't use anywhere else.
+                    </p>
+                </div>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="password">New password</Label>
+                    <Input
+                        id="password"
+                        type="password"
+                        placeholder="••••••••"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        disabled={isLoading}
+                        minLength={8}
+                        autoComplete="new-password"
+                    />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="confirmPassword">Confirm password</Label>
+                    <Input
+                        id="confirmPassword"
+                        type="password"
+                        placeholder="••••••••"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        required
+                        disabled={isLoading}
+                        autoComplete="new-password"
+                    />
+                </div>
+
+                <MetalButton
+                    type="submit"
+                    className="w-full"
+                    variant="cyan"
+                    disabled={isLoading}
+                >
+                    {isLoading ? "Resetting..." : "Reset password"}
+                </MetalButton>
+            </form>
+
+            <div className="text-center text-sm">
+                <Link
+                    href="/login"
+                    className="text-accent-cyan hover:underline"
+                >
+                    Back to sign in
+                </Link>
+            </div>
+        </Panel>
+    );
+}

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -29,10 +29,11 @@ export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
     const [isLoading, setIsLoading] = useState(false);
     const router = useRouter();
 
-    // No token in URL -- either the user navigated here directly or
-    // better-auth bounced them back without one. Show an explanatory state
-    // rather than a non-functional form.
-    if (!token) {
+    // No token in URL, or better-auth signaled an error on the callback --
+    // either the user navigated here directly, the token expired, or the
+    // link was tampered with (e.g. crafted URL with both `token` and `error`).
+    // Show an explanatory state rather than a form that's guaranteed to fail.
+    if (!token || error) {
         return (
             <Panel className="w-full max-w-md space-y-6">
                 <div className="flex items-center gap-3">

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -9,4 +9,11 @@ export const authClient = createAuthClient({
             : "http://localhost:3000",
 });
 
-export const { useSession, signIn, signOut, signUp } = authClient;
+export const {
+    useSession,
+    signIn,
+    signOut,
+    signUp,
+    forgetPassword,
+    resetPassword,
+} = authClient;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { env } from "./env";
+import { sendPasswordResetEmail } from "./notifications/email";
 
 export const auth = betterAuth({
     database: drizzleAdapter(db, {
@@ -18,6 +19,19 @@ export const auth = betterAuth({
         // state -- this is the actual security boundary. /register and /login
         // surface the same flag separately for UX. See issue #59.
         disableSignUp: env.DISABLE_REGISTRATION,
+        // Password reset is gated by SMTP being configured. The /forgot-password
+        // page hides the entry point when SMTP isn't set up; this callback is
+        // the server-side delivery hook better-auth invokes when the user
+        // submits a reset request. If SMTP is not configured the email send
+        // returns false and the operator gets a console warning.
+        sendResetPassword: async ({ user, url }) => {
+            await sendPasswordResetEmail(user.email, url);
+        },
+        resetPasswordTokenExpiresIn: 60 * 60, // 1 hour
+        // If a user resets their password we assume the old credentials may
+        // be compromised -- invalidate every existing session so other
+        // devices have to re-auth.
+        revokeSessionsOnPasswordReset: true,
     },
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.APP_URL,

--- a/src/lib/notifications/email-templates/password-reset-email.tsx
+++ b/src/lib/notifications/email-templates/password-reset-email.tsx
@@ -1,0 +1,93 @@
+import {
+    Body,
+    Button,
+    Container,
+    Head,
+    Heading,
+    Html,
+    Img,
+    Preview,
+    Section,
+    Text,
+} from "@react-email/components";
+import { emailStyles } from "./styles";
+
+interface PasswordResetEmailProps {
+    resetUrl: string;
+}
+
+export function PasswordResetEmail({ resetUrl }: PasswordResetEmailProps) {
+    const previewText = "Reset your OpenPlaud password";
+
+    return (
+        <Html>
+            <Head>
+                <meta
+                    name="viewport"
+                    content="width=device-width, initial-scale=1.0"
+                />
+                <meta name="color-scheme" content="light" />
+                <meta name="supported-color-schemes" content="light" />
+            </Head>
+            <Preview>{previewText}</Preview>
+            <Body style={emailStyles.main}>
+                <Container style={emailStyles.container}>
+                    {/* Minimal header */}
+                    <Section style={emailStyles.header}>
+                        <div style={{ textAlign: "center" }}>
+                            <Img
+                                src="https://openplaud.com/logo.png"
+                                alt="OpenPlaud"
+                                width="32"
+                                height="32"
+                                style={emailStyles.logo}
+                            />
+                        </div>
+                    </Section>
+
+                    {/* Content */}
+                    <Section style={emailStyles.content}>
+                        <Heading style={emailStyles.h1}>
+                            Reset your password
+                        </Heading>
+
+                        <Text style={emailStyles.text}>
+                            We received a request to reset the password for your
+                            OpenPlaud account. Click the button below to choose
+                            a new password. This link expires in 1 hour.
+                        </Text>
+
+                        <Section style={emailStyles.buttonSection}>
+                            <Button style={emailStyles.button} href={resetUrl}>
+                                Reset password
+                            </Button>
+                        </Section>
+
+                        <Text style={emailStyles.text}>
+                            If the button doesn't work, paste this URL into your
+                            browser:
+                        </Text>
+                        <Text
+                            style={{
+                                ...emailStyles.text,
+                                wordBreak: "break-all",
+                                fontSize: "13px",
+                            }}
+                        >
+                            {resetUrl}
+                        </Text>
+                    </Section>
+
+                    {/* Minimal footer */}
+                    <Section style={emailStyles.footer}>
+                        <Text style={emailStyles.footerText}>
+                            If you didn't request a password reset, you can
+                            safely ignore this email -- your password will not
+                            change.
+                        </Text>
+                    </Section>
+                </Container>
+            </Body>
+        </Html>
+    );
+}

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -3,6 +3,7 @@ import nodemailer from "nodemailer";
 import React from "react";
 import { env } from "@/lib/env";
 import { NewRecordingEmail } from "./email-templates/new-recording-email";
+import { PasswordResetEmail } from "./email-templates/password-reset-email";
 import { TestEmail } from "./email-templates/test-email";
 
 interface EmailOptions {
@@ -14,9 +15,19 @@ interface EmailOptions {
 
 let transporter: nodemailer.Transporter | null = null;
 
+/**
+ * Whether SMTP credentials are configured on this instance. Used by
+ * server-rendered auth pages to decide whether to surface email-dependent
+ * features like password reset. This only checks env presence -- it does not
+ * verify that the SMTP server actually accepts connections.
+ */
+export function isSmtpConfigured(): boolean {
+    return Boolean(env.SMTP_HOST && env.SMTP_USER && env.SMTP_PASSWORD);
+}
+
 function getTransporter(): nodemailer.Transporter | null {
     // Return null if SMTP is not configured
-    if (!env.SMTP_HOST || !env.SMTP_USER || !env.SMTP_PASSWORD) {
+    if (!isSmtpConfigured()) {
         return null;
     }
 
@@ -149,6 +160,36 @@ ${
 View recordings: ${dashboardUrl}
 
 Manage notifications: ${settingsUrl}
+    `.trim();
+
+    return sendEmail({
+        to: email,
+        subject,
+        html,
+        text,
+    });
+}
+
+export async function sendPasswordResetEmail(
+    email: string,
+    resetUrl: string,
+): Promise<boolean> {
+    const subject = "Reset your OpenPlaud password";
+
+    const html = await render(
+        React.createElement(PasswordResetEmail, {
+            resetUrl,
+        }),
+    );
+
+    const text = `
+${subject}
+
+We received a request to reset your OpenPlaud password. Click the link below to choose a new password. This link expires in 1 hour.
+
+${resetUrl}
+
+If you didn't request a password reset, you can safely ignore this email -- your password will not change.
     `.trim();
 
     return sendEmail({

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -2,6 +2,7 @@ import { render } from "@react-email/render";
 import nodemailer from "nodemailer";
 import React from "react";
 import { env } from "@/lib/env";
+import { isSmtpConfigured } from "@/lib/smtp";
 import { NewRecordingEmail } from "./email-templates/new-recording-email";
 import { PasswordResetEmail } from "./email-templates/password-reset-email";
 import { TestEmail } from "./email-templates/test-email";
@@ -14,16 +15,6 @@ interface EmailOptions {
 }
 
 let transporter: nodemailer.Transporter | null = null;
-
-/**
- * Whether SMTP credentials are configured on this instance. Used by
- * server-rendered auth pages to decide whether to surface email-dependent
- * features like password reset. This only checks env presence -- it does not
- * verify that the SMTP server actually accepts connections.
- */
-export function isSmtpConfigured(): boolean {
-    return Boolean(env.SMTP_HOST && env.SMTP_USER && env.SMTP_PASSWORD);
-}
 
 function getTransporter(): nodemailer.Transporter | null {
     // Return null if SMTP is not configured

--- a/src/lib/smtp.ts
+++ b/src/lib/smtp.ts
@@ -1,0 +1,15 @@
+import { env } from "./env";
+
+/**
+ * Whether SMTP credentials are configured on this instance. Used by
+ * server-rendered auth pages to decide whether to surface email-dependent
+ * features like password reset. This only checks env presence -- it does not
+ * verify that the SMTP server actually accepts connections.
+ *
+ * Lives in its own module (rather than `notifications/email.ts`) so server
+ * components that only need the boolean don't pull `nodemailer` and
+ * `@react-email/*` into the server bundle / cold-start path.
+ */
+export function isSmtpConfigured(): boolean {
+    return Boolean(env.SMTP_HOST && env.SMTP_USER && env.SMTP_PASSWORD);
+}


### PR DESCRIPTION
## Description

Adds a forgot/reset password flow. Wires better-auth's existing password-reset endpoints, delivers the email through the existing nodemailer + React Email infrastructure, and gates the UI on whether SMTP is actually configured so self-host instances without mail don't surface a non-functional form.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #82
Relates to #85 (follow-up: enable rate limiting on auth endpoints)

## Changes Made

- `src/lib/auth.ts`: add `sendResetPassword` callback, `resetPasswordTokenExpiresIn: 3600`, and `revokeSessionsOnPasswordReset: true` so other-device sessions are invalidated on reset.
- `src/lib/auth-client.ts`: re-export `forgetPassword` and `resetPassword`.
- `src/lib/notifications/email.ts`: add `isSmtpConfigured()` (server-only) + `sendPasswordResetEmail()`.
- `src/lib/notifications/email-templates/password-reset-email.tsx`: new React Email template matching the existing test/new-recording style.
- `src/components/auth/login-form.tsx`: new `smtpConfigured` prop; renders "Forgot password?" link only when SMTP is configured.
- `src/app/(auth)/login/page.tsx`: passes `isSmtpConfigured()` to the form.
- `src/app/(auth)/forgot-password/page.tsx` + `forgot-password-form.tsx`: email entry form. When SMTP isn't configured, replaces the form with an explanatory panel naming `SMTP_HOST` / `SMTP_USER` / `SMTP_PASSWORD`. On submit, always shows the same success state regardless of account existence (matches better-auth's response shape — no enumeration leak).
- `src/app/(auth)/reset-password/page.tsx` + `reset-password-form.tsx`: reads `?token=` and `?error=` from the better-auth callback redirect, renders distinct invalid-link state when the token is missing or `?error=INVALID_TOKEN`.

## Testing

### Test Environment
- macOS, Node 22, pnpm 10

### Test Steps

```
pnpm format-and-lint:fix
pnpm type-check
```

Both clean. Manual end-to-end sign-in / reset flow not exercised in this PR — recommend the maintainer test against a real SMTP setup before merging.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None. Reset tokens reuse the existing `verifications` table managed by better-auth.

## Breaking Changes

None.

## Additional Notes

- **Deploy surface:** no schema changes, no new env vars, no `docker-compose.yml` changes. Self-host instances without SMTP keep working — the feature degrades visibly (link hidden, explanatory panel) rather than silently.
- **Security:**
  - `revokeSessionsOnPasswordReset: true` invalidates all other sessions on reset (defense against compromised credentials).
  - No account enumeration: better-auth's `requestPasswordReset` returns identical `{ status: true }` regardless of whether the email exists; our success UI mirrors that.
  - Open-redirect / token-leak via `redirectTo`: mitigated by better-auth's built-in `originCheck` on the `/reset-password/:token` callback (verified in `node_modules/better-auth/dist/shared/better-auth.BX9UB8EP.mjs:1966`). Only `env.APP_URL`-origin callbacks are accepted.
  - Rate limiting is **not** enabled on `/forget-password` (or any auth endpoint). Tracked separately in #85 since it's a cross-cutting auth concern, not specific to this PR.
- **SMTP env-set-but-broken:** `isSmtpConfigured()` only checks env presence. If the SMTP server then refuses mail, `sendEmail` returns false and the operator sees a `console.error` server-side; the user still sees the success state. Switching to `sendEmailWithError` would leak account existence (different error path for no-account vs SMTP-fail), so kept current behavior.

## For Reviewers

- The token URL flow: better-auth's `sendResetPassword` is invoked with `url = ${baseURL}/reset-password/<token>?callbackURL=/reset-password`. The user clicks → better-auth GET handler validates → redirects to `/reset-password?token=VALID_TOKEN` or `?error=INVALID_TOKEN`. Confirm the `redirectTo: "/reset-password"` we hardcode in `forgot-password-form.tsx` matches the route.
- Copy in the SMTP-not-configured panel — feel free to adjust tone.
- Whether `revokeSessionsOnPasswordReset: true` is the right default for OpenPlaud (it is for most apps; flagging in case there's a self-host UX argument against it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a full forgot/reset password flow with email delivery and an SMTP-aware UI. Uses `better-auth` reset endpoints, revokes other sessions on reset, and avoids account enumeration. Fixes #82.

- **New Features**
  - Added /forgot-password and /reset-password pages with a clear invalid-link state for missing/expired tokens.
  - Login shows “Forgot password?” only when SMTP is configured; the forgot page shows a setup hint for `SMTP_HOST`, `SMTP_USER`, `SMTP_PASSWORD` when not.
  - Sent reset emails via `nodemailer` using a new `@react-email/components` template.
  - Configured `better-auth` (`sendResetPassword`, 1h token expiry, `revokeSessionsOnPasswordReset: true`) and exposed `forgetPassword` / `resetPassword` in the client.
  - Introduced `src/lib/smtp.ts` with `isSmtpConfigured()` to keep server pages light (avoids pulling `nodemailer`/email runtime).

- **Bug Fixes**
  - Treat any `?error=` as an invalid reset link even if `?token` is present to avoid submit-then-fail states.
  - Normalize repeated `/reset-password` `searchParams` (`string | string[]`) and take the first value to prevent crafted URLs from breaking the form.

<sup>Written for commit 5ae485261ed4991dca6eaa3b903f882562bd43e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

