### PR TITLE
feat(transcription): background transcription worker

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
     const transcriptionMap = new Map(
         userTranscriptions.map((t) => [
             t.recordingId,
-            { text: t.text, language: t.language || undefined },
+            { text: t.text ?? undefined, language: t.language || undefined },
         ]),
     );
 

--- a/src/app/(app)/recordings/[id]/page.tsx
+++ b/src/app/(app)/recordings/[id]/page.tsx
@@ -49,10 +49,11 @@ export default async function RecordingDetailPage({
             transcription={
                 transcription
                     ? {
-                          text: transcription.text,
+                          text: transcription.text ?? undefined,
                           detectedLanguage:
                               transcription.detectedLanguage || undefined,
                           transcriptionType: transcription.transcriptionType,
+                          status: transcription.status ?? undefined,
                       }
                     : undefined
             }

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -171,10 +171,11 @@ export async function POST(
 
         // Truncate transcription if too long
         const maxLength = 8000;
+        const transcriptionText = transcription.text || "";
         const truncatedTranscription =
-            transcription.text.length > maxLength
-                ? `${transcription.text.substring(0, maxLength)}...`
-                : transcription.text;
+            transcriptionText.length > maxLength
+                ? `${transcriptionText.substring(0, maxLength)}...`
+                : transcriptionText;
 
         // Apply AI output language directive (if configured) via the system
         // message rather than the user prompt. This separates concerns: the

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -11,6 +11,165 @@ import {
     parseTranscriptionResponse,
 } from "@/lib/transcription/format";
 
+async function runTranscription(
+    recordingId: string,
+    userId: string,
+    credentials: typeof apiCredentials.$inferSelect,
+    overrideModel: string | undefined,
+    recordingStoragePath: string,
+    recordingFilename: string,
+) {
+    console.log(
+        `[runTranscription] Starting for recording ${recordingId} with provider ${credentials.provider}`,
+    );
+
+    const apiKey = decrypt(credentials.apiKey);
+
+    const storage = await createUserStorageProvider(userId);
+    const audioBuffer = await storage.downloadFile(recordingStoragePath);
+
+    const header = new Uint8Array(audioBuffer.slice(0, 4));
+    const isOgg =
+        header[0] === 0x4f &&
+        header[1] === 0x67 &&
+        header[2] === 0x67 &&
+        header[3] === 0x53;
+
+    const ext = isOgg ? "ogg" : recordingStoragePath.split(".").pop() || "mp3";
+    const contentType = isOgg
+        ? "audio/ogg"
+        : recordingStoragePath.endsWith(".mp3")
+          ? "audio/mpeg"
+          : "audio/opus";
+
+    const filename = recordingFilename.match(/\.\w{2,4}$/)
+        ? recordingFilename
+        : `${recordingFilename}.${ext}`;
+
+    const model = overrideModel || credentials.defaultModel || "whisper-1";
+
+    const openai = new OpenAI({
+        apiKey,
+        baseURL: credentials.baseUrl || undefined,
+    });
+    const audioFile = new File([new Uint8Array(audioBuffer)], filename, {
+        type: contentType,
+    });
+    const responseFormat = getResponseFormat(model);
+    const transcription = await openai.audio.transcriptions.create({
+        file: audioFile,
+        model,
+        response_format: responseFormat,
+    });
+    const parsed = parseTranscriptionResponse(
+        transcription,
+        responseFormat,
+    );
+    const transcriptionText = parsed.text;
+    const detectedLanguage = parsed.detectedLanguage;
+
+    await db.transaction(async (tx) => {
+        const [stillActive] = await tx
+            .select({ deletedAt: recordings.deletedAt })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, recordingId),
+                    eq(recordings.userId, userId),
+                ),
+            )
+            .for("update")
+            .limit(1);
+
+        if (!stillActive || stillActive.deletedAt) return;
+
+        const [existing] = await tx
+            .select()
+            .from(transcriptions)
+            .where(eq(transcriptions.recordingId, recordingId))
+            .limit(1);
+
+        if (!existing || existing.status !== "processing") return;
+
+        if (existing) {
+            await tx
+                .update(transcriptions)
+                .set({
+                    text: transcriptionText,
+                    detectedLanguage,
+                    status: "completed",
+                    errorMessage: null,
+                    transcriptionType: "server",
+                    provider: credentials.provider,
+                    model,
+                })
+                .where(eq(transcriptions.id, existing.id));
+        } else {
+            await tx.insert(transcriptions).values({
+                recordingId,
+                userId,
+                text: transcriptionText,
+                detectedLanguage,
+                status: "completed",
+                transcriptionType: "server",
+                provider: credentials.provider,
+                model,
+            });
+        }
+    });
+}
+
+export async function GET(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session?.user) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        const { id } = await params;
+
+        const [transcription] = await db
+            .select({
+                text: transcriptions.text,
+                detectedLanguage: transcriptions.detectedLanguage,
+                transcriptionType: transcriptions.transcriptionType,
+                status: transcriptions.status,
+                errorMessage: transcriptions.errorMessage,
+            })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.recordingId, id),
+                    eq(transcriptions.userId, session.user.id),
+                ),
+            )
+            .limit(1);
+
+        return NextResponse.json({
+            transcription: transcription?.text || null,
+            detectedLanguage: transcription?.detectedLanguage || null,
+            transcriptionType: transcription?.transcriptionType || null,
+            status: transcription?.status || null,
+            errorMessage: transcription?.errorMessage || null,
+        });
+    } catch (error) {
+        console.error("Error fetching transcription status:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch status" },
+            { status: 500 },
+        );
+    }
+}
+
 export async function POST(
     request: Request,
     { params }: { params: Promise<{ id: string }> },
@@ -51,8 +210,6 @@ export async function POST(
             );
         }
 
-        // Get user's transcription API credentials
-        // If a specific provider was requested, look it up by ID
         const [credentials] = overrideProviderId
             ? await db
                   .select()
@@ -82,137 +239,126 @@ export async function POST(
             );
         }
 
-        // Decrypt API key
-        const apiKey = decrypt(credentials.apiKey);
-
-        // Create OpenAI client (works with all OpenAI-compatible APIs)
-        const openai = new OpenAI({
-            apiKey,
-            baseURL: credentials.baseUrl || undefined,
-        });
-
-        // Get storage provider and download audio
-        const storage = await createUserStorageProvider(session.user.id);
-        const audioBuffer = await storage.downloadFile(recording.storagePath);
-
-        // Create a File object for the transcription API
-        // Detect actual audio format from magic bytes since Plaud files
-        // may have .mp3 extension but contain OGG/Opus data
-        const header = new Uint8Array(audioBuffer.slice(0, 4));
-        const isOgg =
-            header[0] === 0x4f &&
-            header[1] === 0x67 &&
-            header[2] === 0x67 &&
-            header[3] === 0x53; // "OggS"
-
-        const ext = isOgg
-            ? "ogg"
-            : recording.storagePath.split(".").pop() || "mp3";
-        const contentType = isOgg
-            ? "audio/ogg"
-            : recording.storagePath.endsWith(".mp3")
-              ? "audio/mpeg"
-              : "audio/opus";
-
-        // Ensure filename has a valid extension so the API can detect the format
-        const filename = recording.filename.match(/\.\w{2,4}$/)
-            ? recording.filename
-            : `${recording.filename}.${ext}`;
-
-        const audioFile = new File([new Uint8Array(audioBuffer)], filename, {
-            type: contentType,
-        });
-
         const model = overrideModel || credentials.defaultModel || "whisper-1";
-        const responseFormat = getResponseFormat(model);
 
-        const transcription = await openai.audio.transcriptions.create({
-            file: audioFile,
-            model,
-            response_format: responseFormat,
-        });
+        const [existing] = await db
+            .select()
+            .from(transcriptions)
+            .where(eq(transcriptions.recordingId, id))
+            .limit(1);
 
-        const { text: transcriptionText, detectedLanguage } =
-            parseTranscriptionResponse(transcription, responseFormat);
-
-        // Atomic tombstone re-check + transcription upsert.
-        //
-        // The user may have deleted the recording while the (long-running)
-        // provider call was in flight. To prevent a delete that lands
-        // *between* our re-check and our upsert from being silently undone,
-        // we run both inside a single transaction that takes a row-level
-        // write lock (`FOR UPDATE`) on the recording. The DELETE handler's
-        // transaction acquires the same lock via its `UPDATE recordings`
-        // tombstone write, so the two transactions serialize: either we
-        // see `deletedAt` set and abort, or our upsert commits before
-        // DELETE runs and DELETE then cleans up our row inside its own tx.
-        // See PR #72.
-        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
-        try {
-            await db.transaction(async (tx) => {
-                const [stillActive] = await tx
-                    .select({ deletedAt: recordings.deletedAt })
-                    .from(recordings)
-                    .where(
-                        and(
-                            eq(recordings.id, id),
-                            eq(recordings.userId, session.user.id),
-                        ),
-                    )
-                    .for("update")
-                    .limit(1);
-
-                if (!stillActive || stillActive.deletedAt) {
-                    throw RECORDING_TOMBSTONED;
-                }
-
-                const [existingTranscription] = await tx
-                    .select()
-                    .from(transcriptions)
-                    .where(eq(transcriptions.recordingId, id))
-                    .limit(1);
-
-                if (existingTranscription) {
-                    await tx
-                        .update(transcriptions)
-                        .set({
-                            text: transcriptionText,
-                            detectedLanguage,
-                            transcriptionType: "server",
-                            provider: credentials.provider,
-                            model,
-                        })
-                        .where(eq(transcriptions.id, existingTranscription.id));
-                } else {
-                    await tx.insert(transcriptions).values({
-                        recordingId: id,
-                        userId: session.user.id,
-                        text: transcriptionText,
-                        detectedLanguage,
-                        transcriptionType: "server",
-                        provider: credentials.provider,
-                        model,
-                    });
-                }
+        if (existing) {
+            await db
+                .update(transcriptions)
+                .set({
+                    text: "",
+                    status: "processing",
+                    errorMessage: null,
+                    transcriptionType: "server",
+                    provider: credentials.provider,
+                    model,
+                    detectedLanguage: null,
+                })
+                .where(eq(transcriptions.id, existing.id));
+        } else {
+            await db.insert(transcriptions).values({
+                recordingId: id,
+                userId: session.user.id,
+                text: "",
+                status: "processing",
+                transcriptionType: "server",
+                provider: credentials.provider,
+                model,
             });
-        } catch (txError) {
-            if (txError === RECORDING_TOMBSTONED) {
-                return NextResponse.json(
-                    { error: "Recording was deleted" },
-                    { status: 410 },
-                );
-            }
-            throw txError;
         }
 
-        return NextResponse.json({
-            transcription: transcriptionText,
-            detectedLanguage,
-        });
+        console.log(
+            `[transcribe] Starting background transcription for recording ${id}`,
+        );
+
+        void runTranscription(
+            id,
+            session.user.id,
+            credentials,
+            overrideModel,
+            recording.storagePath,
+            recording.filename,
+        ).then(
+            () =>
+                console.log(
+                    `[transcribe] Background transcription completed for recording ${id}`,
+                ),
+            (error) => {
+                console.error(
+                    "Background transcription failed:",
+                    error,
+                );
+                db.update(transcriptions)
+                    .set({
+                        status: "failed",
+                        errorMessage:
+                            error instanceof Error
+                                ? error.message
+                                : "Transcription failed",
+                    })
+                    .where(
+                        and(
+                            eq(transcriptions.recordingId, id),
+                            eq(transcriptions.userId, session.user.id),
+                        ),
+                    )
+                    .execute()
+                    .catch((updateError) =>
+                        console.error(
+                            "Failed to update error status:",
+                            updateError,
+                        ),
+                    );
+            },
+        );
+
+        return NextResponse.json({ status: "processing" });
     } catch (error) {
-        console.error("Error transcribing:", error);
+        console.error("Error starting transcription:", error);
+        const message =
+            error instanceof Error
+                ? error.message
+                : "Failed to start transcription";
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    request: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    try {
+        const session = await auth.api.getSession({
+            headers: request.headers,
+        });
+
+        if (!session?.user) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const { id } = await params;
+
+        await db
+            .update(transcriptions)
+            .set({ text: "", status: "" })
+            .where(
+                and(
+                    eq(transcriptions.recordingId, id),
+                    eq(transcriptions.userId, session.user.id),
+                    eq(transcriptions.status, "processing"),
+                ),
+            );
+
+        return NextResponse.json({ status: "cancelled" });
+    } catch (error) {
+        console.error("Error cancelling transcription:", error);
         return NextResponse.json(
-            { error: "Failed to transcribe recording" },
+            { error: "Failed to cancel" },
             { status: 500 },
         );
     }

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -43,6 +43,7 @@ interface TranscriptionPanelProps {
     transcription?: Transcription;
     isTranscribing: boolean;
     onTranscribe: () => void;
+    onCancel?: () => void;
 }
 
 export function TranscriptionPanel({
@@ -50,6 +51,7 @@ export function TranscriptionPanel({
     transcription,
     isTranscribing,
     onTranscribe,
+    onCancel,
 }: TranscriptionPanelProps) {
     const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
     const [isSummarizing, setIsSummarizing] = useState(false);
@@ -177,9 +179,18 @@ export function TranscriptionPanel({
                     {isTranscribing ? (
                         <div className="flex flex-col items-center justify-center py-12">
                             <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full mb-4" />
-                            <p className="text-sm text-muted-foreground">
+                            <p className="text-sm text-muted-foreground mb-4">
                                 Transcribing audio...
                             </p>
+                            {onCancel && (
+                                <Button
+                                    onClick={onCancel}
+                                    variant="outline"
+                                    size="sm"
+                                >
+                                    Cancel
+                                </Button>
+                            )}
                         </div>
                     ) : transcription?.text ? (
                         <div className="space-y-4">

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -123,6 +123,8 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
         const ct = transcriptions.get(recordingId);
         if (ct?.text === undefined || ct?.text === "") {
             const controller = new AbortController();
+            let interval: ReturnType<typeof setInterval> | null = null;
+
             fetch(`/api/recordings/${recordingId}/transcribe`, {
                 signal: controller.signal,
             })
@@ -130,7 +132,7 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                 .then((data) => {
                     if (data.status === "processing") {
                         markTranscribing(recordingId);
-                        const interval = setInterval(async () => {
+                        interval = setInterval(async () => {
                             try {
                                 const statusRes = await fetch(
                                     `/api/recordings/${recordingId}/transcribe`,
@@ -139,12 +141,12 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                                 const statusData = await statusRes.json();
 
                                 if (statusData.status === "completed") {
-                                    clearInterval(interval);
+                                    if (interval) clearInterval(interval);
                                     unmarkTranscribing(recordingId);
                                     toast.success("Transcription complete");
                                     router.refresh();
                                 } else if (statusData.status === "failed") {
-                                    clearInterval(interval);
+                                    if (interval) clearInterval(interval);
                                     unmarkTranscribing(recordingId);
                                     toast.error(
                                         statusData.errorMessage ||
@@ -157,7 +159,11 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                     }
                 })
                 .catch(() => {});
-            return () => controller.abort();
+
+            return () => {
+                controller.abort();
+                if (interval) clearInterval(interval);
+            };
         }
     }, [currentRecording?.id]);
 
@@ -304,13 +310,13 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
     const handleCancel = useCallback(async () => {
         if (!currentRecording) return;
         try {
-            await fetch(
+            const res = await fetch(
                 `/api/recordings/${currentRecording.id}/transcribe`,
                 { method: "DELETE" },
             );
+            if (res.ok) unmarkTranscribing(currentRecording.id);
         } catch {
         }
-        unmarkTranscribing(currentRecording.id);
     }, [currentRecording, unmarkTranscribing]);
 
     const handleUpload = useCallback(

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -34,10 +34,45 @@ interface WorkstationProps {
 
 export function Workstation({ recordings, transcriptions }: WorkstationProps) {
     const router = useRouter();
+
+    const restoreRecording = useCallback((): Recording | null => {
+        const savedId =
+            typeof window !== "undefined"
+                ? localStorage.getItem("openplaud-last-recording")
+                : null;
+        if (savedId) {
+            const found = recordings.find((r) => r.id === savedId);
+            if (found) return found;
+        }
+        return recordings.length > 0 ? recordings[0] : null;
+    }, [recordings]);
+
     const [currentRecording, setCurrentRecording] = useState<Recording | null>(
-        recordings.length > 0 ? recordings[0] : null,
+        restoreRecording,
     );
-    const [isTranscribing, setIsTranscribing] = useState(false);
+
+    const selectRecording = useCallback((recording: Recording | null) => {
+        setCurrentRecording(recording);
+        if (typeof window !== "undefined" && recording?.id) {
+            localStorage.setItem("openplaud-last-recording", recording.id);
+        }
+    }, []);
+
+    const [transcribingIds, setTranscribingIds] = useState<Set<string>>(new Set());
+    const isTranscribing = currentRecording
+        ? transcribingIds.has(currentRecording.id)
+        : false;
+
+    const markTranscribing = useCallback((id: string) => {
+        setTranscribingIds((prev) => new Set(prev).add(id));
+    }, []);
+    const unmarkTranscribing = useCallback((id: string) => {
+        setTranscribingIds((prev) => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+        });
+    }, []);
     const [isUploading, setIsUploading] = useState(false);
     const uploadInputRef = useRef<HTMLInputElement>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
@@ -80,6 +115,51 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
             return updated ?? null;
         });
     }, [recordings]);
+
+    useEffect(() => {
+        if (!currentRecording) return;
+
+        const recordingId = currentRecording.id;
+        const ct = transcriptions.get(recordingId);
+        if (ct?.text === undefined || ct?.text === "") {
+            const controller = new AbortController();
+            fetch(`/api/recordings/${recordingId}/transcribe`, {
+                signal: controller.signal,
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    if (data.status === "processing") {
+                        markTranscribing(recordingId);
+                        const interval = setInterval(async () => {
+                            try {
+                                const statusRes = await fetch(
+                                    `/api/recordings/${recordingId}/transcribe`,
+                                );
+                                if (!statusRes.ok) return;
+                                const statusData = await statusRes.json();
+
+                                if (statusData.status === "completed") {
+                                    clearInterval(interval);
+                                    unmarkTranscribing(recordingId);
+                                    toast.success("Transcription complete");
+                                    router.refresh();
+                                } else if (statusData.status === "failed") {
+                                    clearInterval(interval);
+                                    unmarkTranscribing(recordingId);
+                                    toast.error(
+                                        statusData.errorMessage ||
+                                            "Transcription failed",
+                                    );
+                                }
+                            } catch {
+                            }
+                        }, 3000);
+                    }
+                })
+                .catch(() => {});
+            return () => controller.abort();
+        }
+    }, [currentRecording?.id]);
 
     useEffect(() => {
         getSyncSettings().then(setSyncSettings);
@@ -167,28 +247,71 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
     const handleTranscribe = useCallback(async () => {
         if (!currentRecording) return;
 
-        setIsTranscribing(true);
+        const recordingId = currentRecording.id;
+        markTranscribing(recordingId);
         try {
             const response = await fetch(
-                `/api/recordings/${currentRecording.id}/transcribe`,
-                {
-                    method: "POST",
-                },
+                `/api/recordings/${recordingId}/transcribe`,
+                { method: "POST" },
             );
 
-            if (response.ok) {
-                toast.success("Transcription complete");
-                router.refresh();
-            } else {
+            if (!response.ok) {
                 const error = await response.json();
                 toast.error(error.error || "Transcription failed");
+                unmarkTranscribing(recordingId);
+                return;
+            }
+
+            const data = await response.json();
+            if (data.status === "processing") {
+                toast.info("Transcription started in background");
+
+                const interval = setInterval(async () => {
+                    try {
+                        const statusRes = await fetch(
+                            `/api/recordings/${recordingId}/transcribe`,
+                        );
+                        if (!statusRes.ok) return;
+                        const statusData = await statusRes.json();
+
+                        if (statusData.status === "completed") {
+                            clearInterval(interval);
+                            unmarkTranscribing(recordingId);
+                            toast.success("Transcription complete");
+                            router.refresh();
+                        } else if (statusData.status === "failed") {
+                            clearInterval(interval);
+                            unmarkTranscribing(recordingId);
+                            toast.error(
+                                statusData.errorMessage ||
+                                    "Transcription failed",
+                            );
+                        }
+                    } catch {
+                    }
+                }, 3000);
+            } else {
+                unmarkTranscribing(recordingId);
+                toast.success("Transcription complete");
+                router.refresh();
             }
         } catch {
             toast.error("Failed to transcribe recording");
-        } finally {
-            setIsTranscribing(false);
+            unmarkTranscribing(recordingId);
         }
-    }, [currentRecording, router]);
+    }, [currentRecording, router, markTranscribing, unmarkTranscribing]);
+
+    const handleCancel = useCallback(async () => {
+        if (!currentRecording) return;
+        try {
+            await fetch(
+                `/api/recordings/${currentRecording.id}/transcribe`,
+                { method: "DELETE" },
+            );
+        } catch {
+        }
+        unmarkTranscribing(currentRecording.id);
+    }, [currentRecording, unmarkTranscribing]);
 
     const handleUpload = useCallback(
         async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -338,7 +461,7 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                                 <RecordingList
                                     recordings={recordings}
                                     currentRecording={currentRecording}
-                                    onSelect={setCurrentRecording}
+                                    onSelect={selectRecording}
                                 />
                             </div>
 
@@ -359,7 +482,7 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                                                     currentIndex <
                                                         recordings.length - 1
                                                 ) {
-                                                    setCurrentRecording(
+                                                    selectRecording(
                                                         recordings[
                                                             currentIndex + 1
                                                         ],
@@ -372,6 +495,7 @@ export function Workstation({ recordings, transcriptions }: WorkstationProps) {
                                             transcription={currentTranscription}
                                             isTranscribing={isTranscribing}
                                             onTranscribe={handleTranscribe}
+                                            onCancel={handleCancel}
                                         />
                                     </>
                                 ) : (

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -41,6 +41,10 @@ export function RecordingWorkstation({
     const [isDeleting, setIsDeleting] = useState(false);
     const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+    useEffect(() => {
+        setLiveTranscription(transcription);
+    }, [transcription]);
+
     const startPolling = useCallback(() => {
         if (pollingRef.current) return;
         setIsTranscribing(true);
@@ -132,10 +136,13 @@ export function RecordingWorkstation({
 
     const handleCancel = useCallback(async () => {
         try {
-            await fetch(`/api/recordings/${recording.id}/transcribe`, {
-                method: "DELETE",
-            });
+            const res = await fetch(
+                `/api/recordings/${recording.id}/transcribe`,
+                { method: "DELETE" },
+            );
+            if (!res.ok) return;
         } catch {
+            return;
         }
         if (pollingRef.current) clearInterval(pollingRef.current);
         pollingRef.current = null;

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import { TranscriptionPanel } from "@/components/dashboard/transcription-panel";
@@ -22,6 +22,7 @@ interface Transcription {
     text?: string;
     detectedLanguage?: string;
     transcriptionType?: string;
+    status?: string;
 }
 
 interface RecordingWorkstationProps {
@@ -34,33 +35,112 @@ export function RecordingWorkstation({
     transcription,
 }: RecordingWorkstationProps) {
     const router = useRouter();
+    const [liveTranscription, setLiveTranscription] = useState(transcription);
     const [isTranscribing, setIsTranscribing] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const startPolling = useCallback(() => {
+        if (pollingRef.current) return;
+        setIsTranscribing(true);
+        const interval = setInterval(async () => {
+            try {
+                const res = await fetch(
+                    `/api/recordings/${recording.id}/transcribe`,
+                );
+                if (!res.ok) return;
+                const data = await res.json();
+
+                if (data.status === "completed") {
+                    clearInterval(interval);
+                    pollingRef.current = null;
+                    setIsTranscribing(false);
+                    setLiveTranscription({
+                        text: data.transcription,
+                        detectedLanguage: data.detectedLanguage,
+                        transcriptionType: data.transcriptionType,
+                        status: "completed",
+                    });
+                    toast.success("Transcription complete");
+                    router.refresh();
+                } else if (data.status === "failed") {
+                    clearInterval(interval);
+                    pollingRef.current = null;
+                    setIsTranscribing(false);
+                    toast.error(data.errorMessage || "Transcription failed");
+                }
+            } catch {
+            }
+        }, 3000);
+        pollingRef.current = interval;
+    }, [recording.id, router]);
+
+    useEffect(() => {
+        return () => {
+            if (pollingRef.current) clearInterval(pollingRef.current);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (
+            transcription?.status === "processing" ||
+            transcription?.text === ""
+        ) {
+            const controller = new AbortController();
+            fetch(`/api/recordings/${recording.id}/transcribe`, {
+                signal: controller.signal,
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    if (data.status === "processing") startPolling();
+                })
+                .catch(() => {});
+            return () => controller.abort();
+        }
+    }, [recording.id]);
 
     const handleTranscribe = useCallback(async () => {
         setIsTranscribing(true);
         try {
             const response = await fetch(
                 `/api/recordings/${recording.id}/transcribe`,
-                {
-                    method: "POST",
-                },
+                { method: "POST" },
             );
 
-            if (response.ok) {
-                toast.success("Transcription complete");
-                router.refresh();
-            } else {
+            if (!response.ok) {
                 const error = await response.json();
                 toast.error(error.error || "Transcription failed");
+                setIsTranscribing(false);
+                return;
+            }
+
+            const data = await response.json();
+            if (data.status === "processing") {
+                toast.info("Transcription started in background");
+                startPolling();
+            } else {
+                setIsTranscribing(false);
+                toast.success("Transcription complete");
+                router.refresh();
             }
         } catch {
             toast.error("Failed to transcribe recording");
-        } finally {
             setIsTranscribing(false);
         }
-    }, [recording.id, router]);
+    }, [recording.id, router, startPolling]);
+
+    const handleCancel = useCallback(async () => {
+        try {
+            await fetch(`/api/recordings/${recording.id}/transcribe`, {
+                method: "DELETE",
+            });
+        } catch {
+        }
+        if (pollingRef.current) clearInterval(pollingRef.current);
+        pollingRef.current = null;
+        setIsTranscribing(false);
+    }, [recording.id]);
 
     const handleDelete = useCallback(async () => {
         setIsDeleting(true);
@@ -121,9 +201,10 @@ export function RecordingWorkstation({
                     <RecordingPlayer recording={recording} />
                     <TranscriptionPanel
                         recording={recording}
-                        transcription={transcription}
+                        transcription={liveTranscription}
                         isTranscribing={isTranscribing}
                         onTranscribe={handleTranscribe}
+                        onCancel={handleCancel}
                     />
 
                     {/* Metadata */}

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -78,14 +78,60 @@ export function TranscriptionSection({
         return () => controller.abort();
     }, [recordingId, summaryFetchKey]);
 
+    const startPolling = useCallback(() => {
+        const interval = setInterval(async () => {
+            try {
+                const response = await fetch(
+                    `/api/recordings/${recordingId}/transcribe`,
+                );
+                if (!response.ok) return;
+                const data = await response.json();
+
+                if (data.status === "completed") {
+                    clearInterval(interval);
+                    setTranscription(data.transcription);
+                    setDetectedLanguage(data.detectedLanguage);
+                    setTranscriptionType(data.transcriptionType || "server");
+                    setIsProcessing(false);
+                    setSummaryData(null);
+                    setSummaryFetchKey((k) => k + 1);
+                    toast.success("Transcription complete");
+                } else if (data.status === "failed") {
+                    clearInterval(interval);
+                    setIsProcessing(false);
+                    toast.error(data.errorMessage || "Transcription failed");
+                }
+            } catch {
+            }
+        }, 3000);
+
+        return () => clearInterval(interval);
+    }, [recordingId]);
+
+    useEffect(() => {
+        if (initialTranscription === "" && transcription === "") {
+            const controller = new AbortController();
+            fetch(`/api/recordings/${recordingId}/transcribe`, {
+                signal: controller.signal,
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    if (data.status === "processing" && !isProcessing) {
+                        setIsProcessing(true);
+                        startPolling();
+                    }
+                })
+                .catch(() => {});
+            return () => controller.abort();
+        }
+    }, [recordingId]);
+
     const handleTranscribe = async () => {
         setIsProcessing(true);
         try {
             const response = await fetch(
                 `/api/recordings/${recordingId}/transcribe`,
-                {
-                    method: "POST",
-                },
+                { method: "POST" },
             );
 
             if (!response.ok) {
@@ -100,20 +146,25 @@ export function TranscriptionSection({
                 } else {
                     toast.error(errorData.error || "Transcription failed");
                 }
+                setIsProcessing(false);
                 return;
             }
 
             const data = await response.json();
-            setTranscription(data.transcription);
-            setDetectedLanguage(data.detectedLanguage);
-            setTranscriptionType("server");
-            // Invalidate cached summary — it was based on old text
-            setSummaryData(null);
-            setSummaryFetchKey((k) => k + 1);
-            toast.success("Transcription complete");
+            if (data.status === "processing") {
+                toast.info("Transcription started in background");
+                startPolling();
+            } else {
+                setTranscription(data.transcription);
+                setDetectedLanguage(data.detectedLanguage);
+                setTranscriptionType("server");
+                setSummaryData(null);
+                setSummaryFetchKey((k) => k + 1);
+                setIsProcessing(false);
+                toast.success("Transcription complete");
+            }
         } catch {
             toast.error("Transcription failed. Please try again.");
-        } finally {
             setIsProcessing(false);
         }
     };

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -118,24 +118,6 @@ export function TranscriptionSection({
         }
     }, [recordingId, startPolling]);
 
-    useEffect(() => {
-        if (initialTranscription === "" && transcription === "") {
-            const controller = new AbortController();
-            fetch(`/api/recordings/${recordingId}/transcribe`, {
-                signal: controller.signal,
-            })
-                .then((res) => res.json())
-                .then((data) => {
-                    if (data.status === "processing" && !isProcessing) {
-                        setIsProcessing(true);
-                        startPolling();
-                    }
-                })
-                .catch(() => {});
-            return () => controller.abort();
-        }
-    }, [recordingId]);
-
     const handleTranscribe = async () => {
         setIsProcessing(true);
         try {

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -9,7 +9,7 @@ import {
     Sparkles,
     Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LEDIndicator } from "@/components/led-indicator";
 import { MetalButton } from "@/components/metal-button";
@@ -48,37 +48,25 @@ export function TranscriptionSection({
     const [detectedLanguage, setDetectedLanguage] = useState(initialLanguage);
     const [transcriptionType, setTranscriptionType] = useState(initialType);
     const [isProcessing, setIsProcessing] = useState(false);
+    const isProcessingRef = useRef(false);
+    const pollingCleanupRef = useRef<(() => void) | null>(null);
 
-    // Summary state
-    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-    const [isSummarizing, setIsSummarizing] = useState(false);
-    const [summaryExpanded, setSummaryExpanded] = useState(true);
-    const [summaryPreset, setSummaryPreset] = useState("general");
+    const clearPolling = useCallback(() => {
+        if (pollingCleanupRef.current) {
+            pollingCleanupRef.current();
+            pollingCleanupRef.current = null;
+        }
+    }, []);
 
-    // Key to force re-fetch summary (e.g. after re-transcription)
-    const [summaryFetchKey, setSummaryFetchKey] = useState(0);
-
-    // Fetch existing summary on mount / after re-transcribe
-    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch trigger
     useEffect(() => {
-        const controller = new AbortController();
-        fetch(`/api/recordings/${recordingId}/summary`, {
-            signal: controller.signal,
-        })
-            .then((res) => res.json())
-            .then((data) => {
-                if (data.summary) {
-                    setSummaryData(data);
-                } else {
-                    setSummaryData(null);
-                }
-            })
-            .catch(() => {});
-
-        return () => controller.abort();
-    }, [recordingId, summaryFetchKey]);
+        return () => clearPolling();
+    }, [clearPolling]);
 
     const startPolling = useCallback(() => {
+        clearPolling();
+        isProcessingRef.current = true;
+        setIsProcessing(true);
+
         const interval = setInterval(async () => {
             try {
                 const response = await fetch(
@@ -88,25 +76,47 @@ export function TranscriptionSection({
                 const data = await response.json();
 
                 if (data.status === "completed") {
-                    clearInterval(interval);
+                    clearPolling();
                     setTranscription(data.transcription);
                     setDetectedLanguage(data.detectedLanguage);
                     setTranscriptionType(data.transcriptionType || "server");
                     setIsProcessing(false);
+                    isProcessingRef.current = false;
                     setSummaryData(null);
                     setSummaryFetchKey((k) => k + 1);
                     toast.success("Transcription complete");
                 } else if (data.status === "failed") {
-                    clearInterval(interval);
+                    clearPolling();
                     setIsProcessing(false);
+                    isProcessingRef.current = false;
                     toast.error(data.errorMessage || "Transcription failed");
                 }
             } catch {
             }
         }, 3000);
 
-        return () => clearInterval(interval);
-    }, [recordingId]);
+        pollingCleanupRef.current = () => clearInterval(interval);
+    }, [recordingId, clearPolling]);
+
+    useEffect(() => {
+        if (initialTranscription === "" && transcription === "") {
+            const controller = new AbortController();
+            fetch(`/api/recordings/${recordingId}/transcribe`, {
+                signal: controller.signal,
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    if (
+                        data.status === "processing" &&
+                        !isProcessingRef.current
+                    ) {
+                        startPolling();
+                    }
+                })
+                .catch(() => {});
+            return () => controller.abort();
+        }
+    }, [recordingId, startPolling]);
 
     useEffect(() => {
         if (initialTranscription === "" && transcription === "") {

--- a/src/db/migrations/0018_empty_blacklash.sql
+++ b/src/db/migrations/0018_empty_blacklash.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "transcriptions" ALTER COLUMN "text" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "transcriptions" ALTER COLUMN "text" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "transcriptions" ADD COLUMN "status" varchar(20) DEFAULT 'completed' NOT NULL;--> statement-breakpoint
+ALTER TABLE "transcriptions" ADD COLUMN "error_message" text;

--- a/src/db/migrations/meta/0018_snapshot.json
+++ b/src/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1398 @@
+{
+  "id": "fd11f880-4dbb-4398-b6b3-e2a48ffd8f0c",
+  "prevId": "bcbcb599-73da-4b57-b83d-5dbbb5836262",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_plaud_file_id_unique": {
+          "name": "recordings_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777730082791,
       "tag": "0017_curved_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1778128218223,
+      "tag": "0018_empty_blacklash",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -188,13 +188,17 @@ export const transcriptions = pgTable(
         userId: text("user_id")
             .notNull()
             .references(() => users.id, { onDelete: "cascade" }),
-        text: text("text").notNull(),
+        text: text("text").default(""),
         detectedLanguage: varchar("detected_language", { length: 10 }), // ISO 639-1 language code detected by Whisper
         transcriptionType: varchar("transcription_type", { length: 10 })
             .notNull()
             .default("server"), // 'server' or 'browser'
         provider: varchar("provider", { length: 100 }).notNull(), // e.g., 'openai', 'groq', 'browser'
-        model: varchar("model", { length: 100 }).notNull(), // e.g., 'whisper-1', 'whisper-large-v3-turbo', 'whisper-base'
+        model: varchar("model", { length: 100 }).notNull(),
+        status: varchar("status", { length: 20 })
+            .notNull()
+            .default("completed"),
+        errorMessage: text("error_message"),
         createdAt: timestamp("created_at").notNull().defaultNow(),
     },
     (table) => ({

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -143,6 +143,7 @@ export async function transcribeRecording(
                 .set({
                     text: transcriptionText,
                     detectedLanguage,
+                    status: "completed",
                     transcriptionType: "server",
                     provider: credentials.provider,
                     model: credentials.defaultModel || "whisper-1",
@@ -154,6 +155,7 @@ export async function transcribeRecording(
                 userId,
                 text: transcriptionText,
                 detectedLanguage,
+                status: "completed",
                 transcriptionType: "server",
                 provider: credentials.provider,
                 model: credentials.defaultModel || "whisper-1",


### PR DESCRIPTION
## Description

Converts transcription from a synchronous (blocking) request to a background worker with status polling. Users no longer need to wait on the page, transcription runs in the background, survives page refresh, and shows real-time status. Includes a cancel button to abort in-progress transcriptions.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes made in this PR -->

- Added `status` (`processing`/`completed`/`failed`) and `error_message` columns to `transcriptions` table with migration `0018`
- POST `/api/recordings/[id]/transcribe` now returns `{ status: "processing" }` immediately and fires background transcription via `runTranscription()`
- GET `/api/recordings/[id]/transcribe` returns current status + text (polled by frontend every 3s)
- DELETE `/api/recordings/[id]/transcribe` cancels an in-progress transcription by resetting the row
- Background `runTranscription()` checks `status === "processing"` before saving results (discards if cancelled)
- Dashboard `Workstation` and `RecordingWorkstation` both show loading spinner + cancel button while transcribing
- Per-recording `transcribingIds` Set prevents loading state from leaking to other recordings when switching
- `localStorage` persists selected recording ID so page refresh keeps your place
- `TranscriptionSection` and sync auto-transcribe path updated for the new flow
- `summary/route.ts` handles potentially empty `transcription.text` from processing rows

## Screenshots (if applicable)

<img width="850" height="537" alt="image" src="https://github.com/user-attachments/assets/304ddfde-55cf-4c91-97d7-e2244b6f527c" />

## Testing

### Test Environment
- OS: Ubuntu (run on docker)
- Node version: Bun (1.3.13)
- Browser (if UI changes): zen browser, arc browser

### Test Steps
1. Configure an AI provider in Settings
2. Click "Transcribe" on any recording, should show "Transcription started in background" toast and a spinner with Cancel button
3. Refresh the page mid-transcription, should auto-resume polling (spinner reappears)
4. Switch to another recording during transcription, spinner should only show for the recording being transcribed
5. Click "Cancel", spinner disappears, "Transcribe" button returns, able to re-transcribe
6. Wait for completion, toast shows "Transcription complete", text appears

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

<!-- If this PR includes database schema changes -->

- [x] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

Migration `0018` adds `status VARCHAR(20) NOT NULL DEFAULT 'completed'` and `error_message TEXT` to `transcriptions`. Existing rows default to `status = 'completed'`. Rollback: `ALTER TABLE transcriptions DROP COLUMN status, DROP COLUMN error_message`.

## Breaking Changes

None — existing `text` column changed from `NOT NULL` to `DEFAULT ''` for creating rows before transcription completes, but existing data is unaffected.

## Additional Notes

The background task is fire-and-forget via `void runTranscription(...)`. In Next.js standalone Bun server (which OpenPlaud uses), background promises survive the request cycle. Server restart kills in-progress jobs — the row stays `processing` but the cancel button resets it.

## For Reviewers

- `src/app/api/recordings/[id]/transcribe/route.ts`, the POST/GET/DELETE handlers and `runTranscription`
- `src/components/dashboard/workstation.tsx`, per-recording state + localStorage persistence
- `src/components/recordings/recording-workstation.tsx`, polling + cancel on the detail page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Transcription now runs in a background worker with status polling and cancel, so users aren’t blocked and progress survives page refresh. POST returns immediately; UI shows a spinner with Cancel and auto-resumes after reload.

- **New Features**
  - Background worker processes audio and updates `processing/completed/failed` with `error_message` on errors.
  - API: POST `/api/recordings/[id]/transcribe` returns `{ status: "processing" }`; GET returns status + text; DELETE cancels in-progress jobs.
  - UI: Dashboard and recording pages poll every 3s, show Cancel, keep per-recording state, and persist last selected recording in `localStorage`. Polling is cleaned up on unmount, duplicate polling was removed in `TranscriptionSection`, cancel is guarded, and live transcription state stays in sync after prop changes and refresh.
  - Summary endpoint handles empty transcription text safely.
  - Sync auto-transcribe path writes `status: "completed"` directly.

- **Migration**
  - Adds `status` and `error_message` to `transcriptions`; `text` is now nullable with default `''`.
  - Run migration `0018_empty_blacklash` (existing rows default to `status = 'completed'`).

<sup>Written for commit a5001bd7246f755b389bb8108fef05707dcbd2df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

