### PR TITLE
feat(ai): block localhost AI provider base URLs on hosted

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@ import { SettingsPageContent } from "@/components/settings/settings-page-content
 import { db } from "@/db";
 import { apiCredentials } from "@/db/schema";
 import { requireAuth } from "@/lib/auth-server";
+import { env } from "@/lib/env";
 
 export default async function SettingsPage() {
     const session = await requireAuth();
@@ -21,5 +22,10 @@ export default async function SettingsPage() {
         .from(apiCredentials)
         .where(eq(apiCredentials.userId, session.user.id));
 
-    return <SettingsPageContent initialProviders={providers} />;
+    return (
+        <SettingsPageContent
+            initialProviders={providers}
+            isHosted={env.IS_HOSTED}
+        />
+    );
 }

--- a/src/app/api/settings/ai/providers/[id]/route.ts
+++ b/src/app/api/settings/ai/providers/[id]/route.ts
@@ -2,8 +2,10 @@ import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { apiCredentials } from "@/db/schema";
+import { validateAiBaseUrl } from "@/lib/ai/validate-base-url";
 import { auth } from "@/lib/auth";
 import { encrypt } from "@/lib/encryption";
+import { env } from "@/lib/env";
 
 // PUT - Update AI provider
 export async function PUT(
@@ -47,6 +49,19 @@ export async function PUT(
             return NextResponse.json(
                 { error: "Provider not found" },
                 { status: 404 },
+            );
+        }
+
+        // On hosted, the app process can't reach the user's machine — reject
+        // localhost / loopback baseUrls (e.g. LM Studio, Ollama) with a clear
+        // message. Self-host accepts everything.
+        const baseUrlCheck = validateAiBaseUrl(baseUrl, {
+            isHosted: env.IS_HOSTED,
+        });
+        if (!baseUrlCheck.ok) {
+            return NextResponse.json(
+                { error: baseUrlCheck.message },
+                { status: 400 },
             );
         }
 

--- a/src/app/api/settings/ai/providers/route.ts
+++ b/src/app/api/settings/ai/providers/route.ts
@@ -2,8 +2,10 @@ import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { apiCredentials } from "@/db/schema";
+import { validateAiBaseUrl } from "@/lib/ai/validate-base-url";
 import { auth } from "@/lib/auth";
 import { encrypt } from "@/lib/encryption";
+import { env } from "@/lib/env";
 
 // GET - List all AI providers for the user
 export async function GET(request: Request) {
@@ -68,6 +70,19 @@ export async function POST(request: Request) {
         if (!provider || !apiKey) {
             return NextResponse.json(
                 { error: "Provider and API key are required" },
+                { status: 400 },
+            );
+        }
+
+        // On hosted, the app process can't reach the user's machine — reject
+        // localhost / loopback baseUrls (e.g. LM Studio, Ollama) with a clear
+        // message. Self-host accepts everything.
+        const baseUrlCheck = validateAiBaseUrl(baseUrl, {
+            isHosted: env.IS_HOSTED,
+        });
+        if (!baseUrlCheck.ok) {
+            return NextResponse.json(
+                { error: baseUrlCheck.message },
                 { status: 400 },
             );
         }

--- a/src/components/settings-content.tsx
+++ b/src/components/settings-content.tsx
@@ -26,16 +26,23 @@ interface SettingsContentProps {
     activeSection: SettingsSection;
     initialProviders?: Provider[];
     onReRunOnboarding?: () => void;
+    isHosted?: boolean;
 }
 
 export function SettingsContent({
     activeSection,
     initialProviders = [],
     onReRunOnboarding,
+    isHosted = false,
 }: SettingsContentProps) {
     switch (activeSection) {
         case "providers":
-            return <ProvidersSection initialProviders={initialProviders} />;
+            return (
+                <ProvidersSection
+                    initialProviders={initialProviders}
+                    isHosted={isHosted}
+                />
+            );
         case "transcription":
             return <TranscriptionSection />;
         case "summary":

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -61,6 +61,7 @@ interface SettingsDialogProps {
     onOpenChange: (open: boolean) => void;
     initialProviders?: Provider[];
     onReRunOnboarding?: () => void;
+    isHosted?: boolean;
 }
 
 import type { SettingsSection } from "@/types/settings";
@@ -105,6 +106,7 @@ export function SettingsDialog({
     onOpenChange,
     initialProviders = [],
     onReRunOnboarding,
+    isHosted = false,
 }: SettingsDialogProps) {
     const [activeSection, setActiveSection] =
         React.useState<SettingsSection>("providers");
@@ -365,6 +367,7 @@ export function SettingsDialog({
                                     activeSection={activeSection}
                                     initialProviders={initialProviders}
                                     onReRunOnboarding={onReRunOnboarding}
+                                    isHosted={isHosted}
                                 />
                             </div>
                         </div>

--- a/src/components/settings-sections/providers-section.tsx
+++ b/src/components/settings-sections/providers-section.tsx
@@ -39,10 +39,12 @@ interface Provider {
 
 interface ProvidersSectionProps {
     initialProviders?: Provider[];
+    isHosted?: boolean;
 }
 
 export function ProvidersSection({
     initialProviders = [],
+    isHosted = false,
 }: ProvidersSectionProps) {
     const { isLoadingSettings, isSavingSettings, setIsLoadingSettings } =
         useSettings();
@@ -721,6 +723,7 @@ Generate the title now:`}
             <AddProviderDialog
                 open={isAddProviderOpen}
                 onOpenChange={setIsAddProviderOpen}
+                isHosted={isHosted}
                 onSuccess={() => {
                     setIsAddProviderOpen(false);
                     refreshProviders();
@@ -736,6 +739,7 @@ Generate the title now:`}
                     }
                 }}
                 provider={editingProvider}
+                isHosted={isHosted}
                 onSuccess={() => {
                     setIsEditProviderOpen(false);
                     setEditingProvider(null);

--- a/src/components/settings/add-provider-dialog.tsx
+++ b/src/components/settings/add-provider-dialog.tsx
@@ -24,7 +24,15 @@ interface AddProviderDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onSuccess: () => void;
+    /**
+     * When true, hide the LM Studio / Ollama presets and show a hint that
+     * localhost base URLs aren't reachable from the hosted app. The server
+     * also rejects them — this is just a friendlier UI.
+     */
+    isHosted?: boolean;
 }
+
+const LOCAL_PRESET_NAMES = new Set(["LM Studio", "Ollama"]);
 
 const providerPresets = [
     {
@@ -75,7 +83,11 @@ export function AddProviderDialog({
     open,
     onOpenChange,
     onSuccess,
+    isHosted = false,
 }: AddProviderDialogProps) {
+    const visiblePresets = isHosted
+        ? providerPresets.filter((p) => !LOCAL_PRESET_NAMES.has(p.name))
+        : providerPresets;
     const [provider, setProvider] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
@@ -116,7 +128,10 @@ export function AddProviderDialog({
                 }),
             });
 
-            if (!response.ok) throw new Error("Failed to add provider");
+            if (!response.ok) {
+                const data = await response.json().catch(() => null);
+                throw new Error(data?.error || "Failed to add provider");
+            }
 
             toast.success("AI provider added successfully");
             onSuccess();
@@ -128,8 +143,12 @@ export function AddProviderDialog({
             setDefaultModel("");
             setIsDefaultTranscription(false);
             setIsDefaultEnhancement(false);
-        } catch {
-            toast.error("Failed to add AI provider");
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to add AI provider",
+            );
         } finally {
             setIsLoading(false);
         }
@@ -155,7 +174,7 @@ export function AddProviderDialog({
                                 <SelectValue placeholder="Select a provider" />
                             </SelectTrigger>
                             <SelectContent>
-                                {providerPresets.map((preset) => (
+                                {visiblePresets.map((preset) => (
                                     <SelectItem
                                         key={preset.name}
                                         value={preset.name}
@@ -193,6 +212,18 @@ export function AddProviderDialog({
                             disabled={isLoading}
                             className="font-mono text-sm"
                         />
+                        {isHosted && (
+                            <p className="text-xs text-muted-foreground">
+                                We can&apos;t reach{" "}
+                                <code className="font-mono">localhost</code> or
+                                other private addresses from the hosted app. To
+                                use LM Studio or Ollama, self-host OpenPlaud (
+                                <code className="font-mono">
+                                    docker compose up
+                                </code>
+                                ).
+                            </p>
+                        )}
                     </div>
 
                     <div className="space-y-2">

--- a/src/components/settings/edit-provider-dialog.tsx
+++ b/src/components/settings/edit-provider-dialog.tsx
@@ -35,7 +35,15 @@ interface EditProviderDialogProps {
     onOpenChange: (open: boolean) => void;
     provider: Provider | null;
     onSuccess: () => void;
+    /**
+     * When true, hide the LM Studio / Ollama presets and show a hint that
+     * localhost base URLs aren't reachable from the hosted app. The server
+     * also rejects them on save.
+     */
+    isHosted?: boolean;
 }
+
+const LOCAL_PRESET_NAMES = new Set(["LM Studio", "Ollama"]);
 
 const providerPresets = [
     {
@@ -87,7 +95,11 @@ export function EditProviderDialog({
     onOpenChange,
     provider,
     onSuccess,
+    isHosted = false,
 }: EditProviderDialogProps) {
+    const visiblePresets = isHosted
+        ? providerPresets.filter((p) => !LOCAL_PRESET_NAMES.has(p.name))
+        : providerPresets;
     const [providerName, setProviderName] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
@@ -213,7 +225,7 @@ export function EditProviderDialog({
                                 <SelectValue placeholder="Select a provider" />
                             </SelectTrigger>
                             <SelectContent>
-                                {providerPresets.map((preset) => (
+                                {visiblePresets.map((preset) => (
                                     <SelectItem
                                         key={preset.name}
                                         value={preset.name}
@@ -260,6 +272,18 @@ export function EditProviderDialog({
                             disabled={isLoading}
                             className="font-mono text-sm"
                         />
+                        {isHosted && (
+                            <p className="text-xs text-muted-foreground">
+                                We can&apos;t reach{" "}
+                                <code className="font-mono">localhost</code> or
+                                other private addresses from the hosted app. To
+                                use LM Studio or Ollama, self-host OpenPlaud (
+                                <code className="font-mono">
+                                    docker compose up
+                                </code>
+                                ).
+                            </p>
+                        )}
                     </div>
 
                     <div className="space-y-2">

--- a/src/components/settings/settings-page-content.tsx
+++ b/src/components/settings/settings-page-content.tsx
@@ -6,10 +6,12 @@ import { type Provider, SettingsDialog } from "@/components/settings-dialog";
 
 interface SettingsPageContentProps {
     initialProviders?: Provider[];
+    isHosted?: boolean;
 }
 
 export function SettingsPageContent({
     initialProviders = [],
+    isHosted = false,
 }: SettingsPageContentProps) {
     const router = useRouter();
     const [open, setOpen] = useState(true);
@@ -27,6 +29,7 @@ export function SettingsPageContent({
             open={open}
             onOpenChange={handleOpenChange}
             initialProviders={initialProviders}
+            isHosted={isHosted}
         />
     );
 }

--- a/src/lib/ai/validate-base-url.ts
+++ b/src/lib/ai/validate-base-url.ts
@@ -1,0 +1,97 @@
+/**
+ * Validates an AI provider `baseUrl` for the current deployment mode.
+ *
+ * On the hosted instance (`IS_HOSTED=true`) the app process can't reach
+ * the user's machine, so loopback / unspecified addresses (localhost,
+ * 127.0.0.0/8, 0.0.0.0, ::1, ::) make no sense and silently break AI
+ * calls. We reject them at the API layer and surface a short message
+ * explaining the user should self-host to use LM Studio / Ollama.
+ *
+ * On self-host (`IS_HOSTED=false`) every value is allowed — local AI is
+ * a first-class path (Ollama, LM Studio, docker-network hostnames).
+ */
+
+export const HOSTED_LOCAL_BASE_URL_MESSAGE =
+    "We can't reach `localhost` or other private addresses from the hosted app — to use LM Studio or Ollama, self-host OpenPlaud (`docker compose up`).";
+
+export type BaseUrlValidationResult =
+    | { ok: true }
+    | { ok: false; message: string };
+
+interface ValidateOptions {
+    isHosted: boolean;
+}
+
+/**
+ * @param input  Raw user-supplied base URL. `null`, `undefined`, or empty
+ *               string are treated as "no override" and always allowed
+ *               (callers fall back to the OpenAI default).
+ */
+export function validateAiBaseUrl(
+    input: string | null | undefined,
+    { isHosted }: ValidateOptions,
+): BaseUrlValidationResult {
+    if (input == null) return { ok: true };
+    const trimmed = input.trim();
+    if (trimmed === "") return { ok: true };
+
+    // Self-host accepts anything — local AI must keep working.
+    if (!isHosted) return { ok: true };
+
+    let parsed: URL;
+    try {
+        parsed = new URL(trimmed);
+    } catch {
+        return {
+            ok: false,
+            message:
+                "Base URL must be a valid absolute URL (e.g. https://api.example.com/v1).",
+        };
+    }
+
+    // URL.hostname keeps brackets for IPv6 literals (`[::1]`); strip them
+    // so the loopback check sees the bare address. Also drop any trailing
+    // dot — DNS treats `localhost.` as equivalent to `localhost`.
+    let host = parsed.hostname.toLowerCase();
+    if (host.startsWith("[") && host.endsWith("]")) {
+        host = host.slice(1, -1);
+    }
+    if (host.endsWith(".")) {
+        host = host.slice(0, -1);
+    }
+    if (isLoopbackOrUnspecified(host)) {
+        return { ok: false, message: HOSTED_LOCAL_BASE_URL_MESSAGE };
+    }
+
+    return { ok: true };
+}
+
+function isLoopbackOrUnspecified(host: string): boolean {
+    if (host === "localhost") return true;
+    // RFC 6761: `*.localhost` must resolve to loopback. Real-world resolvers
+    // honor it; assume the same on hosted.
+    if (host.endsWith(".localhost")) return true;
+    if (host === "0.0.0.0") return true;
+    // IPv6 loopback / unspecified (URL.hostname has stripped brackets).
+    if (host === "::1" || host === "::") return true;
+    // Some parsers leave the zero-compressed forms; be defensive.
+    if (host === "0:0:0:0:0:0:0:1" || host === "0:0:0:0:0:0:0:0") return true;
+    // 127.0.0.0/8 — every address in that block is loopback.
+    if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) {
+        const octets = host.split(".").map(Number);
+        if (octets.every((o) => o >= 0 && o <= 255)) return true;
+    }
+    // IPv4-mapped IPv6 (`::ffff:a.b.c.d`). WHATWG URL normalizes the embedded
+    // IPv4 to hex (`::ffff:7f00:1`), so check that form. Block the entire
+    // `::ffff:` family routed at loopback (`7f00:0000`–`7fff:ffff`).
+    const v4MappedLoopback = /^::ffff:7[0-9a-f]{1,3}:[0-9a-f]{1,4}$/;
+    if (v4MappedLoopback.test(host)) {
+        const lastTwoOctets = host.slice("::ffff:".length); // e.g. "7f00:1"
+        const [hi] = lastTwoOctets.split(":");
+        const hiNum = Number.parseInt(hi, 16);
+        // hi is the high two octets of the embedded IPv4. 0x7f00–0x7fff
+        // covers 127.0.0.0/8.
+        if (hiNum >= 0x7f00 && hiNum <= 0x7fff) return true;
+    }
+    return false;
+}

--- a/src/tests/validate-base-url.test.ts
+++ b/src/tests/validate-base-url.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "vitest";
+import {
+    HOSTED_LOCAL_BASE_URL_MESSAGE,
+    validateAiBaseUrl,
+} from "@/lib/ai/validate-base-url";
+
+describe("validateAiBaseUrl", () => {
+    describe("self-host (isHosted=false)", () => {
+        test("allows empty / nullish (use default)", () => {
+            expect(validateAiBaseUrl("", { isHosted: false }).ok).toBe(true);
+            expect(validateAiBaseUrl(null, { isHosted: false }).ok).toBe(true);
+            expect(validateAiBaseUrl(undefined, { isHosted: false }).ok).toBe(
+                true,
+            );
+        });
+
+        test("allows localhost-style URLs (Ollama, LM Studio, docker network)", () => {
+            const urls = [
+                "http://localhost:1234/v1",
+                "http://127.0.0.1:11434/v1",
+                "http://0.0.0.0:8080/v1",
+                "http://[::1]:1234/v1",
+                "http://ollama:11434/v1",
+                "https://api.openai.com/v1",
+            ];
+            for (const u of urls) {
+                expect(
+                    validateAiBaseUrl(u, { isHosted: false }),
+                    `self-host should allow ${u}`,
+                ).toEqual({ ok: true });
+            }
+        });
+
+        test("self-host does not even bother to parse — garbage strings pass", () => {
+            // Self-host trusts the operator; the OpenAI SDK will surface
+            // a helpful error at request time. We don't try to second-guess.
+            expect(validateAiBaseUrl("not a url", { isHosted: false }).ok).toBe(
+                true,
+            );
+        });
+    });
+
+    describe("hosted (isHosted=true)", () => {
+        test("allows empty / nullish (falls back to OpenAI default)", () => {
+            expect(validateAiBaseUrl("", { isHosted: true }).ok).toBe(true);
+            expect(validateAiBaseUrl(null, { isHosted: true }).ok).toBe(true);
+            expect(validateAiBaseUrl(undefined, { isHosted: true }).ok).toBe(
+                true,
+            );
+            // Whitespace-only collapses to empty.
+            expect(validateAiBaseUrl("   ", { isHosted: true }).ok).toBe(true);
+        });
+
+        test("allows public HTTPS provider URLs", () => {
+            const urls = [
+                "https://api.openai.com/v1",
+                "https://api.groq.com/openai/v1",
+                "https://api.together.xyz/v1",
+                "https://openrouter.ai/api/v1",
+                "https://example.com:8443/v1",
+            ];
+            for (const u of urls) {
+                expect(
+                    validateAiBaseUrl(u, { isHosted: true }),
+                    `hosted should allow ${u}`,
+                ).toEqual({ ok: true });
+            }
+        });
+
+        test("rejects loopback hostnames with the user-facing message", () => {
+            const urls = [
+                "http://localhost:1234/v1",
+                "http://LOCALHOST/v1",
+                "https://localhost",
+                // Trailing-dot variant — equivalent to localhost per DNS.
+                "http://localhost.:1234/v1",
+                // RFC 6761: *.localhost is loopback.
+                "http://app.localhost/v1",
+                "http://api.localhost:1234/v1",
+                "http://127.0.0.1:11434/v1",
+                "http://127.1.2.3/v1",
+                "http://0.0.0.0:8080/v1",
+                "http://[::1]:1234/v1",
+                "http://[::]:8080/v1",
+                // IPv4-mapped IPv6 routed at loopback. WHATWG normalizes
+                // hostname to `[::ffff:7f00:1]` etc.
+                "http://[::ffff:127.0.0.1]:1234/v1",
+                "http://[::ffff:127.1.2.3]/v1",
+            ];
+            for (const u of urls) {
+                const res = validateAiBaseUrl(u, { isHosted: true });
+                expect(res.ok, `hosted should reject ${u}`).toBe(false);
+                if (!res.ok) {
+                    expect(res.message).toBe(HOSTED_LOCAL_BASE_URL_MESSAGE);
+                }
+            }
+        });
+
+        test("rejects unparseable URLs with a parse-error message", () => {
+            const res = validateAiBaseUrl("not a url", { isHosted: true });
+            expect(res.ok).toBe(false);
+            if (!res.ok) {
+                expect(res.message).not.toBe(HOSTED_LOCAL_BASE_URL_MESSAGE);
+                expect(res.message).toMatch(/valid absolute URL/i);
+            }
+        });
+
+        test("does not over-block: hostnames that merely contain 'localhost' or v4-mapped non-loopback", () => {
+            // These should pass — they're not loopback.
+            const urls = [
+                "http://localhostfoo.example.com/v1",
+                "http://my-localhost.example.com/v1",
+                // IPv4-mapped IPv6 to a public address — not loopback.
+                "http://[::ffff:8.8.8.8]/v1",
+                // 128.x.x.x is not in 127/8.
+                "http://128.0.0.1/v1",
+            ];
+            for (const u of urls) {
+                expect(
+                    validateAiBaseUrl(u, { isHosted: true }),
+                    `hosted should allow ${u}`,
+                ).toEqual({ ok: true });
+            }
+        });
+
+        test("does NOT block private/container hostnames (out of scope)", () => {
+            // We only block loopback/unspecified. Container DNS like
+            // `ollama` will fail at request time on hosted infra, which
+            // is acceptable — see plan, full SSRF guard is a separate
+            // piece tracked under hosted-egress hardening.
+            expect(
+                validateAiBaseUrl("http://ollama:11434/v1", {
+                    isHosted: true,
+                }).ok,
+            ).toBe(true);
+            expect(
+                validateAiBaseUrl("http://192.168.1.10/v1", {
+                    isHosted: true,
+                }).ok,
+            ).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Description

On the hosted instance (`IS_HOSTED=true`) the app process can't reach the user's machine, so AI provider `baseUrl` values like `http://localhost:1234/v1` (LM Studio) or `http://localhost:11434/v1` (Ollama) silently fail at request time. This PR rejects loopback / unspecified base URLs at the API layer with a short, user-facing message and stops suggesting them in the UI on hosted. Self-host (`IS_HOSTED=false`) is unchanged — local AI stays a first-class path.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #
Relates to #

## Changes Made

- New `validateAiBaseUrl(input, { isHosted })` in `src/lib/ai/validate-base-url.ts`. Hosted rejects: `localhost` (including trailing-dot variant and `*.localhost` per RFC 6761), `127.0.0.0/8`, `0.0.0.0`, `::1`, `::`, and IPv4-mapped IPv6 routed at loopback (`::ffff:7XXX:YYYY` in WHATWG normalized form). Empty / nullish input is allowed (callers fall back to OpenAI default). Self-host short-circuits to `ok`.
- Enforce in `POST /api/settings/ai/providers` and `PUT /api/settings/ai/providers/[id]`; return `400 { error: <message> }` on rejection.
- Thread `isHosted` from the settings server page through `SettingsPageContent` → `SettingsDialog` → `SettingsContent` → `ProvidersSection` into `AddProviderDialog` / `EditProviderDialog`. On hosted the LM Studio and Ollama presets are filtered out of the dropdown and a one-line hint sits under the Base URL input. Both dialogs now surface server `error` messages via `toast.error` (the Add dialog previously swallowed them).
- Unit tests covering self-host allow-all, hosted reject set including the bypass classes (`localhost.`, `app.localhost`, `[::ffff:127.0.0.1]`), and over-block guards (`localhostfoo.example.com`, `[::ffff:8.8.8.8]`, `128.0.0.1`).

Out of scope (deliberately): RFC1918 ranges, link-local (`169.254/16`), DNS-time bypasses (`localtest.me`, `lvh.me`), and non-http schemes. Those belong to the broader hosted-egress hardening covered by AGENTS.md, not URL-shape validation.

## Screenshots (if applicable)

N/A — UI change is a one-line hint under the existing Base URL input plus filtering two presets out of an existing dropdown on hosted only.

## Testing

### Test Environment
- OS: macOS
- Node version: pnpm 10.18.1 / Node 20
- Browser (if UI changes): not exercised in browser; UI change is text-only and prop-threaded

### Test Steps
1. `pnpm format-and-lint:fix` — clean.
2. `pnpm type-check` — clean.
3. `pnpm test` — 92 passed, 3 pre-existing skips, 0 failures (includes 9 new cases in `src/tests/validate-base-url.test.ts`).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

Docs note: user-visible message links to self-host instructions in the existing README; no separate doc page added in this PR (can follow up if you want a dedicated hosted-limitations page).

## Database Changes

None.

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

No deploy-surface break. Self-host behavior is unchanged. On hosted, any pre-existing `apiCredentials` row whose `baseUrl` points at loopback will now reject `PUT` updates until the field is changed — this is the intended behavior (those rows were never working on hosted anyway). The error toast tells the user what to do; deletion still works.

## Additional Notes

User-facing message (one sentence, used by both the API 400 response and the UI hint):

> We can't reach `localhost` or other private addresses from the hosted app — to use LM Studio or Ollama, self-host OpenPlaud (`docker compose up`).

A dedicated docs page can follow; for now the inline hint is the surface.

## For Reviewers

- Validator scope: do you want `*.localhost` blocked (currently yes, RFC 6761) or kept as a deliberate escape hatch?
- IPv4-mapped IPv6 regex: I block the entire `::ffff:7XXX:YYYY` family in 0x7f00–0x7fff. Stricter than necessary but safe for our use case. OK?
- Edit dialog UX when an existing record's stored `provider` label is `LM Studio` / `Ollama` on hosted: the Select shows the raw value with no matching item highlighted (cosmetic). Worth fixing here or leave for later?


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block localhost/loopback AI provider base URLs on hosted (`IS_HOSTED=true`) to prevent silent failures; self‑host (`IS_HOSTED=false`) remains unchanged.

- **New Features**
  - Added `validateAiBaseUrl(input, { isHosted })` to reject `localhost`, `*.localhost`, `127.0.0.0/8`, `0.0.0.0`, `::1`, `::`, and IPv4‑mapped loopback on hosted; empty values allowed.
  - Enforced in `POST /api/settings/ai/providers` and `PUT /api/settings/ai/providers/[id]`; returns `400 { error }` with a clear message.
  - Threaded `isHosted` into settings UI; hide LM Studio/Ollama presets on hosted and show a one‑line hint under Base URL; Add/Edit dialogs now surface server errors via `toast.error`.
  - Added unit tests for hosted rejects, self‑host allow‑all, and guard cases.

- **Migration**
  - On hosted, updating a provider with a loopback `baseUrl` now fails with a 400 error; change the URL to a public endpoint or self‑host to use LM Studio/Ollama.

<sup>Written for commit 71b3e387df42edb22efb7de46e0f59dafdb2281b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

