### PR TITLE
feat(analytics): add Rybbit analytics for hosted mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,26 @@ LOCAL_STORAGE_PATH=./storage
 # S3_ACCESS_KEY_ID=
 # S3_SECRET_ACCESS_KEY=
 
+# Rybbit analytics (hosted-only - leave blank for self-host)
+# Both must be set together. The tracking script is proxied through
+# /api/_int/* to bypass ad-blockers, so RYBBIT_HOST must be reachable
+# from the OpenPlaud server (server-to-server) - it does not need to be
+# public. Self-hosters: ignore both vars; the analytics component returns
+# null and no proxy routes are registered.
+#
+# Edge-proxy requirement: Rybbit derives client IP / geo from the
+# X-Forwarded-For (or X-Real-IP) header on the incoming request. Your
+# edge proxy in front of OpenPlaud (Caddy / nginx / Cloudflare) must
+# set X-Forwarded-For - all of those do by default. A bare `next start`
+# exposed directly to the internet will not, and Rybbit will see every
+# visitor as the OpenPlaud server's IP. Verify on first deploy by
+# checking that visitors show varied IPs / countries in the Rybbit dash.
+#
+# Enable "SPA Navigation" per-site in your Rybbit dashboard so client-side
+# Next.js route changes are tracked as pageviews.
+# RYBBIT_SITE_ID=
+# RYBBIT_HOST=https://rybbit.example.com
+
 # SMTP Configuration (optional - for email notifications)
 # SMTP_HOST=smtp.gmail.com
 # SMTP_PORT=587

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { env } from "./src/lib/env";
 
 const nextConfig: NextConfig = {
     output: "standalone",
@@ -6,6 +7,26 @@ const nextConfig: NextConfig = {
         loader: "custom",
         loaderFile: "./loader.ts",
         remotePatterns: [],
+    },
+    async rewrites() {
+        // Hosted-only stealth proxy for Rybbit analytics. Same-origin paths
+        // bypass ad-blockers; the underscored `_int` prefix avoids analytics
+        // keyword filters. Self-host (no IS_HOSTED + RYBBIT_*) registers no
+        // rewrites and never proxies to Rybbit.
+        if (!env.IS_HOSTED || !env.RYBBIT_HOST || !env.RYBBIT_SITE_ID) {
+            return [];
+        }
+        const host = env.RYBBIT_HOST.replace(/\/$/, "");
+        return [
+            {
+                source: "/api/_int/s.js",
+                destination: `${host}/api/script.js`,
+            },
+            {
+                source: "/api/_int/:path*",
+                destination: `${host}/api/:path*`,
+            },
+        ];
     },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from "next";
-import { env } from "./src/lib/env";
+
+// Note: we read `process.env` directly here instead of importing the
+// validated `env` from `src/lib/env.ts`. `next.config.ts` is evaluated
+// before Next sets `NEXT_PHASE=phase-production-build`, so the build-phase
+// skip in env.ts doesn't trigger and CI builds (which set placeholder
+// ENCRYPTION_KEY etc.) would fail validation. Build configuration is the
+// documented exception to the "no process.env in feature code" rule.
+const IS_HOSTED = process.env.IS_HOSTED === "true";
+const RYBBIT_HOST = process.env.RYBBIT_HOST?.replace(/\/$/, "");
+const RYBBIT_SITE_ID = process.env.RYBBIT_SITE_ID;
 
 const nextConfig: NextConfig = {
     output: "standalone",
@@ -13,18 +22,17 @@ const nextConfig: NextConfig = {
         // bypass ad-blockers; the underscored `_int` prefix avoids analytics
         // keyword filters. Self-host (no IS_HOSTED + RYBBIT_*) registers no
         // rewrites and never proxies to Rybbit.
-        if (!env.IS_HOSTED || !env.RYBBIT_HOST || !env.RYBBIT_SITE_ID) {
+        if (!IS_HOSTED || !RYBBIT_HOST || !RYBBIT_SITE_ID) {
             return [];
         }
-        const host = env.RYBBIT_HOST.replace(/\/$/, "");
         return [
             {
                 source: "/api/_int/s.js",
-                destination: `${host}/api/script.js`,
+                destination: `${RYBBIT_HOST}/api/script.js`,
             },
             {
                 source: "/api/_int/:path*",
-                destination: `${host}/api/:path*`,
+                destination: `${RYBBIT_HOST}/api/:path*`,
             },
         ];
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,14 +25,22 @@ const nextConfig: NextConfig = {
         if (!IS_HOSTED || !RYBBIT_HOST || !RYBBIT_SITE_ID) {
             return [];
         }
+        // Explicit allowlist instead of a `:path*` catch-all so the upstream
+        // Rybbit instance's full /api surface (admin/dashboard endpoints) is
+        // never inadvertently exposed under our origin. Update this list if a
+        // new tracking endpoint is added (e.g. session replay).
         return [
             {
                 source: "/api/_int/s.js",
                 destination: `${RYBBIT_HOST}/api/script.js`,
             },
             {
-                source: "/api/_int/:path*",
-                destination: `${RYBBIT_HOST}/api/:path*`,
+                source: "/api/_int/track",
+                destination: `${RYBBIT_HOST}/api/track`,
+            },
+            {
+                source: "/api/_int/identify",
+                destination: `${RYBBIT_HOST}/api/identify`,
             },
         ];
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { RybbitAnalytics } from "@/components/rybbit-analytics";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
@@ -39,6 +40,7 @@ export default function RootLayout({
                     {children}
                     <Toaster />
                 </ThemeProvider>
+                <RybbitAnalytics />
             </body>
         </html>
     );

--- a/src/components/rybbit-analytics.tsx
+++ b/src/components/rybbit-analytics.tsx
@@ -1,6 +1,11 @@
 import Script from "next/script";
 import { env } from "@/lib/env";
 
+// Module-scoped guard so the misconfig warning logs at most once per
+// server process, even though this server component re-renders on every
+// request (and may render multiple times in dev).
+let warnedMisconfig = false;
+
 /**
  * Rybbit analytics tracking script. Hosted-only.
  *
@@ -17,7 +22,8 @@ import { env } from "@/lib/env";
 export function RybbitAnalytics() {
     if (!env.IS_HOSTED) return null;
     if (!env.RYBBIT_SITE_ID || !env.RYBBIT_HOST) {
-        if (env.IS_HOSTED) {
+        if (!warnedMisconfig) {
+            warnedMisconfig = true;
             // Loud-but-non-fatal: hosted deploy missing analytics config.
             console.warn(
                 "[rybbit] IS_HOSTED=true but RYBBIT_SITE_ID and/or RYBBIT_HOST are unset; analytics disabled.",

--- a/src/components/rybbit-analytics.tsx
+++ b/src/components/rybbit-analytics.tsx
@@ -1,0 +1,36 @@
+import Script from "next/script";
+import { env } from "@/lib/env";
+
+/**
+ * Rybbit analytics tracking script. Hosted-only.
+ *
+ * Renders nothing unless `IS_HOSTED=true` and both `RYBBIT_SITE_ID` and
+ * `RYBBIT_HOST` are set. Self-hosters never load it and never make a
+ * request to Rybbit.
+ *
+ * The script is loaded from same-origin (`/api/_int/s.js`) via Next.js
+ * rewrites in `next.config.ts`. The Rybbit client derives its tracking
+ * endpoint from its own `src`, so events POST back to `/api/_int/track`
+ * (also same-origin), which the proxy forwards to `${RYBBIT_HOST}/api/track`.
+ * This bypasses ad-blockers that filter third-party analytics.
+ */
+export function RybbitAnalytics() {
+    if (!env.IS_HOSTED) return null;
+    if (!env.RYBBIT_SITE_ID || !env.RYBBIT_HOST) {
+        if (env.IS_HOSTED) {
+            // Loud-but-non-fatal: hosted deploy missing analytics config.
+            console.warn(
+                "[rybbit] IS_HOSTED=true but RYBBIT_SITE_ID and/or RYBBIT_HOST are unset; analytics disabled.",
+            );
+        }
+        return null;
+    }
+
+    return (
+        <Script
+            src="/api/_int/s.js"
+            data-site-id={env.RYBBIT_SITE_ID}
+            strategy="afterInteractive"
+        />
+    );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -52,6 +52,13 @@ export const envSchema = z.object({
         .transform((val) => val === "true"),
     SMTP_USER: z.string().optional(),
     SMTP_PASSWORD: z.string().optional(),
+    // Rybbit analytics (hosted mode only). Both must be set together for
+    // the tracking script and proxy rewrites to activate. Self-host leaves
+    // them unset; the analytics component returns null and no rewrites are
+    // registered, so no requests go to Rybbit at all.
+    RYBBIT_SITE_ID: z.string().optional(),
+    RYBBIT_HOST: z.string().url("RYBBIT_HOST must be a valid URL").optional(),
+
     SMTP_FROM: z
         .string()
         .optional()
@@ -97,6 +104,8 @@ function validateEnv(): Env {
             SMTP_HOST: process.env.SMTP_HOST,
             SMTP_PORT: process.env.SMTP_PORT,
             SMTP_SECURE: process.env.SMTP_SECURE,
+            RYBBIT_SITE_ID: process.env.RYBBIT_SITE_ID,
+            RYBBIT_HOST: process.env.RYBBIT_HOST,
             SMTP_USER: process.env.SMTP_USER,
             SMTP_PASSWORD: process.env.SMTP_PASSWORD,
             SMTP_FROM: process.env.SMTP_FROM,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Strip auth-bearing request headers from the Rybbit analytics proxy
+ * (`/api/_int/*`) so the upstream Rybbit instance never sees app session
+ * cookies or bearer tokens. The browser sends these by default for any
+ * same-origin request; without this middleware, Next's `rewrites()` would
+ * forward them to Rybbit as-is.
+ *
+ * X-Forwarded-For / User-Agent / Accept-Language are preserved so Rybbit
+ * can still derive geo, device, and language data.
+ */
+export function middleware(request: NextRequest) {
+    const headers = new Headers(request.headers);
+    headers.delete("cookie");
+    headers.delete("authorization");
+    return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+    matcher: "/api/_int/:path*",
+};

--- a/src/tests/regressions/90-rybbit-env.test.ts
+++ b/src/tests/regressions/90-rybbit-env.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for PR #90:
+ *   "feat(analytics): add Rybbit analytics for hosted mode"
+ *
+ * Verifies the env-schema contract for the Rybbit hosted-only vars:
+ *   - RYBBIT_SITE_ID is an optional string (no shape validation).
+ *   - RYBBIT_HOST is an optional URL; non-URL strings must be rejected.
+ *   - Partial config (only one of the two set) parses fine at the schema
+ *     level. The runtime gate in src/components/rybbit-analytics.tsx and
+ *     next.config.ts requires BOTH to be set before activating analytics,
+ *     so a half-configured hosted deploy stays disabled rather than
+ *     half-broken.
+ *
+ * NEXT_PHASE is set so importing env.ts does not run the runtime
+ * validation (DATABASE_URL etc) - we only need the schema here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+type EnvSchema = typeof import("@/lib/env")["envSchema"];
+let envSchema: EnvSchema;
+let originalNextPhase: string | undefined;
+
+beforeAll(async () => {
+    originalNextPhase = process.env.NEXT_PHASE;
+    process.env.NEXT_PHASE = "phase-production-build";
+    ({ envSchema } = await import("@/lib/env"));
+});
+
+afterAll(() => {
+    if (originalNextPhase === undefined) {
+        delete process.env.NEXT_PHASE;
+    } else {
+        process.env.NEXT_PHASE = originalNextPhase;
+    }
+});
+
+describe("PR #90: Rybbit env contract", () => {
+    it("defaults both vars to undefined when unset", () => {
+        const parsed = envSchema.parse({});
+        expect(parsed.RYBBIT_SITE_ID).toBeUndefined();
+        expect(parsed.RYBBIT_HOST).toBeUndefined();
+    });
+
+    it("accepts a valid RYBBIT_HOST URL", () => {
+        const parsed = envSchema.parse({
+            RYBBIT_HOST: "https://rybbit.example.com",
+        });
+        expect(parsed.RYBBIT_HOST).toBe("https://rybbit.example.com");
+    });
+
+    it("rejects a non-URL RYBBIT_HOST", () => {
+        expect(() =>
+            envSchema.parse({ RYBBIT_HOST: "not-a-url" }),
+        ).toThrowError(/RYBBIT_HOST must be a valid URL/);
+    });
+
+    it("rejects empty-string RYBBIT_HOST", () => {
+        expect(() => envSchema.parse({ RYBBIT_HOST: "" })).toThrowError(
+            /RYBBIT_HOST must be a valid URL/,
+        );
+    });
+
+    it("accepts only RYBBIT_SITE_ID without RYBBIT_HOST (partial config)", () => {
+        // The schema allows partial config; runtime gates in the analytics
+        // component + next.config.ts enforce that BOTH must be set before
+        // analytics activates. This stays disabled, not half-broken.
+        const parsed = envSchema.parse({ RYBBIT_SITE_ID: "abc123" });
+        expect(parsed.RYBBIT_SITE_ID).toBe("abc123");
+        expect(parsed.RYBBIT_HOST).toBeUndefined();
+    });
+
+    it("accepts only RYBBIT_HOST without RYBBIT_SITE_ID (partial config)", () => {
+        const parsed = envSchema.parse({
+            RYBBIT_HOST: "https://rybbit.example.com",
+        });
+        expect(parsed.RYBBIT_HOST).toBe("https://rybbit.example.com");
+        expect(parsed.RYBBIT_SITE_ID).toBeUndefined();
+    });
+
+    it("accepts both vars set together", () => {
+        const parsed = envSchema.parse({
+            RYBBIT_SITE_ID: "abc123",
+            RYBBIT_HOST: "https://rybbit.example.com",
+        });
+        expect(parsed.RYBBIT_SITE_ID).toBe("abc123");
+        expect(parsed.RYBBIT_HOST).toBe("https://rybbit.example.com");
+    });
+});


### PR DESCRIPTION
## Description

Adds Rybbit analytics to OpenPlaud, scoped strictly to hosted mode (`IS_HOSTED=true`). The tracking script is loaded via a same-origin stealth proxy at `/api/_int/*` to bypass ad-blockers. Self-host instances render no script tag and register no rewrites — zero requests to Rybbit, no config required.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

N/A

## Changes Made

- `src/lib/env.ts`: add `RYBBIT_SITE_ID` and `RYBBIT_HOST` (URL-validated, both optional). Both must be set together for analytics to activate.
- `next.config.ts`: conditional `rewrites()` proxying `/api/_int/s.js` → `${RYBBIT_HOST}/api/script.js` and `/api/_int/:path*` → `${RYBBIT_HOST}/api/:path*`. Returns `[]` unless `IS_HOSTED && RYBBIT_HOST && RYBBIT_SITE_ID` are all set.
- `src/components/rybbit-analytics.tsx`: new server component. Returns `null` unless all three env gates pass; otherwise renders `<Script src="/api/_int/s.js" data-site-id={...} strategy="afterInteractive" />`. Logs a one-time warning if `IS_HOSTED=true` but Rybbit vars are unset (loud-but-non-fatal misconfig signal).
- `src/app/layout.tsx`: mount `<RybbitAnalytics />` inside `<body>`.
- `.env.example`: document both vars under a hosted-only block, including the X-Forwarded-For edge-proxy requirement and the per-site SPA navigation toggle in Rybbit's dashboard.

## Design notes

- **Path naming (`/api/_int/`)**: chosen for ad-blocker resistance — no analytics keywords (`track`, `analytics`, vendor names) and underscored prefix reads as internal plumbing, not a tracker.
- **Pageviews only**: no custom events this round. Rybbit's per-site dashboard toggle handles SPA navigation tracking, so client-side Next.js route changes are captured without code. Adding events later is one helper + a call site.
- **Same-origin tradeoff**: loading Rybbit's script through `/api/_int/s.js` means it runs as same-origin with OpenPlaud and has full DOM access. Acceptable because Rybbit is self-hosted by us; trust boundary is ours.
- **Client IP forwarding**: Rybbit derives geo from `X-Forwarded-For` / `X-Real-IP`. Caddy / nginx / Cloudflare set this by default; bare `next start` does not. Documented in `.env.example`.
- **`next.config.ts` now imports validated `env`**: safe because `NEXT_PHASE=phase-production-build` skips strict runtime checks during build, matching existing behavior elsewhere.

## Testing

### Test Environment
- OS: macOS
- Node version: 22.20

### Test Steps
1. `pnpm format-and-lint:fix` — clean.
2. `pnpm type-check` — passes.
3. Manual deploy verification (post-merge): in Rybbit dashboard, confirm visitors show varied IPs / countries (validates X-Forwarded-For propagation through the rewrite). Enable "SPA Navigation" per-site so client-side route changes register as pageviews.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.env.example`)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — gating is trivial and `IS_HOSTED` is already covered by `src/tests/regressions/70-is-hosted.test.ts`
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. Self-host behavior is byte-identical when `IS_HOSTED` / `RYBBIT_*` are unset.

## Additional Notes

- The component and the rewrites use the same triple-gate (`IS_HOSTED && RYBBIT_SITE_ID && RYBBIT_HOST`), so there's no half-broken state where the script loads but proxy routes are missing (or vice versa).
- Path swap is a one-line change if `/api/_int/` ever lands on a filter list.

## For Reviewers

- Confirm the gating logic in `rybbit-analytics.tsx` and `next.config.ts` matches: both must require all three env vars before activating.
- Confirm `.env.example` accurately describes the X-Forwarded-For requirement for self-hosted Rybbit deployments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Rybbit analytics for hosted deployments via a same‑origin `/api/_int/*` proxy to bypass ad‑blockers. Disabled for self‑hosted; enable with `RYBBIT_SITE_ID` and `RYBBIT_HOST`.

- **New Features**
  - Activates only when `IS_HOSTED` and both vars are set; otherwise no rewrites and the component returns null.
  - New `RybbitAnalytics` server component mounted in the root layout; loads `/api/_int/s.js` with `data-site-id` and warns once per process if hosted but unset.

- **Bug Fixes**
  - Proxy narrowed to an allowlist: `/api/_int/s.js` → `${RYBBIT_HOST}/api/script.js`, `/api/_int/track` → `/api/track`, `/api/_int/identify` → `/api/identify`.
  - Middleware on `/api/_int/*` strips `Cookie` and `Authorization`; preserves `X-Forwarded-For` for geo.
  - `next.config.ts` reads `process.env` directly; rewrites stay gated by `IS_HOSTED`, `RYBBIT_SITE_ID`, and `RYBBIT_HOST`.

<sup>Written for commit 60dce7f12301fdc3e4fc7a4c4e40fe1bb40daf5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

