### PR TITLE
refactor(settings): remove redundant transcription status footer

### DIFF
--- a/src/components/settings-sections/transcription-section.tsx
+++ b/src/components/settings-sections/transcription-section.tsx
@@ -384,28 +384,6 @@ export function TranscriptionSection() {
                     </div>
                 )}
             </div>
-
-            <div className="pt-4 border-t">
-                <div className="space-y-2 text-sm">
-                    <div className="flex items-center justify-between">
-                        <span className="text-muted-foreground">Status</span>
-                        <span
-                            className={`font-medium ${
-                                autoTranscribe
-                                    ? "text-primary"
-                                    : "text-muted-foreground"
-                            }`}
-                        >
-                            {autoTranscribe ? "Enabled" : "Disabled"}
-                        </span>
-                    </div>
-                    <p className="text-xs text-muted-foreground pt-2">
-                        When enabled, new recordings will be automatically
-                        transcribed using your default transcription provider
-                        after syncing.
-                    </p>
-                </div>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Description

Removes the redundant "Status: Enabled/Disabled" footer block from the Transcription Settings section. The block only mirrored the `autoTranscribe` switch state, which is already conveyed by the toggle itself plus its existing helper line ("Automatically transcribe recordings when they are synced from your Plaud device").

## Type of Change

- [x] Code refactoring

## Related Issues

n/a

## Changes Made

- Deleted the trailing `<div className="pt-4 border-t">` block in `src/components/settings-sections/transcription-section.tsx` containing the duplicate Status row and description paragraph.
- No state, handler, API, schema, or settings semantics changed; `autoTranscribe` is still wired to the same switch.

## Screenshots (if applicable)

Before: settings → Transcription Settings showed a "Status: Disabled" row and a paragraph at the bottom that duplicated the switch above.
After: that footer block is gone; the switch + its helper text remain the single source of truth.

## Testing

### Test Environment
- OS: macOS
- Node version: per repo (.nvmrc / engines)
- Browser: n/a (no rendered verification run)

### Test Steps
1. `pnpm format-and-lint:fix` — clean, no fixes applied.
2. `pnpm type-check` — passes.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None. UI-only cleanup; no schema, env, or API surface changes.

## Additional Notes

Pure deletion. The auto-transcribe behavior is unchanged.

## For Reviewers

- Confirm you agree the footer block was redundant (switch + helper text below it already cover "what it does" and "is it on").


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant “Status: Enabled/Disabled” footer from Transcription Settings that duplicated the `autoTranscribe` toggle state. Simplifies the UI with no behavior, API, or schema changes.

<sup>Written for commit 36b8c564dd1e0a45ab04ea67dc2b27e792703f00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

