### PR TITLE
feat: Transcription summary multi tab

### DIFF
--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { OpenAI } from "openai";
 import { db } from "@/db";
@@ -27,7 +27,162 @@ import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
 
 type IdContext = { params: Promise<{ id: string }> };
 
-// POST - Generate summary
+async function resolveCredentials(userId: string) {
+    const [enhancementCredentials] = await db
+        .select()
+        .from(apiCredentials)
+        .where(
+            and(
+                eq(apiCredentials.userId, userId),
+                eq(apiCredentials.isDefaultEnhancement, true),
+            ),
+        )
+        .limit(1);
+
+    const [transcriptionCredentials] = await db
+        .select()
+        .from(apiCredentials)
+        .where(
+            and(
+                eq(apiCredentials.userId, userId),
+                eq(apiCredentials.isDefaultTranscription, true),
+            ),
+        )
+        .limit(1);
+
+    const credentials = enhancementCredentials || transcriptionCredentials;
+    if (!credentials) return null;
+
+    const apiKey = decrypt(credentials.apiKey);
+    let model = credentials.defaultModel || "gpt-4o-mini";
+    if (model.includes("whisper")) {
+        const baseUrl = credentials.baseUrl || "";
+        if (baseUrl.includes("groq")) {
+            model = "llama-3.1-8b-instant";
+        } else if (baseUrl.includes("together")) {
+            model = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo";
+        } else if (baseUrl.includes("openrouter")) {
+            model = "openai/gpt-4o-mini";
+        } else {
+            model = "gpt-4o-mini";
+        }
+    }
+
+    return { credentials, apiKey, model };
+}
+
+async function buildSummaryPrompt(
+    userId: string,
+    presetId: string | undefined,
+): Promise<{ promptTemplate: string; selectedPreset: string }> {
+    const [userSettingsRow] = await db
+        .select()
+        .from(userSettings)
+        .where(eq(userSettings.userId, userId))
+        .limit(1);
+
+    let promptConfig: SummaryPromptConfiguration =
+        getDefaultSummaryPromptConfig();
+    if (userSettingsRow?.summaryPrompt) {
+        const config =
+            decryptJsonField<SummaryPromptConfiguration>(
+                userSettingsRow.summaryPrompt,
+            ) ?? getDefaultSummaryPromptConfig();
+        promptConfig = {
+            selectedPrompt: config.selectedPrompt || "general",
+            customPrompts: config.customPrompts || [],
+        };
+    }
+
+    const selectedPreset = presetId || promptConfig.selectedPrompt || "general";
+    let promptTemplate = getSummaryPromptById(selectedPreset, promptConfig);
+
+    if (!promptTemplate) {
+        const defaultConfig = getDefaultSummaryPromptConfig();
+        promptTemplate = getSummaryPromptById(
+            defaultConfig.selectedPrompt,
+            defaultConfig,
+        );
+        if (!promptTemplate) {
+            throw new AppError(
+                ErrorCode.INTERNAL_ERROR,
+                "Failed to load summary prompt",
+                500,
+            );
+        }
+    }
+
+    return { promptTemplate, selectedPreset };
+}
+
+async function callAiSummary(
+    credentials: {
+        credentials: typeof apiCredentials.$inferSelect;
+        apiKey: string;
+        model: string;
+    },
+    transcriptText: string,
+    promptTemplate: string,
+    aiOutputLanguage: string | null,
+) {
+    const openai = new OpenAI({
+        apiKey: credentials.apiKey,
+        baseURL: credentials.credentials.baseUrl || undefined,
+    });
+
+    const maxLength = 8000;
+    const truncatedTranscription =
+        transcriptText.length > maxLength
+            ? `${transcriptText.substring(0, maxLength)}...`
+            : transcriptText;
+
+    const languageDirective = getAiOutputLanguageDirective(aiOutputLanguage);
+    const prompt = promptTemplate.replace(
+        "{transcription}",
+        truncatedTranscription,
+    );
+
+    const baseSystem =
+        "You are a helpful assistant that summarizes audio transcriptions. Always respond with valid JSON only, no markdown formatting or code fences.";
+    const systemContent = languageDirective
+        ? `${baseSystem} ${languageDirective}`
+        : baseSystem;
+
+    const response = await openai.chat.completions.create({
+        model: credentials.model,
+        messages: [
+            { role: "system", content: systemContent },
+            { role: "user", content: prompt },
+        ],
+        temperature: 0.5,
+        max_tokens: 2000,
+    });
+
+    const rawContent = response.choices[0]?.message?.content?.trim() || "";
+
+    let summary = "";
+    let keyPoints: string[] = [];
+    let actionItems: string[] = [];
+
+    try {
+        const cleanContent = rawContent
+            .replace(/^```(?:json)?\s*/i, "")
+            .replace(/\s*```$/i, "")
+            .trim();
+        const parsed = JSON.parse(cleanContent);
+        summary = parsed.summary || "";
+        keyPoints = Array.isArray(parsed.keyPoints) ? parsed.keyPoints : [];
+        actionItems = Array.isArray(parsed.actionItems)
+            ? parsed.actionItems
+            : [];
+    } catch {
+        summary = rawContent;
+    }
+
+    return { summary, keyPoints, actionItems };
+}
+
+// POST - Generate or regenerate a summary
 export const POST = apiHandler<IdContext>(async (request, context) => {
     const session = await auth.api.getSession({
         headers: request.headers,
@@ -40,17 +195,14 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
     const { id } = await (context as IdContext).params;
     const body = await request.json().catch(() => ({}));
     const presetId = (body.preset as string) || undefined;
+    const summaryId = (body.summaryId as string) || undefined;
 
     // Verify recording belongs to user
     const [recording] = await db
         .select()
         .from(recordings)
         .where(
-            and(
-                eq(recordings.id, id),
-                eq(recordings.userId, session.user.id),
-                isNull(recordings.deletedAt),
-            ),
+            and(eq(recordings.id, id), eq(recordings.userId, session.user.id)),
         )
         .limit(1);
 
@@ -77,74 +229,13 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         );
     }
 
-    // Get user's summary prompt configuration
-    const [userSettingsRow] = await db
-        .select()
-        .from(userSettings)
-        .where(eq(userSettings.userId, session.user.id))
-        .limit(1);
+    const { promptTemplate, selectedPreset } = await buildSummaryPrompt(
+        session.user.id,
+        presetId,
+    );
 
-    let promptConfig: SummaryPromptConfiguration =
-        getDefaultSummaryPromptConfig();
-    if (userSettingsRow?.summaryPrompt) {
-        // `summaryPrompt` is jsonb-envelope encrypted at rest. Decrypt
-        // (legacy plaintext rows pass through verbatim) before reading
-        // the user's prompt configuration.
-        const config =
-            decryptJsonField<SummaryPromptConfiguration>(
-                userSettingsRow.summaryPrompt,
-            ) ?? getDefaultSummaryPromptConfig();
-        promptConfig = {
-            selectedPrompt: config.selectedPrompt || "general",
-            customPrompts: config.customPrompts || [],
-        };
-    }
-
-    // Determine which prompt to use (body override > user setting > default)
-    const selectedPreset = presetId || promptConfig.selectedPrompt || "general";
-    let promptTemplate = getSummaryPromptById(selectedPreset, promptConfig);
-
-    if (!promptTemplate) {
-        const defaultConfig = getDefaultSummaryPromptConfig();
-        promptTemplate = getSummaryPromptById(
-            defaultConfig.selectedPrompt,
-            defaultConfig,
-        );
-        if (!promptTemplate) {
-            throw new AppError(
-                ErrorCode.INTERNAL_ERROR,
-                "Failed to load summary prompt",
-                500,
-            );
-        }
-    }
-
-    // Get AI credentials (prefer enhancement provider, fallback to transcription)
-    const [enhancementCredentials] = await db
-        .select()
-        .from(apiCredentials)
-        .where(
-            and(
-                eq(apiCredentials.userId, session.user.id),
-                eq(apiCredentials.isDefaultEnhancement, true),
-            ),
-        )
-        .limit(1);
-
-    const [transcriptionCredentials] = await db
-        .select()
-        .from(apiCredentials)
-        .where(
-            and(
-                eq(apiCredentials.userId, session.user.id),
-                eq(apiCredentials.isDefaultTranscription, true),
-            ),
-        )
-        .limit(1);
-
-    const credentials = enhancementCredentials || transcriptionCredentials;
-
-    if (!credentials) {
+    const creds = await resolveCredentials(session.user.id);
+    if (!creds) {
         throw new AppError(
             ErrorCode.AI_PROVIDER_NOT_CONFIGURED,
             "No AI provider configured",
@@ -152,115 +243,21 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         );
     }
 
-    const apiKey = decrypt(credentials.apiKey);
-
-    const openai = new OpenAI({
-        apiKey,
-        baseURL: credentials.baseUrl || undefined,
-    });
-
-    // Use a chat model, not whisper
-    // If the configured model is a transcription-only model,
-    // fall back to a reasonable chat model for the provider
-    let model = credentials.defaultModel || "gpt-4o-mini";
-    if (model.includes("whisper")) {
-        // Pick a lightweight chat model appropriate for the provider
-        const baseUrl = credentials.baseUrl || "";
-        if (baseUrl.includes("groq")) {
-            model = "llama-3.1-8b-instant";
-        } else if (baseUrl.includes("together")) {
-            model = "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo";
-        } else if (baseUrl.includes("openrouter")) {
-            model = "openai/gpt-4o-mini";
-        } else {
-            model = "gpt-4o-mini";
-        }
-    }
-
-    // Decrypt the transcript before sending it to the LLM. Plaintext is
-    // the LLM's input contract; ciphertext lives only in the DB.
     const transcriptText = decryptText(transcription.text);
 
-    // Truncate transcription if too long
-    const maxLength = 8000;
-    const truncatedTranscription =
-        transcriptText.length > maxLength
-            ? `${transcriptText.substring(0, maxLength)}...`
-            : transcriptText;
+    const [userSettingsRow] = await db
+        .select()
+        .from(userSettings)
+        .where(eq(userSettings.userId, session.user.id))
+        .limit(1);
 
-    // Apply AI output language directive (if configured) via the system
-    // message rather than the user prompt. This separates concerns: the
-    // user prompt carries the JSON-shape contract (English keys), the
-    // system message carries the output-language preference. Smaller
-    // models tend to honor this split more reliably than a combined
-    // prompt where language and JSON-shape rules compete.
-    const languageDirective = getAiOutputLanguageDirective(
+    const { summary, keyPoints, actionItems } = await callAiSummary(
+        creds,
+        transcriptText,
+        promptTemplate,
         userSettingsRow?.aiOutputLanguage ?? null,
     );
 
-    const prompt = promptTemplate.replace(
-        "{transcription}",
-        truncatedTranscription,
-    );
-
-    const baseSystem =
-        "You are a helpful assistant that summarizes audio transcriptions. Always respond with valid JSON only, no markdown formatting or code fences.";
-    const systemContent = languageDirective
-        ? `${baseSystem} ${languageDirective}`
-        : baseSystem;
-
-    const response = await openai.chat.completions.create({
-        model,
-        messages: [
-            {
-                role: "system",
-                content: systemContent,
-            },
-            {
-                role: "user",
-                content: prompt,
-            },
-        ],
-        temperature: 0.5,
-        max_tokens: 2000,
-    });
-
-    const rawContent = response.choices[0]?.message?.content?.trim() || "";
-
-    // Parse the JSON response
-    let summary = "";
-    let keyPoints: string[] = [];
-    let actionItems: string[] = [];
-
-    try {
-        // Strip markdown code fences if present
-        const cleanContent = rawContent
-            .replace(/^```(?:json)?\s*/i, "")
-            .replace(/\s*```$/i, "")
-            .trim();
-        const parsed = JSON.parse(cleanContent);
-        summary = parsed.summary || "";
-        keyPoints = Array.isArray(parsed.keyPoints) ? parsed.keyPoints : [];
-        actionItems = Array.isArray(parsed.actionItems)
-            ? parsed.actionItems
-            : [];
-    } catch {
-        // Fallback: treat entire response as summary text
-        summary = rawContent;
-    }
-
-    // Atomic tombstone re-check + upsert.
-    //
-    // The user may have deleted the recording while the (long-running)
-    // provider call was in flight. To prevent a delete that lands
-    // *between* our re-check and our upsert from being silently undone,
-    // we run both inside a single transaction that takes a row-level
-    // write lock (`FOR UPDATE`) on the recording. The DELETE handler's
-    // transaction acquires the same lock via its `UPDATE recordings`
-    // tombstone write, so the two transactions serialize: either we
-    // see `deletedAt` set and abort, or our upsert commits before
-    // DELETE runs and DELETE then cleans up our row inside its own tx.
-    // See PR #72.
     const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
     try {
         await db.transaction(async (tx) => {
@@ -280,34 +277,40 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                 throw RECORDING_TOMBSTONED;
             }
 
-            const [existing] = await tx
-                .select()
-                .from(aiEnhancements)
-                .where(
-                    and(
-                        eq(aiEnhancements.recordingId, id),
-                        eq(aiEnhancements.userId, session.user.id),
-                    ),
-                )
-                .limit(1);
-
-            // Encrypt content fields at rest. `summary` is a text column;
-            // `keyPoints` / `actionItems` are jsonb columns and are stored
-            // as `{ c: <ciphertext> }` envelopes (option (a) from the
-            // rollout plan — keeps the schema unchanged).
             const encryptedSummary = encryptText(summary);
             const encryptedKeyPoints = encryptJsonField(keyPoints);
             const encryptedActionItems = encryptJsonField(actionItems);
 
-            if (existing) {
+            if (summaryId) {
+                const [existing] = await tx
+                    .select()
+                    .from(aiEnhancements)
+                    .where(
+                        and(
+                            eq(aiEnhancements.id, summaryId),
+                            eq(aiEnhancements.recordingId, id),
+                            eq(aiEnhancements.userId, session.user.id),
+                        ),
+                    )
+                    .limit(1);
+
+                if (!existing) {
+                    throw new AppError(
+                        ErrorCode.NOT_FOUND,
+                        "Summary not found",
+                        404,
+                    );
+                }
+
                 await tx
                     .update(aiEnhancements)
                     .set({
                         summary: encryptedSummary,
                         keyPoints: encryptedKeyPoints,
                         actionItems: encryptedActionItems,
-                        provider: credentials.provider,
-                        model,
+                        provider: creds.credentials.provider,
+                        model: creds.model,
+                        presetId: selectedPreset,
                     })
                     .where(eq(aiEnhancements.id, existing.id));
             } else {
@@ -317,8 +320,9 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                     summary: encryptedSummary,
                     keyPoints: encryptedKeyPoints,
                     actionItems: encryptedActionItems,
-                    provider: credentials.provider,
-                    model,
+                    provider: creds.credentials.provider,
+                    model: creds.model,
+                    presetId: selectedPreset,
                 });
             }
         });
@@ -337,12 +341,13 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         summary,
         keyPoints,
         actionItems,
-        provider: credentials.provider,
-        model,
+        provider: creds.credentials.provider,
+        model: creds.model,
+        presetId: selectedPreset,
     });
 });
 
-// GET - Fetch existing summary
+// GET - Fetch all summaries for a recording
 export const GET = apiHandler<IdContext>(async (request, context) => {
     const session = await auth.api.getSession({
         headers: request.headers,
@@ -354,7 +359,7 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
 
     const { id } = await (context as IdContext).params;
 
-    const [enhancement] = await db
+    const enhancements = await db
         .select()
         .from(aiEnhancements)
         .where(
@@ -363,25 +368,23 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
                 eq(aiEnhancements.userId, session.user.id),
             ),
         )
-        .limit(1);
+        .orderBy(aiEnhancements.createdAt);
 
-    if (!enhancement) {
-        return NextResponse.json({ summary: null });
-    }
+    const summaries = enhancements.map((e) => ({
+        id: e.id,
+        summary: decryptText(e.summary),
+        keyPoints: decryptJsonField<string[]>(e.keyPoints),
+        actionItems: decryptJsonField<string[]>(e.actionItems),
+        provider: e.provider,
+        model: e.model,
+        presetId: e.presetId,
+        createdAt: e.createdAt,
+    }));
 
-    // Decrypt content fields before returning to the client. Legacy
-    // plaintext rows pass through verbatim during the backfill window.
-    return NextResponse.json({
-        summary: decryptText(enhancement.summary),
-        keyPoints: decryptJsonField<string[]>(enhancement.keyPoints),
-        actionItems: decryptJsonField<string[]>(enhancement.actionItems),
-        provider: enhancement.provider,
-        model: enhancement.model,
-        createdAt: enhancement.createdAt,
-    });
+    return NextResponse.json({ summaries });
 });
 
-// DELETE - Remove summary
+// DELETE - Remove a specific summary by id
 export const DELETE = apiHandler<IdContext>(async (request, context) => {
     const session = await auth.api.getSession({
         headers: request.headers,
@@ -392,11 +395,22 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
     }
 
     const { id } = await (context as IdContext).params;
+    const { searchParams } = new URL(request.url);
+    const summaryId = searchParams.get("summaryId");
+
+    if (!summaryId) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "summaryId query parameter is required",
+            400,
+        );
+    }
 
     await db
         .delete(aiEnhancements)
         .where(
             and(
+                eq(aiEnhancements.id, summaryId),
                 eq(aiEnhancements.recordingId, id),
                 eq(aiEnhancements.userId, session.user.id),
             ),

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -214,11 +214,20 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         );
     }
 
+    if (recording.deletedAt) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Recording was deleted", 410);
+    }
+
     // Get transcription text
     const [transcription] = await db
         .select()
         .from(transcriptions)
-        .where(eq(transcriptions.recordingId, id))
+        .where(
+            and(
+                eq(transcriptions.recordingId, id),
+                eq(transcriptions.userId, session.user.id),
+            ),
+        )
         .limit(1);
 
     if (!transcription) {

--- a/src/components/dashboard/summary-tabs.tsx
+++ b/src/components/dashboard/summary-tabs.tsx
@@ -88,6 +88,8 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
     // biome-ignore lint/correctness/useExhaustiveDependencies: fetchKey is an intentional re-fetch signal passed from parent
     useEffect(() => {
         setIsLoading(true);
+        setSummaries([]);
+        setActiveId(null);
         const controller = new AbortController();
 
         fetch(`/api/recordings/${recordingId}/summary`, {
@@ -386,13 +388,24 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                 promptConfig,
                             );
                             return (
-                                <button
+                                <div
                                     key={summary.id}
-                                    type="button"
+                                    role="tab"
+                                    aria-selected={isActive}
+                                    tabIndex={0}
                                     onClick={() => setActiveId(summary.id)}
+                                    onKeyDown={(e) => {
+                                        if (
+                                            e.key === "Enter" ||
+                                            e.key === " "
+                                        ) {
+                                            e.preventDefault();
+                                            setActiveId(summary.id);
+                                        }
+                                    }}
                                     className={`
                                     flex items-center gap-2 px-3 py-1.5 rounded-md text-sm
-                                    transition-colors whitespace-nowrap shrink-0
+                                    transition-colors whitespace-nowrap shrink-0 cursor-pointer
                                     ${
                                         isActive
                                             ? "bg-primary text-primary-foreground"
@@ -415,6 +428,7 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                     {summaries.length > 1 && (
                                         <button
                                             type="button"
+                                            aria-label="Delete summary"
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 handleDelete(summary.id);
@@ -425,7 +439,7 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                             <X className="w-3 h-3" />
                                         </button>
                                     )}
-                                </button>
+                                </div>
                             );
                         })}
                     </div>
@@ -524,8 +538,8 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                             </h4>
                                             <ul className="space-y-1">
                                                 {activeSummary.keyPoints.map(
-                                                    (point) => {
-                                                        const key = `kp-${point.slice(0, 32)}`;
+                                                    (point, index) => {
+                                                        const key = `kp-${index}`;
                                                         return (
                                                             <li
                                                                 key={key}
@@ -549,8 +563,8 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                             </h4>
                                             <ul className="space-y-1">
                                                 {activeSummary.actionItems.map(
-                                                    (item) => {
-                                                        const key = `ai-${item.slice(0, 32)}`;
+                                                    (item, index) => {
+                                                        const key = `ai-${index}`;
                                                         return (
                                                             <li
                                                                 key={key}

--- a/src/components/dashboard/summary-tabs.tsx
+++ b/src/components/dashboard/summary-tabs.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import {
+    ChevronDown,
+    ChevronUp,
+    ListChecks,
+    Loader2,
+    Plus,
+    RefreshCw,
+    Sparkles,
+    Trash2,
+    X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    getAllSummaryPrompts,
+    getDefaultSummaryPromptConfig,
+    SUMMARY_PRESETS,
+    type SummaryPromptConfiguration,
+} from "@/lib/ai/summary-presets";
+
+interface SummaryData {
+    id: string;
+    summary: string | null;
+    keyPoints: string[] | null;
+    actionItems: string[] | null;
+    provider?: string;
+    model?: string;
+    presetId: string;
+    createdAt: string;
+}
+
+interface SummaryTabsProps {
+    recordingId: string;
+    fetchKey?: number;
+}
+
+function getPresetName(
+    presetId: string,
+    config: SummaryPromptConfiguration,
+): string {
+    if (presetId in SUMMARY_PRESETS) {
+        return SUMMARY_PRESETS[presetId as keyof typeof SUMMARY_PRESETS].name;
+    }
+    const custom = config.customPrompts.find((p) => p.id === presetId);
+    return custom?.name || presetId;
+}
+
+export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
+    const [summaries, setSummaries] = useState<SummaryData[]>([]);
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isGenerating, setIsGenerating] = useState(false);
+    const [isRegenerating, setIsRegenerating] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [modalOpen, setModalOpen] = useState(false);
+    const [selectedPreset, setSelectedPreset] = useState("general");
+    const [expanded, setExpanded] = useState(true);
+    const [promptConfig, setPromptConfig] =
+        useState<SummaryPromptConfiguration>(getDefaultSummaryPromptConfig());
+
+    const activeSummary = useMemo(
+        () => summaries.find((s) => s.id === activeId) || summaries[0] || null,
+        [summaries, activeId],
+    );
+
+    const activeIdRef = useRef(activeId);
+    activeIdRef.current = activeId;
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: fetchKey is an intentional re-fetch signal passed from parent
+    useEffect(() => {
+        setIsLoading(true);
+        const controller = new AbortController();
+
+        fetch(`/api/recordings/${recordingId}/summary`, {
+            signal: controller.signal,
+        })
+            .then((res) => res.json())
+            .then((data: { summaries?: SummaryData[] }) => {
+                const list = data.summaries || [];
+                setSummaries(list);
+                if (
+                    list.length > 0 &&
+                    !list.find((s) => s.id === activeIdRef.current)
+                ) {
+                    setActiveId(list[0].id);
+                }
+                if (list.length === 0) {
+                    setActiveId(null);
+                }
+            })
+            .catch(() => {})
+            .finally(() => setIsLoading(false));
+
+        return () => controller.abort();
+    }, [recordingId, fetchKey]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        fetch("/api/settings/user", { signal: controller.signal })
+            .then((res) => res.json())
+            .then((settings) => {
+                if (settings?.summaryPrompt) {
+                    setPromptConfig({
+                        selectedPrompt:
+                            settings.summaryPrompt.selectedPrompt || "general",
+                        customPrompts:
+                            settings.summaryPrompt.customPrompts || [],
+                    });
+                }
+            })
+            .catch(() => {});
+        return () => controller.abort();
+    }, []);
+
+    const handleGenerateNew = useCallback(async () => {
+        setIsGenerating(true);
+        try {
+            const response = await fetch(
+                `/api/recordings/${recordingId}/summary`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ preset: selectedPreset }),
+                },
+            );
+
+            if (response.ok) {
+                const data = await response.json();
+                const newSummary: SummaryData = {
+                    id: data.id || crypto.randomUUID(),
+                    summary: data.summary,
+                    keyPoints: data.keyPoints,
+                    actionItems: data.actionItems,
+                    provider: data.provider,
+                    model: data.model,
+                    presetId: data.presetId || selectedPreset,
+                    createdAt: data.createdAt || new Date().toISOString(),
+                };
+                setSummaries((prev) => [...prev, newSummary]);
+                setActiveId(newSummary.id);
+                setModalOpen(false);
+                toast.success("Summary generated");
+            } else {
+                const error = await response.json();
+                toast.error(error.error || "Summary generation failed");
+            }
+        } catch {
+            toast.error("Failed to generate summary");
+        } finally {
+            setIsGenerating(false);
+        }
+    }, [recordingId, selectedPreset]);
+
+    const handleRegenerate = useCallback(
+        async (summaryId: string) => {
+            setIsRegenerating(true);
+            try {
+                const summary = summaries.find((s) => s.id === summaryId);
+                const response = await fetch(
+                    `/api/recordings/${recordingId}/summary`,
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                            summaryId,
+                            preset: summary?.presetId,
+                        }),
+                    },
+                );
+
+                if (response.ok) {
+                    const data = await response.json();
+                    setSummaries((prev) =>
+                        prev.map((s) =>
+                            s.id === summaryId
+                                ? {
+                                      ...s,
+                                      summary: data.summary,
+                                      keyPoints: data.keyPoints,
+                                      actionItems: data.actionItems,
+                                      provider: data.provider,
+                                      model: data.model,
+                                      presetId: data.presetId || s.presetId,
+                                      createdAt: data.createdAt || s.createdAt,
+                                  }
+                                : s,
+                        ),
+                    );
+                    toast.success("Summary regenerated");
+                } else {
+                    const error = await response.json();
+                    toast.error(error.error || "Regeneration failed");
+                }
+            } catch {
+                toast.error("Failed to regenerate summary");
+            } finally {
+                setIsRegenerating(false);
+            }
+        },
+        [recordingId, summaries],
+    );
+
+    const handleDelete = useCallback(
+        async (summaryId: string) => {
+            const previous = summaries;
+            setIsDeleting(true);
+            setSummaries((prev) => prev.filter((s) => s.id !== summaryId));
+            if (activeId === summaryId) {
+                const next = summaries.find((s) => s.id !== summaryId);
+                setActiveId(next?.id || null);
+            }
+
+            try {
+                const response = await fetch(
+                    `/api/recordings/${recordingId}/summary?summaryId=${summaryId}`,
+                    { method: "DELETE" },
+                );
+
+                if (response.ok) {
+                    toast.success("Summary deleted");
+                } else {
+                    setSummaries(previous);
+                    if (activeId === summaryId) {
+                        setActiveId(summaryId);
+                    }
+                    toast.error("Failed to delete summary");
+                }
+            } catch {
+                setSummaries(previous);
+                if (activeId === summaryId) {
+                    setActiveId(summaryId);
+                }
+                toast.error("Failed to delete summary");
+            } finally {
+                setIsDeleting(false);
+            }
+        },
+        [recordingId, summaries, activeId],
+    );
+
+    const allPrompts = useMemo(
+        () => getAllSummaryPrompts(promptConfig),
+        [promptConfig],
+    );
+
+    const firstGenerate = async () => {
+        setIsGenerating(true);
+        try {
+            const response = await fetch(
+                `/api/recordings/${recordingId}/summary`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({}),
+                },
+            );
+
+            if (response.ok) {
+                const data = await response.json();
+                const newSummary: SummaryData = {
+                    id: data.id || crypto.randomUUID(),
+                    summary: data.summary,
+                    keyPoints: data.keyPoints,
+                    actionItems: data.actionItems,
+                    provider: data.provider,
+                    model: data.model,
+                    presetId: data.presetId || "general",
+                    createdAt: data.createdAt || new Date().toISOString(),
+                };
+                setSummaries([newSummary]);
+                setActiveId(newSummary.id);
+                toast.success("Summary generated");
+            } else {
+                const error = await response.json();
+                toast.error(error.error || "Summary generation failed");
+            }
+        } catch {
+            toast.error("Failed to generate summary");
+        } finally {
+            setIsGenerating(false);
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <Card>
+                <CardContent className="py-8 text-center">
+                    <Loader2 className="w-8 h-8 animate-spin text-primary mx-auto mb-4" />
+                    <p className="text-sm text-muted-foreground">
+                        Loading summaries...
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (summaries.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <CardTitle className="flex items-center gap-2">
+                            <ListChecks className="w-5 h-5" />
+                            Summary
+                        </CardTitle>
+                        <Button
+                            onClick={firstGenerate}
+                            size="sm"
+                            disabled={isGenerating}
+                        >
+                            {isGenerating ? (
+                                <>
+                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    Generating...
+                                </>
+                            ) : (
+                                <>
+                                    <Sparkles className="w-4 h-4 mr-2" />
+                                    Summarize
+                                </>
+                            )}
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    <div className="flex flex-col items-center justify-center py-8 text-center">
+                        <ListChecks className="w-10 h-10 text-muted-foreground mb-3" />
+                        <p className="text-sm text-muted-foreground">
+                            No summary yet. Click Summarize to generate one.
+                        </p>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                    <CardTitle className="flex items-center gap-2">
+                        <ListChecks className="w-5 h-5" />
+                        Summaries
+                    </CardTitle>
+                </div>
+                <div className="flex items-center gap-2 mt-3 overflow-x-auto pb-1">
+                    {summaries.map((summary) => {
+                        const isActive = summary.id === activeId;
+                        const name = getPresetName(
+                            summary.presetId,
+                            promptConfig,
+                        );
+                        return (
+                            <button
+                                key={summary.id}
+                                type="button"
+                                onClick={() => setActiveId(summary.id)}
+                                className={`
+                                    flex items-center gap-2 px-3 py-1.5 rounded-md text-sm
+                                    transition-colors whitespace-nowrap shrink-0
+                                    ${
+                                        isActive
+                                            ? "bg-primary text-primary-foreground"
+                                            : "bg-muted hover:bg-muted/80 text-muted-foreground"
+                                    }
+                                `}
+                            >
+                                <span>{name}</span>
+                                <span
+                                    className={`text-xs opacity-60 ${
+                                        isActive
+                                            ? "text-primary-foreground"
+                                            : ""
+                                    }`}
+                                >
+                                    {new Date(
+                                        summary.createdAt,
+                                    ).toLocaleDateString()}
+                                </span>
+                                {summaries.length > 1 && (
+                                    <button
+                                        type="button"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleDelete(summary.id);
+                                        }}
+                                        className="ml-1 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
+                                        disabled={isDeleting}
+                                    >
+                                        <X className="w-3 h-3" />
+                                    </button>
+                                )}
+                            </button>
+                        );
+                    })}
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 h-8 px-2"
+                        onClick={() => setModalOpen(true)}
+                        disabled={isGenerating}
+                    >
+                        <Plus className="w-4 h-4" />
+                    </Button>
+                </div>
+            </CardHeader>
+
+            <CardContent>
+                {activeSummary && (
+                    <div className="space-y-4">
+                        <div className="flex items-center justify-between">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setExpanded(!expanded)}
+                                className="text-sm"
+                            >
+                                {expanded ? (
+                                    <>
+                                        <ChevronUp className="w-4 h-4 mr-1" />
+                                        Collapse
+                                    </>
+                                ) : (
+                                    <>
+                                        <ChevronDown className="w-4 h-4 mr-1" />
+                                        Expand
+                                    </>
+                                )}
+                            </Button>
+                            <div className="flex items-center gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                        handleRegenerate(activeSummary.id)
+                                    }
+                                    disabled={isRegenerating}
+                                >
+                                    {isRegenerating ? (
+                                        <>
+                                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                            Regenerating...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <RefreshCw className="w-4 h-4 mr-2" />
+                                            Re-generate
+                                        </>
+                                    )}
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="text-destructive hover:text-destructive"
+                                    onClick={() =>
+                                        handleDelete(activeSummary.id)
+                                    }
+                                    disabled={isDeleting}
+                                >
+                                    <Trash2 className="w-4 h-4 mr-1" />
+                                    Delete
+                                </Button>
+                            </div>
+                        </div>
+
+                        {expanded && (
+                            <>
+                                <div className="bg-muted rounded-lg p-4">
+                                    <p className="text-sm leading-relaxed">
+                                        {activeSummary.summary ||
+                                            "No summary text available."}
+                                    </p>
+                                </div>
+
+                                {activeSummary.keyPoints &&
+                                    activeSummary.keyPoints.length > 0 && (
+                                        <div>
+                                            <h4 className="text-sm font-medium mb-2">
+                                                Key Points
+                                            </h4>
+                                            <ul className="space-y-1">
+                                                {activeSummary.keyPoints.map(
+                                                    (point) => {
+                                                        const key = `kp-${point.slice(0, 32)}`;
+                                                        return (
+                                                            <li
+                                                                key={key}
+                                                                className="text-sm text-muted-foreground flex items-start gap-2"
+                                                            >
+                                                                <span className="text-primary mt-1.5 w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
+                                                                {point}
+                                                            </li>
+                                                        );
+                                                    },
+                                                )}
+                                            </ul>
+                                        </div>
+                                    )}
+
+                                {activeSummary.actionItems &&
+                                    activeSummary.actionItems.length > 0 && (
+                                        <div>
+                                            <h4 className="text-sm font-medium mb-2">
+                                                Action Items
+                                            </h4>
+                                            <ul className="space-y-1">
+                                                {activeSummary.actionItems.map(
+                                                    (item) => {
+                                                        const key = `ai-${item.slice(0, 32)}`;
+                                                        return (
+                                                            <li
+                                                                key={key}
+                                                                className="text-sm text-muted-foreground flex items-start gap-2"
+                                                            >
+                                                                <ListChecks className="w-3.5 h-3.5 mt-0.5 text-primary shrink-0" />
+                                                                {item}
+                                                            </li>
+                                                        );
+                                                    },
+                                                )}
+                                            </ul>
+                                        </div>
+                                    )}
+
+                                <div className="flex items-center gap-3 text-xs text-muted-foreground pt-2 border-t">
+                                    {activeSummary.provider && (
+                                        <span className="px-2 py-0.5 rounded bg-muted">
+                                            {activeSummary.provider}
+                                        </span>
+                                    )}
+                                    {activeSummary.model && (
+                                        <span className="px-2 py-0.5 rounded bg-muted font-mono">
+                                            {activeSummary.model}
+                                        </span>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                    </div>
+                )}
+            </CardContent>
+
+            <Dialog open={modalOpen} onOpenChange={setModalOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Generate New Summary</DialogTitle>
+                        <DialogDescription>
+                            Choose a template to create an additional summary
+                            for this recording.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="py-4">
+                        <Select
+                            value={selectedPreset}
+                            onValueChange={setSelectedPreset}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {allPrompts.map((prompt) => (
+                                    <SelectItem
+                                        key={prompt.id}
+                                        value={prompt.id}
+                                    >
+                                        {prompt.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setModalOpen(false)}
+                            disabled={isGenerating}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            onClick={handleGenerateNew}
+                            disabled={isGenerating}
+                        >
+                            {isGenerating ? (
+                                <>
+                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    Generating...
+                                </>
+                            ) : (
+                                <>
+                                    <Sparkles className="w-4 h-4 mr-2" />
+                                    Generate
+                                </>
+                            )}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </Card>
+    );
+}

--- a/src/components/dashboard/summary-tabs.tsx
+++ b/src/components/dashboard/summary-tabs.tsx
@@ -132,6 +132,7 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
     }, []);
 
     const handleGenerateNew = useCallback(async () => {
+        setModalOpen(false);
         setIsGenerating(true);
         try {
             const response = await fetch(
@@ -157,7 +158,6 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                 };
                 setSummaries((prev) => [...prev, newSummary]);
                 setActiveId(newSummary.id);
-                setModalOpen(false);
                 toast.success("Summary generated");
             } else {
                 const error = await response.json();
@@ -342,12 +342,21 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                     </div>
                 </CardHeader>
                 <CardContent>
-                    <div className="flex flex-col items-center justify-center py-8 text-center">
-                        <ListChecks className="w-10 h-10 text-muted-foreground mb-3" />
-                        <p className="text-sm text-muted-foreground">
-                            No summary yet. Click Summarize to generate one.
-                        </p>
-                    </div>
+                    {isGenerating ? (
+                        <div className="flex flex-col items-center justify-center py-8">
+                            <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
+                            <p className="text-sm text-muted-foreground">
+                                Generating summary...
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col items-center justify-center py-8 text-center">
+                            <ListChecks className="w-10 h-10 text-muted-foreground mb-3" />
+                            <p className="text-sm text-muted-foreground">
+                                No summary yet. Click Summarize to generate one.
+                            </p>
+                        </div>
+                    )}
                 </CardContent>
             </Card>
         );
@@ -433,7 +442,15 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
             </CardHeader>
 
             <CardContent>
-                {activeSummary && (
+                {isGenerating && (
+                    <div className="flex flex-col items-center justify-center py-8">
+                        <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
+                        <p className="text-sm text-muted-foreground">
+                            Generating new summary...
+                        </p>
+                    </div>
+                )}
+                {!isGenerating && activeSummary && (
                     <div className="space-y-4">
                         <div className="flex items-center justify-between">
                             <Button
@@ -600,25 +617,12 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                         <Button
                             variant="outline"
                             onClick={() => setModalOpen(false)}
-                            disabled={isGenerating}
                         >
                             Cancel
                         </Button>
-                        <Button
-                            onClick={handleGenerateNew}
-                            disabled={isGenerating}
-                        >
-                            {isGenerating ? (
-                                <>
-                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                                    Generating...
-                                </>
-                            ) : (
-                                <>
-                                    <Sparkles className="w-4 h-4 mr-2" />
-                                    Generate
-                                </>
-                            )}
+                        <Button onClick={handleGenerateNew}>
+                            <Sparkles className="w-4 h-4 mr-2" />
+                            Generate
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/src/components/dashboard/summary-tabs.tsx
+++ b/src/components/dashboard/summary-tabs.tsx
@@ -362,19 +362,26 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                         Summaries
                     </CardTitle>
                 </div>
-                <div className="flex items-center gap-2 mt-3 overflow-x-auto pb-1">
-                    {summaries.map((summary) => {
-                        const isActive = summary.id === activeId;
-                        const name = getPresetName(
-                            summary.presetId,
-                            promptConfig,
-                        );
-                        return (
-                            <button
-                                key={summary.id}
-                                type="button"
-                                onClick={() => setActiveId(summary.id)}
-                                className={`
+                <div className="flex items-center gap-2 mt-3">
+                    <div
+                        className="flex items-center gap-2 overflow-x-auto pb-1 flex-1 [&::-webkit-scrollbar]:hidden"
+                        style={{
+                            scrollbarWidth: "none",
+                            msOverflowStyle: "none",
+                        }}
+                    >
+                        {summaries.map((summary) => {
+                            const isActive = summary.id === activeId;
+                            const name = getPresetName(
+                                summary.presetId,
+                                promptConfig,
+                            );
+                            return (
+                                <button
+                                    key={summary.id}
+                                    type="button"
+                                    onClick={() => setActiveId(summary.id)}
+                                    className={`
                                     flex items-center gap-2 px-3 py-1.5 rounded-md text-sm
                                     transition-colors whitespace-nowrap shrink-0
                                     ${
@@ -383,35 +390,36 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
                                             : "bg-muted hover:bg-muted/80 text-muted-foreground"
                                     }
                                 `}
-                            >
-                                <span>{name}</span>
-                                <span
-                                    className={`text-xs opacity-60 ${
-                                        isActive
-                                            ? "text-primary-foreground"
-                                            : ""
-                                    }`}
                                 >
-                                    {new Date(
-                                        summary.createdAt,
-                                    ).toLocaleDateString()}
-                                </span>
-                                {summaries.length > 1 && (
-                                    <button
-                                        type="button"
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            handleDelete(summary.id);
-                                        }}
-                                        className="ml-1 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
-                                        disabled={isDeleting}
+                                    <span>{name}</span>
+                                    <span
+                                        className={`text-xs opacity-60 ${
+                                            isActive
+                                                ? "text-primary-foreground"
+                                                : ""
+                                        }`}
                                     >
-                                        <X className="w-3 h-3" />
-                                    </button>
-                                )}
-                            </button>
-                        );
-                    })}
+                                        {new Date(
+                                            summary.createdAt,
+                                        ).toLocaleDateString()}
+                                    </span>
+                                    {summaries.length > 1 && (
+                                        <button
+                                            type="button"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleDelete(summary.id);
+                                            }}
+                                            className="ml-1 p-0.5 rounded hover:bg-black/10 dark:hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
+                                            disabled={isDeleting}
+                                        >
+                                            <X className="w-3 h-3" />
+                                        </button>
+                                    )}
+                                </button>
+                            );
+                        })}
+                    </div>
                     <Button
                         variant="outline"
                         size="sm"

--- a/src/components/dashboard/summary-tabs.tsx
+++ b/src/components/dashboard/summary-tabs.tsx
@@ -89,7 +89,6 @@ export function SummaryTabs({ recordingId, fetchKey = 0 }: SummaryTabsProps) {
     useEffect(() => {
         setIsLoading(true);
         setSummaries([]);
-        setActiveId(null);
         const controller = new AbortController();
 
         fetch(`/api/recordings/${recordingId}/summary`, {

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -1,41 +1,15 @@
 "use client";
 
-import {
-    ChevronDown,
-    ChevronUp,
-    FileText,
-    Languages,
-    ListChecks,
-    Loader2,
-    RefreshCw,
-    Sparkles,
-    Trash2,
-} from "lucide-react";
-import React, { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
+import { FileText, Languages, RefreshCw, Sparkles } from "lucide-react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
-import { SUMMARY_PRESETS } from "@/lib/ai/summary-presets";
 import type { Recording } from "@/types/recording";
+import { SummaryTabs } from "./summary-tabs";
 
 interface Transcription {
     text?: string;
     language?: string;
-}
-
-interface SummaryData {
-    summary: string | null;
-    keyPoints: string[] | null;
-    actionItems: string[] | null;
-    provider?: string;
-    model?: string;
 }
 
 interface TranscriptionPanelProps {
@@ -51,96 +25,16 @@ export function TranscriptionPanel({
     isTranscribing,
     onTranscribe,
 }: TranscriptionPanelProps) {
-    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-    const [isSummarizing, setIsSummarizing] = useState(false);
-    const [summaryExpanded, setSummaryExpanded] = useState(true);
-    const [summaryPreset, setSummaryPreset] = useState("general");
-    // Key to force re-fetch summary (e.g. after transcription text changes)
     const [summaryFetchKey, setSummaryFetchKey] = useState(0);
     const transcriptionTextRef = React.useRef(transcription?.text);
 
-    // Detect when transcription text actually changes → invalidate summary
     if (transcription?.text !== transcriptionTextRef.current) {
         transcriptionTextRef.current = transcription?.text;
-        // will trigger the useEffect below on next render
         setSummaryFetchKey((k) => k + 1);
-        setSummaryData(null);
     }
-
-    // Fetch existing summary when recording changes
-    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch signal
-    useEffect(() => {
-        setSummaryData(null);
-        if (!recording?.id) return;
-
-        const controller = new AbortController();
-        fetch(`/api/recordings/${recording.id}/summary`, {
-            signal: controller.signal,
-        })
-            .then((res) => res.json())
-            .then((data) => {
-                if (data.summary) {
-                    setSummaryData(data);
-                }
-            })
-            .catch(() => {});
-
-        return () => controller.abort();
-    }, [recording?.id, summaryFetchKey]);
-
-    const handleSummarize = useCallback(async () => {
-        setIsSummarizing(true);
-        try {
-            const response = await fetch(
-                `/api/recordings/${recording.id}/summary`,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ preset: summaryPreset }),
-                },
-            );
-
-            if (response.ok) {
-                const data = await response.json();
-                setSummaryData(data);
-                toast.success("Summary generated");
-            } else {
-                const error = await response.json();
-                toast.error(error.error || "Summary generation failed");
-            }
-        } catch {
-            toast.error("Failed to generate summary");
-        } finally {
-            setIsSummarizing(false);
-        }
-    }, [recording.id, summaryPreset]);
-
-    const handleDeleteSummary = useCallback(async () => {
-        // Optimistic delete
-        const previous = summaryData;
-        setSummaryData(null);
-
-        try {
-            const response = await fetch(
-                `/api/recordings/${recording.id}/summary`,
-                { method: "DELETE" },
-            );
-
-            if (response.ok) {
-                toast.success("Summary deleted");
-            } else {
-                setSummaryData(previous);
-                toast.error("Failed to delete summary");
-            }
-        } catch {
-            setSummaryData(previous);
-            toast.error("Failed to delete summary");
-        }
-    }, [recording.id, summaryData]);
 
     return (
         <div className="space-y-4">
-            {/* Transcription Card */}
             <Card>
                 <CardHeader>
                     <div className="flex items-center justify-between">
@@ -224,198 +118,11 @@ export function TranscriptionPanel({
                 </CardContent>
             </Card>
 
-            {/* Summary Card — only show when transcription exists */}
             {transcription?.text && (
-                <Card>
-                    <CardHeader>
-                        <div className="flex items-center justify-between">
-                            <CardTitle className="flex items-center gap-2">
-                                <ListChecks className="w-5 h-5" />
-                                Summary
-                            </CardTitle>
-                            <div className="flex items-center gap-2">
-                                {!isSummarizing && (
-                                    <Select
-                                        value={summaryPreset}
-                                        onValueChange={setSummaryPreset}
-                                    >
-                                        <SelectTrigger className="w-[160px] h-8 text-xs">
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {Object.values(SUMMARY_PRESETS).map(
-                                                (preset) => (
-                                                    <SelectItem
-                                                        key={preset.id}
-                                                        value={preset.id}
-                                                    >
-                                                        {preset.name}
-                                                    </SelectItem>
-                                                ),
-                                            )}
-                                        </SelectContent>
-                                    </Select>
-                                )}
-                                <Button
-                                    onClick={handleSummarize}
-                                    size="sm"
-                                    variant={
-                                        summaryData ? "outline" : "default"
-                                    }
-                                    disabled={isSummarizing}
-                                >
-                                    {isSummarizing ? (
-                                        <>
-                                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                                            Generating...
-                                        </>
-                                    ) : summaryData ? (
-                                        <>
-                                            <RefreshCw className="w-4 h-4 mr-2" />
-                                            Re-generate
-                                        </>
-                                    ) : (
-                                        <>
-                                            <Sparkles className="w-4 h-4 mr-2" />
-                                            Summarize
-                                        </>
-                                    )}
-                                </Button>
-                            </div>
-                        </div>
-                    </CardHeader>
-                    <CardContent>
-                        {isSummarizing ? (
-                            <div className="flex flex-col items-center justify-center py-8">
-                                <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
-                                <p className="text-sm text-muted-foreground">
-                                    Generating summary...
-                                </p>
-                            </div>
-                        ) : summaryData?.summary ? (
-                            <div className="space-y-4">
-                                <button
-                                    type="button"
-                                    onClick={() =>
-                                        setSummaryExpanded(!summaryExpanded)
-                                    }
-                                    className="flex items-center gap-1 text-sm font-medium hover:text-primary transition-colors"
-                                >
-                                    {summaryExpanded ? (
-                                        <ChevronUp className="w-4 h-4" />
-                                    ) : (
-                                        <ChevronDown className="w-4 h-4" />
-                                    )}
-                                    {summaryExpanded
-                                        ? "Collapse"
-                                        : "Expand summary"}
-                                </button>
-
-                                {summaryExpanded && (
-                                    <div className="space-y-4">
-                                        {/* Summary text */}
-                                        <div className="bg-muted rounded-lg p-4">
-                                            <p className="text-sm leading-relaxed">
-                                                {summaryData.summary}
-                                            </p>
-                                        </div>
-
-                                        {/* Key points */}
-                                        {summaryData.keyPoints &&
-                                            summaryData.keyPoints.length >
-                                                0 && (
-                                                <div>
-                                                    <h4 className="text-sm font-medium mb-2">
-                                                        Key Points
-                                                    </h4>
-                                                    <ul className="space-y-1">
-                                                        {summaryData.keyPoints.map(
-                                                            (point) => {
-                                                                const key = `kp-${point.slice(0, 32)}`;
-                                                                return (
-                                                                    <li
-                                                                        key={
-                                                                            key
-                                                                        }
-                                                                        className="text-sm text-muted-foreground flex items-start gap-2"
-                                                                    >
-                                                                        <span className="text-primary mt-1.5 w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
-                                                                        {point}
-                                                                    </li>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </ul>
-                                                </div>
-                                            )}
-
-                                        {/* Action items */}
-                                        {summaryData.actionItems &&
-                                            summaryData.actionItems.length >
-                                                0 && (
-                                                <div>
-                                                    <h4 className="text-sm font-medium mb-2">
-                                                        Action Items
-                                                    </h4>
-                                                    <ul className="space-y-1">
-                                                        {summaryData.actionItems.map(
-                                                            (item) => {
-                                                                const key = `ai-${item.slice(0, 32)}`;
-                                                                return (
-                                                                    <li
-                                                                        key={
-                                                                            key
-                                                                        }
-                                                                        className="text-sm text-muted-foreground flex items-start gap-2"
-                                                                    >
-                                                                        <ListChecks className="w-3.5 h-3.5 mt-0.5 text-primary shrink-0" />
-                                                                        {item}
-                                                                    </li>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </ul>
-                                                </div>
-                                            )}
-
-                                        {/* Meta + Delete */}
-                                        <div className="flex items-center justify-between pt-2 border-t">
-                                            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                                                {summaryData.provider && (
-                                                    <span className="px-2 py-0.5 rounded bg-muted">
-                                                        {summaryData.provider}
-                                                    </span>
-                                                )}
-                                                {summaryData.model && (
-                                                    <span className="px-2 py-0.5 rounded bg-muted font-mono">
-                                                        {summaryData.model}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            <Button
-                                                onClick={handleDeleteSummary}
-                                                size="sm"
-                                                variant="ghost"
-                                                className="text-destructive hover:text-destructive"
-                                            >
-                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                Delete
-                                            </Button>
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        ) : (
-                            <div className="flex flex-col items-center justify-center py-8 text-center">
-                                <ListChecks className="w-10 h-10 text-muted-foreground mb-3" />
-                                <p className="text-sm text-muted-foreground">
-                                    No summary yet. Click "Summarize" to
-                                    generate one.
-                                </p>
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
+                <SummaryTabs
+                    recordingId={recording.id}
+                    fetchKey={summaryFetchKey}
+                />
             )}
         </div>
     );

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -1,35 +1,11 @@
 "use client";
 
-import {
-    ChevronDown,
-    ChevronUp,
-    ListChecks,
-    Loader2,
-    RefreshCw,
-    Sparkles,
-    Trash2,
-} from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
+import { SummaryTabs } from "@/components/dashboard/summary-tabs";
 import { LEDIndicator } from "@/components/led-indicator";
 import { MetalButton } from "@/components/metal-button";
 import { Panel } from "@/components/panel";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
-import { SUMMARY_PRESETS } from "@/lib/ai/summary-presets";
-
-interface SummaryData {
-    summary: string | null;
-    keyPoints: string[] | null;
-    actionItems: string[] | null;
-    provider?: string;
-    model?: string;
-}
 
 interface TranscriptionSectionProps {
     recordingId: string;
@@ -48,44 +24,14 @@ export function TranscriptionSection({
     const [detectedLanguage, setDetectedLanguage] = useState(initialLanguage);
     const [transcriptionType, setTranscriptionType] = useState(initialType);
     const [isProcessing, setIsProcessing] = useState(false);
-
-    // Summary state
-    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-    const [isSummarizing, setIsSummarizing] = useState(false);
-    const [summaryExpanded, setSummaryExpanded] = useState(true);
-    const [summaryPreset, setSummaryPreset] = useState("general");
-
-    // Key to force re-fetch summary (e.g. after re-transcription)
     const [summaryFetchKey, setSummaryFetchKey] = useState(0);
-
-    // Fetch existing summary on mount / after re-transcribe
-    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch trigger
-    useEffect(() => {
-        const controller = new AbortController();
-        fetch(`/api/recordings/${recordingId}/summary`, {
-            signal: controller.signal,
-        })
-            .then((res) => res.json())
-            .then((data) => {
-                if (data.summary) {
-                    setSummaryData(data);
-                } else {
-                    setSummaryData(null);
-                }
-            })
-            .catch(() => {});
-
-        return () => controller.abort();
-    }, [recordingId, summaryFetchKey]);
 
     const handleTranscribe = async () => {
         setIsProcessing(true);
         try {
             const response = await fetch(
                 `/api/recordings/${recordingId}/transcribe`,
-                {
-                    method: "POST",
-                },
+                { method: "POST" },
             );
 
             if (!response.ok) {
@@ -107,8 +53,6 @@ export function TranscriptionSection({
             setTranscription(data.transcription);
             setDetectedLanguage(data.detectedLanguage);
             setTranscriptionType("server");
-            // Invalidate cached summary — it was based on old text
-            setSummaryData(null);
             setSummaryFetchKey((k) => k + 1);
             toast.success("Transcription complete");
         } catch {
@@ -118,59 +62,8 @@ export function TranscriptionSection({
         }
     };
 
-    const handleSummarize = useCallback(async () => {
-        setIsSummarizing(true);
-        try {
-            const response = await fetch(
-                `/api/recordings/${recordingId}/summary`,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ preset: summaryPreset }),
-                },
-            );
-
-            if (response.ok) {
-                const data = await response.json();
-                setSummaryData(data);
-                toast.success("Summary generated");
-            } else {
-                const error = await response.json();
-                toast.error(error.error || "Summary generation failed");
-            }
-        } catch {
-            toast.error("Failed to generate summary");
-        } finally {
-            setIsSummarizing(false);
-        }
-    }, [recordingId, summaryPreset]);
-
-    const handleDeleteSummary = useCallback(async () => {
-        // Optimistic delete
-        const previous = summaryData;
-        setSummaryData(null);
-
-        try {
-            const response = await fetch(
-                `/api/recordings/${recordingId}/summary`,
-                { method: "DELETE" },
-            );
-
-            if (response.ok) {
-                toast.success("Summary deleted");
-            } else {
-                setSummaryData(previous);
-                toast.error("Failed to delete summary");
-            }
-        } catch {
-            setSummaryData(previous);
-            toast.error("Failed to delete summary");
-        }
-    }, [recordingId, summaryData]);
-
     return (
         <div className="space-y-6">
-            {/* Transcription Panel */}
             <Panel>
                 <div className="space-y-4">
                     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
@@ -237,189 +130,11 @@ export function TranscriptionSection({
                 </div>
             </Panel>
 
-            {/* Summary Panel — only show when transcription exists */}
             {transcription && (
-                <Panel>
-                    <div className="space-y-4">
-                        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                            <div className="flex items-center gap-3">
-                                <h2 className="text-xl font-bold">Summary</h2>
-                            </div>
-                            <div className="flex items-center gap-2">
-                                {!isSummarizing && (
-                                    <Select
-                                        value={summaryPreset}
-                                        onValueChange={setSummaryPreset}
-                                    >
-                                        <SelectTrigger className="w-[160px] h-8 text-xs">
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {Object.values(SUMMARY_PRESETS).map(
-                                                (preset) => (
-                                                    <SelectItem
-                                                        key={preset.id}
-                                                        value={preset.id}
-                                                    >
-                                                        {preset.name}
-                                                    </SelectItem>
-                                                ),
-                                            )}
-                                        </SelectContent>
-                                    </Select>
-                                )}
-                                <MetalButton
-                                    onClick={handleSummarize}
-                                    variant="cyan"
-                                    disabled={isSummarizing}
-                                    className="w-full md:w-auto"
-                                >
-                                    {isSummarizing ? (
-                                        <>
-                                            <Loader2 className="w-4 h-4 mr-2 animate-spin inline" />
-                                            Generating...
-                                        </>
-                                    ) : summaryData ? (
-                                        <>
-                                            <RefreshCw className="w-4 h-4 mr-2 inline" />
-                                            Re-generate
-                                        </>
-                                    ) : (
-                                        <>
-                                            <Sparkles className="w-4 h-4 mr-2 inline" />
-                                            Summarize
-                                        </>
-                                    )}
-                                </MetalButton>
-                            </div>
-                        </div>
-
-                        {isSummarizing ? (
-                            <Panel variant="inset" className="text-center py-8">
-                                <Loader2 className="w-8 h-8 animate-spin text-accent-cyan mx-auto mb-4" />
-                                <p className="text-muted-foreground">
-                                    Generating summary...
-                                </p>
-                            </Panel>
-                        ) : summaryData?.summary ? (
-                            <div className="space-y-4">
-                                <button
-                                    type="button"
-                                    onClick={() =>
-                                        setSummaryExpanded(!summaryExpanded)
-                                    }
-                                    className="flex items-center gap-1 text-sm font-medium hover:text-accent-cyan transition-colors"
-                                >
-                                    {summaryExpanded ? (
-                                        <ChevronUp className="w-4 h-4" />
-                                    ) : (
-                                        <ChevronDown className="w-4 h-4" />
-                                    )}
-                                    {summaryExpanded
-                                        ? "Collapse"
-                                        : "Expand summary"}
-                                </button>
-
-                                {summaryExpanded && (
-                                    <div className="space-y-4">
-                                        <div className="info-card">
-                                            <p className="leading-relaxed">
-                                                {summaryData.summary}
-                                            </p>
-                                        </div>
-
-                                        {summaryData.keyPoints &&
-                                            summaryData.keyPoints.length >
-                                                0 && (
-                                                <div>
-                                                    <h4 className="text-sm font-medium mb-2">
-                                                        Key Points
-                                                    </h4>
-                                                    <ul className="space-y-1">
-                                                        {summaryData.keyPoints.map(
-                                                            (point) => {
-                                                                const key = `kp-${point.slice(0, 32)}`;
-                                                                return (
-                                                                    <li
-                                                                        key={
-                                                                            key
-                                                                        }
-                                                                        className="text-sm text-muted-foreground flex items-start gap-2"
-                                                                    >
-                                                                        <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-accent-cyan shrink-0" />
-                                                                        {point}
-                                                                    </li>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </ul>
-                                                </div>
-                                            )}
-
-                                        {summaryData.actionItems &&
-                                            summaryData.actionItems.length >
-                                                0 && (
-                                                <div>
-                                                    <h4 className="text-sm font-medium mb-2">
-                                                        Action Items
-                                                    </h4>
-                                                    <ul className="space-y-1">
-                                                        {summaryData.actionItems.map(
-                                                            (item) => {
-                                                                const key = `ai-${item.slice(0, 32)}`;
-                                                                return (
-                                                                    <li
-                                                                        key={
-                                                                            key
-                                                                        }
-                                                                        className="text-sm text-muted-foreground flex items-start gap-2"
-                                                                    >
-                                                                        <ListChecks className="w-3.5 h-3.5 mt-0.5 text-accent-cyan shrink-0" />
-                                                                        {item}
-                                                                    </li>
-                                                                );
-                                                            },
-                                                        )}
-                                                    </ul>
-                                                </div>
-                                            )}
-
-                                        <div className="flex items-center justify-between pt-2 border-t border-panel-border">
-                                            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                                                {summaryData.provider && (
-                                                    <span className="px-2 py-0.5 rounded bg-panel-inset">
-                                                        {summaryData.provider}
-                                                    </span>
-                                                )}
-                                                {summaryData.model && (
-                                                    <span className="px-2 py-0.5 rounded bg-panel-inset font-mono">
-                                                        {summaryData.model}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            <MetalButton
-                                                onClick={handleDeleteSummary}
-                                                variant="cyan"
-                                                className="text-xs"
-                                            >
-                                                <Trash2 className="w-3.5 h-3.5 mr-1 inline" />
-                                                Delete
-                                            </MetalButton>
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        ) : (
-                            <Panel variant="inset" className="text-center py-8">
-                                <ListChecks className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
-                                <p className="text-sm text-muted-foreground">
-                                    No summary yet. Click &quot;Summarize&quot;
-                                    to generate one.
-                                </p>
-                            </Panel>
-                        )}
-                    </div>
-                </Panel>
+                <SummaryTabs
+                    recordingId={recordingId}
+                    fetchKey={summaryFetchKey}
+                />
             )}
         </div>
     );

--- a/src/db/migrations/0018_mean_impossible_man.sql
+++ b/src/db/migrations/0018_mean_impossible_man.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "ai_enhancements" DROP CONSTRAINT "ai_enhancements_recording_id_user_id_unique";--> statement-breakpoint
+ALTER TABLE "ai_enhancements" ADD COLUMN "preset_id" varchar(100) DEFAULT 'general' NOT NULL;--> statement-breakpoint
+CREATE INDEX "ai_enhancements_recording_id_idx" ON "ai_enhancements" USING btree ("recording_id");--> statement-breakpoint
+CREATE INDEX "ai_enhancements_user_id_idx" ON "ai_enhancements" USING btree ("user_id");

--- a/src/db/migrations/meta/0018_snapshot.json
+++ b/src/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1413 @@
+{
+  "id": "472f569a-a655-4273-bd46-ce697d5ae779",
+  "prevId": "bcbcb599-73da-4b57-b83d-5dbbb5836262",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_enhancements_recording_id_idx": {
+          "name": "ai_enhancements_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_enhancements_user_id_idx": {
+          "name": "ai_enhancements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_plaud_file_id_unique": {
+          "name": "recordings_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777730082791,
       "tag": "0017_curved_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1778205400105,
+      "tag": "0018_mean_impossible_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -225,11 +225,18 @@ export const aiEnhancements = pgTable(
         keyPoints: jsonb("key_points"), // Array of key points
         provider: varchar("provider", { length: 100 }).notNull(), // e.g., 'openai', 'anthropic-via-openrouter'
         model: varchar("model", { length: 100 }).notNull(), // e.g., 'gpt-4o', 'claude-3.5-sonnet'
+        presetId: varchar("preset_id", { length: 100 })
+            .notNull()
+            .default("general"), // Which prompt preset was used
         createdAt: timestamp("created_at").notNull().defaultNow(),
     },
     (table) => ({
-        // Each user can have at most one enhancement per recording
-        userRecordingUnique: unique().on(table.recordingId, table.userId),
+        // Index for looking up all summaries for a recording
+        recordingIdIdx: index("ai_enhancements_recording_id_idx").on(
+            table.recordingId,
+        ),
+        // Index for user-scoped queries
+        userIdIdx: index("ai_enhancements_user_id_idx").on(table.userId),
     }),
 );
 


### PR DESCRIPTION
## Description

Enable multiple AI-generated summaries per recording using different templates. Instead of overwriting a single summary on regeneration, users can create additional summaries via a + button and switch between them with a tab bar. Each summary is tagged with the template that produced it.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes made in this PR -->

Database & API
- Dropped UNIQUE(recording_id, user_id) constraint on ai_enhancements
- Added preset_id column to ai_enhancements to track which template was used for each summary
- Generated Drizzle migration 0018_mean_impossible_man.sql
- Rewrote /api/recordings/[id]/summary route:
  - GET now returns { summaries: SummaryData[] } instead of a single summary
  - POST creates a new summary when preset is provided; regenerates an existing one when summaryId is provided
  - DELETE now requires ?summaryId= query param and removes only the targeted summary
    UI Components
- Created SummaryTabs — a reusable tabbed summary component with:
  - Horizontal tab bar showing preset name + creation date
  - Active tab highlighting; click to switch
  - - button fixed to the right of the tab bar (does not scroll with tabs)
  - Template picker modal for generating a new summary
  - Modal closes immediately on Generate; loading state shown in the summary card area
  - Per-tab Re-generate and Delete actions
  - Expand/collapse summary content
  - Full support for custom prompts from user settings
  - Scrollbar hidden on tab bar for clean visual appearance
- Updated TranscriptionPanel (shadcn version) to delegate summary display to SummaryTabs
- Updated TranscriptionSection (hardware-aesthetic version) to delegate summary display to SummaryTabs

## Screenshots (if applicable)

<img width="840" height="619" alt="image" src="https://github.com/user-attachments/assets/55f4f52c-ca28-47cc-8013-d5abd7326fbb" />
<img width="887" height="528" alt="image" src="https://github.com/user-attachments/assets/b8933ece-7b46-4751-9dfd-009dd90a0871" />
<img width="910" height="540" alt="image" src="https://github.com/user-attachments/assets/075559af-3875-4af7-bf64-197c831a8fb7" />


## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Test Environment
- OS: Docker
- Node version:
- Browser (if UI changes): zen, arc

### Test Steps
1. Open any recording with a transcription
2. Click Summarize to generate the first summary with the default template
3. Verify the summary appears in a single tab
4. Click the + button and choose a different template (e.g., "Meeting Notes")
5. Verify the modal closes instantly, a loading spinner appears in the summary card area, and the new tab is created and auto-selected
6. Verify the first summary remains accessible via its tab
7. Click Re-generate on the active tab to refresh only that summary
8. Click Delete on a tab to remove only that specific summary (confirm others remain)
9. Re-transcribe the recording and verify the summaries invalidate and re-fetch
   Checklist

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

<!-- If this PR includes database schema changes -->

- [x] I have generated a new migration (`pnpm db:generate`)
- [x] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

Backward compatibility note:
- Existing clients that call GET /api/recordings/{id}/summary expecting { summary } will need to be updated to read from { summaries[0] }.
- The DELETE endpoint no longer deletes all summaries for a recording; it now requires ?summaryId=.
- The POST endpoint preset only creates new summaries; summaryId is required to regenerate an existing one.

## Additional Notes

<!-- Any additional information that reviewers should know -->

## For Reviewers

- API behavior correctness — POST with and without summaryId
- SummaryTabs component — tab state management and generation flow UX
- Migration correctness for existing data (old unique-constraint rows remain valid)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users create multiple generated summaries per recording and switch between them with tabs. Also hardens API tenant checks, adds a tombstone guard for deleted recordings, improves tab accessibility, and preserves the active tab after re-transcription re-fetch.

- New Features
  - Tabbed summaries with preset name and date; fixed + button to add another summary.
  - Template picker modal closes on Generate; loading shown in the summary card; supports custom prompts.
  - Per-tab actions: Regenerate and Delete; expand/collapse content.
  - Integrated into TranscriptionPanel and TranscriptionSection via a new SummaryTabs component.

- Migration
  - Clients must read from summaries[] instead of a single summary.
  - API: GET returns { summaries: SummaryData[] }; POST creates with preset or regenerates with summaryId; DELETE requires ?summaryId=.
  - DB: drop UNIQUE(recording_id, user_id); add preset_id to ai_enhancements; add indexes on recording_id and user_id. Run migration 0018.

<sup>Written for commit 4ffb78a94f8cefede59d41045e8f092db4773797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

