### PR TITLE
refactor(settings): centralize AI provider presets and fix legacy local provider edit on hosted

### DIFF
--- a/src/components/settings/add-provider-dialog.tsx
+++ b/src/components/settings/add-provider-dialog.tsx
@@ -19,6 +19,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { findPreset, getVisiblePresets } from "@/lib/ai/provider-presets";
 
 interface AddProviderDialogProps {
     open: boolean;
@@ -32,62 +33,13 @@ interface AddProviderDialogProps {
     isHosted?: boolean;
 }
 
-const LOCAL_PRESET_NAMES = new Set(["LM Studio", "Ollama"]);
-
-const providerPresets = [
-    {
-        name: "OpenAI",
-        baseUrl: "",
-        placeholder: "sk-...",
-        defaultModel: "whisper-1",
-    },
-    {
-        name: "Groq",
-        baseUrl: "https://api.groq.com/openai/v1",
-        placeholder: "gsk_...",
-        defaultModel: "whisper-large-v3-turbo",
-    },
-    {
-        name: "Together AI",
-        baseUrl: "https://api.together.xyz/v1",
-        placeholder: "...",
-        defaultModel: "whisper-large-v3",
-    },
-    {
-        name: "OpenRouter",
-        baseUrl: "https://openrouter.ai/api/v1",
-        placeholder: "sk-or-...",
-        defaultModel: "whisper-1",
-    },
-    {
-        name: "LM Studio",
-        baseUrl: "http://localhost:1234/v1",
-        placeholder: "lm-studio",
-        defaultModel: "",
-    },
-    {
-        name: "Ollama",
-        baseUrl: "http://localhost:11434/v1",
-        placeholder: "ollama",
-        defaultModel: "",
-    },
-    {
-        name: "Custom",
-        baseUrl: "",
-        placeholder: "Your API key",
-        defaultModel: "",
-    },
-];
-
 export function AddProviderDialog({
     open,
     onOpenChange,
     onSuccess,
     isHosted = false,
 }: AddProviderDialogProps) {
-    const visiblePresets = isHosted
-        ? providerPresets.filter((p) => !LOCAL_PRESET_NAMES.has(p.name))
-        : providerPresets;
+    const visiblePresets = getVisiblePresets({ isHosted });
     const [provider, setProvider] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
@@ -98,7 +50,7 @@ export function AddProviderDialog({
 
     const handleProviderChange = (value: string) => {
         setProvider(value);
-        const preset = providerPresets.find((p) => p.name === value);
+        const preset = findPreset(value);
         if (preset) {
             setBaseUrl(preset.baseUrl);
             setDefaultModel(preset.defaultModel);
@@ -154,7 +106,7 @@ export function AddProviderDialog({
         }
     };
 
-    const selectedPreset = providerPresets.find((p) => p.name === provider);
+    const selectedPreset = findPreset(provider);
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/settings/edit-provider-dialog.tsx
+++ b/src/components/settings/edit-provider-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Shield } from "lucide-react";
+import { AlertTriangle, Shield } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { MetalButton } from "@/components/metal-button";
@@ -20,6 +20,11 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import {
+    findPreset,
+    getVisiblePresets,
+    isLocalPreset,
+} from "@/lib/ai/provider-presets";
 
 interface Provider {
     id: string;
@@ -43,53 +48,6 @@ interface EditProviderDialogProps {
     isHosted?: boolean;
 }
 
-const LOCAL_PRESET_NAMES = new Set(["LM Studio", "Ollama"]);
-
-const providerPresets = [
-    {
-        name: "OpenAI",
-        baseUrl: "",
-        placeholder: "sk-...",
-        defaultModel: "whisper-1",
-    },
-    {
-        name: "Groq",
-        baseUrl: "https://api.groq.com/openai/v1",
-        placeholder: "gsk_...",
-        defaultModel: "whisper-large-v3-turbo",
-    },
-    {
-        name: "Together AI",
-        baseUrl: "https://api.together.xyz/v1",
-        placeholder: "...",
-        defaultModel: "whisper-large-v3",
-    },
-    {
-        name: "OpenRouter",
-        baseUrl: "https://openrouter.ai/api/v1",
-        placeholder: "sk-or-...",
-        defaultModel: "whisper-1",
-    },
-    {
-        name: "LM Studio",
-        baseUrl: "http://localhost:1234/v1",
-        placeholder: "lm-studio",
-        defaultModel: "",
-    },
-    {
-        name: "Ollama",
-        baseUrl: "http://localhost:11434/v1",
-        placeholder: "ollama",
-        defaultModel: "",
-    },
-    {
-        name: "Custom",
-        baseUrl: "",
-        placeholder: "Your API key",
-        defaultModel: "",
-    },
-];
-
 export function EditProviderDialog({
     open,
     onOpenChange,
@@ -97,9 +55,17 @@ export function EditProviderDialog({
     onSuccess,
     isHosted = false,
 }: EditProviderDialogProps) {
-    const visiblePresets = isHosted
-        ? providerPresets.filter((p) => !LOCAL_PRESET_NAMES.has(p.name))
-        : providerPresets;
+    const visiblePresets = getVisiblePresets({ isHosted });
+    // Legacy case: a hosted user has an existing LM Studio / Ollama provider
+    // (added before hosted enforcement, or imported). Keep their currently
+    // selected preset visible in the dropdown — disabled — so the Select
+    // doesn't render an empty trigger. The save will still fail server-side
+    // because the stored baseUrl is loopback; we surface a notice so the
+    // user knows to delete and re-add with a public endpoint.
+    const legacyLocalProvider =
+        isHosted && provider != null && isLocalPreset(provider.provider)
+            ? provider.provider
+            : null;
     const [providerName, setProviderName] = useState("");
     const [apiKey, setApiKey] = useState("");
     const [baseUrl, setBaseUrl] = useState("");
@@ -128,7 +94,7 @@ export function EditProviderDialog({
 
     const handleProviderChange = (value: string) => {
         setProviderName(value);
-        const preset = providerPresets.find((p) => p.name === value);
+        const preset = findPreset(value);
         if (preset) {
             setBaseUrl(preset.baseUrl);
             setDefaultModel(preset.defaultModel);
@@ -202,7 +168,7 @@ export function EditProviderDialog({
         }
     };
 
-    const selectedPreset = providerPresets.find((p) => p.name === providerName);
+    const selectedPreset = findPreset(providerName);
 
     if (!open || !provider) return null;
 
@@ -233,8 +199,34 @@ export function EditProviderDialog({
                                         {preset.name}
                                     </SelectItem>
                                 ))}
+                                {legacyLocalProvider && (
+                                    <SelectItem
+                                        key={legacyLocalProvider}
+                                        value={legacyLocalProvider}
+                                        disabled
+                                    >
+                                        {legacyLocalProvider} (not available on
+                                        hosted)
+                                    </SelectItem>
+                                )}
                             </SelectContent>
                         </Select>
+                        {legacyLocalProvider && (
+                            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-300">
+                                <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                                <span>
+                                    {legacyLocalProvider} isn&apos;t usable on
+                                    the hosted app — we can&apos;t reach your
+                                    machine. Delete this provider and re-add one
+                                    with a public endpoint, or self-host
+                                    OpenPlaud (
+                                    <code className="font-mono">
+                                        docker compose up
+                                    </code>
+                                    ).
+                                </span>
+                            </div>
+                        )}
                     </div>
 
                     <div className="space-y-2">

--- a/src/lib/ai/provider-presets.ts
+++ b/src/lib/ai/provider-presets.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared preset list for the Add/Edit AI provider dialogs.
+ *
+ * Single source of truth — both dialogs import from here so the list can't
+ * drift. `LOCAL_PRESET_NAMES` are presets whose default `baseUrl` points at
+ * the user's machine; on hosted (`IS_HOSTED=true`) we hide them from the
+ * dropdown because the hosted app process can't reach loopback. The API
+ * layer enforces the same rule via `validateAiBaseUrl`.
+ */
+
+export interface ProviderPreset {
+    name: string;
+    baseUrl: string;
+    placeholder: string;
+    defaultModel: string;
+}
+
+export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
+    {
+        name: "OpenAI",
+        baseUrl: "",
+        placeholder: "sk-...",
+        defaultModel: "whisper-1",
+    },
+    {
+        name: "Groq",
+        baseUrl: "https://api.groq.com/openai/v1",
+        placeholder: "gsk_...",
+        defaultModel: "whisper-large-v3-turbo",
+    },
+    {
+        name: "Together AI",
+        baseUrl: "https://api.together.xyz/v1",
+        placeholder: "...",
+        defaultModel: "whisper-large-v3",
+    },
+    {
+        name: "OpenRouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        placeholder: "sk-or-...",
+        defaultModel: "whisper-1",
+    },
+    {
+        name: "LM Studio",
+        baseUrl: "http://localhost:1234/v1",
+        placeholder: "lm-studio",
+        defaultModel: "",
+    },
+    {
+        name: "Ollama",
+        baseUrl: "http://localhost:11434/v1",
+        placeholder: "ollama",
+        defaultModel: "",
+    },
+    {
+        name: "Custom",
+        baseUrl: "",
+        placeholder: "Your API key",
+        defaultModel: "",
+    },
+] as const;
+
+export const LOCAL_PRESET_NAMES: ReadonlySet<string> = new Set([
+    "LM Studio",
+    "Ollama",
+]);
+
+/**
+ * Presets to render in the dropdown for a given deployment mode.
+ * On hosted we omit local-only presets; on self-host we show everything.
+ */
+export function getVisiblePresets({
+    isHosted,
+}: {
+    isHosted: boolean;
+}): readonly ProviderPreset[] {
+    if (!isHosted) return PROVIDER_PRESETS;
+    return PROVIDER_PRESETS.filter((p) => !LOCAL_PRESET_NAMES.has(p.name));
+}
+
+export function findPreset(name: string): ProviderPreset | undefined {
+    return PROVIDER_PRESETS.find((p) => p.name === name);
+}
+
+export function isLocalPreset(name: string): boolean {
+    return LOCAL_PRESET_NAMES.has(name);
+}

--- a/src/tests/provider-presets.test.ts
+++ b/src/tests/provider-presets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+    findPreset,
+    getVisiblePresets,
+    isLocalPreset,
+    LOCAL_PRESET_NAMES,
+    PROVIDER_PRESETS,
+} from "@/lib/ai/provider-presets";
+
+describe("provider-presets", () => {
+    describe("getVisiblePresets", () => {
+        it("returns every preset on self-host", () => {
+            const visible = getVisiblePresets({ isHosted: false });
+            expect(visible).toEqual(PROVIDER_PRESETS);
+        });
+
+        it("hides LM Studio and Ollama on hosted", () => {
+            const visible = getVisiblePresets({ isHosted: true });
+            const names = visible.map((p) => p.name);
+            expect(names).not.toContain("LM Studio");
+            expect(names).not.toContain("Ollama");
+        });
+
+        it("keeps every non-local preset on hosted", () => {
+            const visible = getVisiblePresets({ isHosted: true }).map(
+                (p) => p.name,
+            );
+            expect(visible).toContain("OpenAI");
+            expect(visible).toContain("Groq");
+            expect(visible).toContain("Together AI");
+            expect(visible).toContain("OpenRouter");
+            expect(visible).toContain("Custom");
+        });
+    });
+
+    describe("isLocalPreset", () => {
+        it("matches the published LOCAL_PRESET_NAMES set", () => {
+            expect(isLocalPreset("LM Studio")).toBe(true);
+            expect(isLocalPreset("Ollama")).toBe(true);
+            expect(isLocalPreset("OpenAI")).toBe(false);
+            expect(isLocalPreset("Custom")).toBe(false);
+            expect(LOCAL_PRESET_NAMES.has("LM Studio")).toBe(true);
+        });
+    });
+
+    describe("findPreset", () => {
+        it("returns the preset by name", () => {
+            expect(findPreset("OpenAI")?.defaultModel).toBe("whisper-1");
+            expect(findPreset("Ollama")?.baseUrl).toBe(
+                "http://localhost:11434/v1",
+            );
+        });
+
+        it("returns undefined for an unknown name", () => {
+            expect(findPreset("Nope")).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Tightens the hosted-mode AI provider UX by deduplicating the preset list and fixing a UI regression for users who have a legacy local provider (LM Studio / Ollama) stored from before hosted enforcement landed in #88.

The hosted enforcement itself (hiding LM Studio/Ollama from the Add dialog dropdown, server-side rejection of loopback `baseUrl` via `validateAiBaseUrl`) already shipped in #88 — this PR closes the two remaining gaps.

## Type of Change

- [x] Code refactoring
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Follow-up to #88.

## Changes Made

- New `src/lib/ai/provider-presets.ts` as the single source of truth for `PROVIDER_PRESETS`, `LOCAL_PRESET_NAMES`, `getVisiblePresets`, `findPreset`, `isLocalPreset`. Both Add and Edit dialogs now import from here — no more drift risk when adding a provider.
- `AddProviderDialog`: dropped the duplicated preset array, now calls `getVisiblePresets({ isHosted })` and `findPreset(name)`. No behavior change for users.
- `EditProviderDialog`: same refactor, plus legacy-local handling. Previously, if a hosted user had a stored `LM Studio` or `Ollama` provider (added before hosted enforcement), filtering removed the currently-selected option from the `<Select>`, leaving the trigger empty and confusing. Now we still render that preset as a disabled `SelectItem` labeled `(not available on hosted)` and surface an amber inline notice telling the user to delete + re-add with a public endpoint, or self-host. Server-side save continues to reject loopback `baseUrl` — no change to the API contract.
- New `src/tests/provider-presets.test.ts` covering `getVisiblePresets` (both modes), `isLocalPreset`, `findPreset`.

No DB / schema / env / API / migration changes.

## Screenshots (if applicable)

N/A — small UI refinement; existing screenshots from #88 still apply.

## Testing

### Test Environment
- OS: macOS
- Node: pnpm/Node toolchain pinned by repo
- Browser: not exercised (logic + unit tests only)

### Test Steps

Commands run:

- `pnpm format-and-lint:fix` — clean (auto-formatted 2 files).
- `pnpm type-check` — clean.
- `pnpm test` — 159 passed, 3 skipped (unrelated). New `provider-presets.test.ts` adds 6 passing tests.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A, no user-facing docs reference the preset list
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None. Self-host behavior is unchanged (all presets visible, all base URLs accepted). Hosted behavior is unchanged for new providers (LM Studio / Ollama remain hidden, server still rejects loopback). The only visible difference on hosted is that legacy local providers now render correctly with a clear remediation notice instead of an empty Select trigger.

## Additional Notes

`CHANGELOG.md` intentionally untouched per `AGENTS.md` ("maintainer-curated at release time").

## For Reviewers

- The `isLocalPreset` check on the Edit dialog is name-based (matches `provider.provider === "LM Studio" | "Ollama"`). A user who hand-rolled a `Custom` provider pointing at `localhost` won't trigger the legacy-notice path — but the server already blocks them via `validateAiBaseUrl`, so the failure mode is a clear toast on save rather than silent breakage. That seems like the right tradeoff; flag if you'd rather widen the notice to any stored loopback `baseUrl`.
- The disabled `SelectItem` for the legacy provider is appended after `visiblePresets`. Radix renders disabled items as non-interactive but keeps the trigger label correct, which is the actual fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized AI provider presets for Add/Edit dialogs and fixed a hosted-mode UI bug when editing legacy local providers. Prevents empty selects and gives clear guidance for LM Studio/Ollama stored from before hosted enforcement.

- **Refactors**
  - Introduced `PROVIDER_PRESETS`, `LOCAL_PRESET_NAMES`, `getVisiblePresets`, `findPreset`, `isLocalPreset` in `src/lib/ai/provider-presets.ts`.
  - Updated Add/Edit dialogs to use shared presets; no behavior change for new providers.
  - Added unit tests for preset utilities.

- **Bug Fixes**
  - On hosted, legacy `LM Studio`/`Ollama` now appear as a disabled Select option with an inline notice to delete and re-add with a public endpoint or self-host.
  - Prevents empty Select trigger; server-side still rejects loopback `baseUrl`.

<sup>Written for commit 7e639126926dbd45925c8b9a9f5422a6edf3c14c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

