### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,6 @@ When designing or reviewing any feature, assume hosted is real and check both mo
 OpenPlaud has "marketing ahead of code" in some places. **Always cross-check landing / pricing / changelog claims against actual code before designing features that depend on them.** Known gaps:
 
 - Plaud refresh-token handling was removed in `bed9cd3` — Plaud issues only long-lived access tokens (~300 day JWT). Do not re-add refresh-token plumbing.
-- "Switch Plaud account" flow referenced on the landing page is not wired up yet.
 
 ### Target UX comparisons
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
 ### Added
+- Switch and disconnect Plaud account from Settings — new "Plaud Account" section shows the connected email + region, with **Switch account** (clears the connection and reopens the connect dialog) and **Disconnect** actions. Legacy connections without a stored email render as "Connected (email unknown)". Recordings are unaffected by either action ([#63](https://github.com/openplaud/openplaud/issues/63)).
 - Hosted-only admin dashboard at `/admin` with cost-attribution views (per-user storage, server transcription minutes, Plaud sync freshness, signup timeseries, pricing-snapshot CDFs) and a small set of audited operator actions (suspend / unsuspend user, force-disconnect Plaud, soft-delete recording). Gated by `IS_HOSTED=true` + `ADMIN_EMAILS` allowlist + signed elevated-session cookie (password reprompt) + optional `ADMIN_IP_ALLOWLIST`. Self-host instances 404 every admin route. Reads logged to `admin_audit_log`; mutations logged to `admin_action_log` with required reason text. Admins never see transcript text, summary text, audio, or decrypted secrets.
 - `users.suspendedAt` / `users.suspendedReason` columns supporting cooperative account suspension. Suspended users are redirected to `/suspended` on next request and skipped by the sync worker on next claim. Set/cleared exclusively by the admin suspend action; unused on self-host.
 - One-line self-host installer: `curl -fsSL https://openplaud.com/install.sh | sh`. Detects OS, verifies Docker + Compose v2, downloads `docker-compose.yml` and `env.example` from the matching GitHub release, generates `BETTER_AUTH_SECRET` / `ENCRYPTION_KEY` / `POSTGRES_PASSWORD`, starts the stack, and waits on `/api/health`. Version-pinned form available at `https://openplaud.com/vX.Y.Z/install.sh`. Source: [`scripts/install.sh`](scripts/install.sh) ([#95](https://github.com/openplaud/openplaud/issues/95)).
@@ -98,7 +101,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/openplaud/openplaud/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/openplaud/openplaud/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/openplaud/openplaud/releases/tag/v0.4.0
 [0.3.0]: https://github.com/openplaud/openplaud/releases/tag/v0.3.0
 [0.2.0]: https://github.com/openplaud/openplaud/releases/tag/v0.2.0
 [0.1.0]: https://github.com/openplaud/openplaud/releases/tag/v0.1.0


### PR DESCRIPTION
Cuts v0.4.0.

- Move `[Unreleased]` → `[0.4.0] - 2026-05-09` in `CHANGELOG.md`.
- Add Added entry for #106 (switch + disconnect Plaud account from Settings) which had not been logged.
- Update changelog comparison links.
- Drop the "Switch Plaud account flow not wired up" gap note from `AGENTS.md` (shipped via #106).

After merge: tag `v0.4.0` from `main`, push tag, review draft GitHub Release, publish.

Highlights for users (full notes in CHANGELOG):
- Encryption at rest (AES-256-GCM) for `recordings.filename`, transcript text, AI enhancements, user prompts. Optional one-time backfill: `bun scripts/encrypt-backfill.ts`.
- Hosted-only `/admin` dashboard with audited operator actions; cooperative user suspension.
- One-line self-host installer: `curl -fsSL https://openplaud.com/install.sh | sh`.
- Switch / disconnect Plaud account from Settings.
- `requireAuth()` / new `requireApiSession()` enforce suspension + unified `AppError` envelope.
- `docker-compose.yml` reads `POSTGRES_PASSWORD` from env (default preserves existing deploys).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut v0.4.0 by finalizing the changelog and docs. This release includes encryption at rest, a hosted-only `/admin` dashboard, and a one-line self-host installer.

- **Refactors**
  - Move `[Unreleased]` to `[0.4.0] - 2026-05-09` in `CHANGELOG.md`.
  - Add missing changelog entry for Plaud account switch/disconnect.
  - Update changelog comparison links.
  - Remove outdated "Switch Plaud account" gap note from `AGENTS.md`.

<sup>Written for commit dd9e6397a62400b762da25fa0130cc8dc726e931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

