### PR TITLE
fix(admin): force /admin/reauth dynamic so it isn't baked as a build-time 404

### DIFF
--- a/src/app/(admin)/admin/reauth/page.tsx
+++ b/src/app/(admin)/admin/reauth/page.tsx
@@ -9,6 +9,13 @@ import { auth } from "@/lib/auth";
 import { env } from "@/lib/env";
 import { ReauthForm } from "./reauth-form";
 
+// Force dynamic rendering. Without this, Next.js may statically prerender
+// this page during `next build` -- and because the IS_HOSTED / ADMIN_EMAILS
+// checks run before any dynamic API (headers/cookies/searchParams), build
+// environments that lack those vars would bake a permanent 404 into the
+// output. Admin config is always runtime, never build-time.
+export const dynamic = "force-dynamic";
+
 /**
  * Password reprompt for the admin dashboard. Reachable only after a regular
  * session is in place; non-admins, self-host, and IP-blocked clients all 404.


### PR DESCRIPTION
## Description

`/admin/reauth` returns 404 in production Docker images even when `IS_HOSTED=true` and `ADMIN_EMAILS` are configured. The dashboard's `Admin` link appears (since `isAdminEmail` is evaluated inside an already-dynamic page) and `/admin` correctly redirects to `/admin/reauth`, but the reauth page itself is permanently 404.

Root cause: `src/app/(admin)/admin/reauth/page.tsx` performs the `env.IS_HOSTED` and `env.ADMIN_EMAILS` checks before awaiting any dynamic API (`headers()`, `cookies()`, `searchParams`). During `next build`, with `IS_HOSTED`/`ADMIN_EMAILS` unset, Next.js statically prerenders the page, hits `notFound()`, and bakes a permanent 404 into the build output. Runtime env never gets a chance.

The `(gated)/layout.tsx` doesn't have this bug because it `await nextHeaders()` before invoking the guard, which marks the segment dynamic.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `export const dynamic = "force-dynamic"` to `src/app/(admin)/admin/reauth/page.tsx` so the page is always rendered at request time and reads the live runtime env.
- Inline comment explaining why the directive is required (build-time env is intentionally absent for admin config).

## Testing

- `pnpm format-and-lint:fix` — clean (2 pre-existing infos in unrelated test files).
- `pnpm type-check` — pre-existing failures only (missing `node_modules` in this worktree); no new errors from this change.
- Runtime verification: rebuild the Docker image and load `/admin/reauth` while logged in as an `ADMIN_EMAILS` account — page renders the password reprompt instead of 404.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Additional Notes

No build-time admin config is introduced or required — all admin env stays runtime-only by design.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force dynamic rendering of `/admin/reauth` to prevent build-time 404s. The page now renders at request time and reads `IS_HOSTED` and `ADMIN_EMAILS`, fixing the admin redirect flow in production.

<sup>Written for commit 9f897922a85d91bc2c55e89848cee48b036294b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

