### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-09
+
+### Fixed
+- `/admin/reauth` returned a permanent 404 in production Docker images even with `IS_HOSTED=true` and `ADMIN_EMAILS` configured, leaving admins unable to elevate their session. The page performed its `env.IS_HOSTED` / `env.ADMIN_EMAILS` `notFound()` checks before any dynamic API call, so `next build` (which doesn't see admin env by design) statically prerendered it as a 404 and baked that into the image. Every other admin page already declared `export const dynamic = "force-dynamic"`; reauth was the only miss. Added the directive ([#113](https://github.com/openplaud/openplaud/pull/113)).
+
 ## [0.4.1] - 2026-05-09
 
 ### Fixed


### PR DESCRIPTION
## Description

Cuts v0.4.2 — hotfix for the admin reauth 404 regression introduced in v0.4.0.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `[0.4.2]` section to `CHANGELOG.md` with the `/admin/reauth` static-404 fix landed in #113.

## Testing

- Not run (changelog-only).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.4.2 and add a CHANGELOG entry for the admin /admin/reauth 404 hotfix. Documents the static-404 issue in Docker builds and the fix that restores admin reauth in hosted environments.

<sup>Written for commit 14adf6f1a7b3fce8ccbc4d308c081ebae2d8f493. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

