### PR TITLE
feat(admin): week-over-week deltas and coverage metrics on fleet overview

### DIFF
--- a/src/app/(admin)/admin/(gated)/_components/metrics.tsx
+++ b/src/app/(admin)/admin/(gated)/_components/metrics.tsx
@@ -5,11 +5,32 @@ export function MetricCard({
     value,
     sub,
     accent,
+    delta,
 }: {
     label: string;
     value: string | number;
     sub?: string;
     accent?: "danger" | "warning";
+    /**
+     * Optional week-over-week delta. `current` and `prior` are raw counts
+     * (not formatted strings). `healthyDirection` decides the color: "up"
+     * for things we want to grow (signups, activations), "down" for things
+     * that cost us money (bytes, server-tx, audio minutes). Within ±5% of
+     * prior we render neutral grey to avoid noise.
+     */
+    delta?: {
+        current: number;
+        prior: number;
+        healthyDirection: "up" | "down";
+        /** Optional formatter for the absolute delta (e.g. formatBytes). */
+        format?: (n: number) => string;
+        /**
+         * Suppress the trailing "(+X% WoW)" suffix. Use when the metric is
+         * itself a rate (coverage %, etc.) where a percent-change-of-percent
+         * is more confusing than informative.
+         */
+        suppressPercent?: boolean;
+    };
 }) {
     return (
         <div className="border rounded-xl p-4 bg-card">
@@ -23,9 +44,69 @@ export function MetricCard({
             >
                 {value}
             </div>
+            {delta ? <DeltaLine {...delta} /> : null}
             {sub ? (
                 <div className="text-xs text-muted-foreground mt-1">{sub}</div>
             ) : null}
+        </div>
+    );
+}
+
+function DeltaLine({
+    current,
+    prior,
+    healthyDirection,
+    format,
+    suppressPercent,
+}: {
+    current: number;
+    prior: number;
+    healthyDirection: "up" | "down";
+    format?: (n: number) => string;
+    suppressPercent?: boolean;
+}) {
+    const diff = current - prior;
+    const sign = diff > 0 ? "+" : diff < 0 ? "−" : "±";
+    const absDiff = Math.abs(diff);
+    const fmt = format ?? formatNumber;
+    const absStr = fmt(absDiff);
+
+    // Percent: undefined when prior is 0 (avoid ∞ / divide-by-zero noise).
+    const pct = prior > 0 ? (diff / prior) * 100 : undefined;
+
+    // Color rule: within ±5% → neutral. Otherwise direction vs healthy.
+    // For rate-type metrics (suppressPercent), use absolute diff threshold
+    // instead -- a 0 → 1 change in count would otherwise read as "∞%".
+    let tone: "neutral" | "good" | "bad" = "neutral";
+    const significant = suppressPercent
+        ? absDiff > 0
+        : pct !== undefined && Math.abs(pct) > 5;
+    if (significant) {
+        const movingUp = diff > 0;
+        const isHealthy =
+            (movingUp && healthyDirection === "up") ||
+            (!movingUp && healthyDirection === "down");
+        tone = isHealthy ? "good" : "bad";
+    }
+
+    const suffix = suppressPercent
+        ? " WoW"
+        : pct === undefined
+          ? " (vs 0 prior)"
+          : ` (${pct >= 0 ? "+" : "−"}${Math.abs(pct).toFixed(0)}% WoW)`;
+
+    return (
+        <div
+            className={cn(
+                "text-xs mt-1",
+                tone === "neutral" && "text-muted-foreground",
+                tone === "good" && "text-emerald-600",
+                tone === "bad" && "text-amber-600",
+            )}
+        >
+            {sign}
+            {absStr}
+            {suffix}
         </div>
     );
 }
@@ -39,6 +120,17 @@ export function formatBytes(b: number): string {
 
 export function formatNumber(n: number): string {
     return new Intl.NumberFormat("en-US").format(n);
+}
+
+export function formatHours(ms: number): string {
+    if (!ms || ms < 0) return "0h";
+    const hours = ms / 3_600_000;
+    if (hours < 1) {
+        const minutes = Math.round(ms / 60_000);
+        return `${minutes}m`;
+    }
+    if (hours < 100) return `${hours.toFixed(1)}h`;
+    return `${Math.round(hours).toLocaleString("en-US")}h`;
 }
 
 export function formatDate(d: Date | null | undefined): string {

--- a/src/app/(admin)/admin/(gated)/_components/metrics.tsx
+++ b/src/app/(admin)/admin/(gated)/_components/metrics.tsx
@@ -127,6 +127,9 @@ export function formatHours(ms: number): string {
     const hours = ms / 3_600_000;
     if (hours < 1) {
         const minutes = Math.round(ms / 60_000);
+        // Edge case: 59m31s+ rounds to 60min -- roll over to 1.0h instead
+        // of rendering the nonsensical "60m".
+        if (minutes >= 60) return "1.0h";
         return `${minutes}m`;
     }
     if (hours < 100) return `${hours.toFixed(1)}h`;

--- a/src/app/(admin)/admin/(gated)/page.tsx
+++ b/src/app/(admin)/admin/(gated)/page.tsx
@@ -216,20 +216,29 @@ export default async function AdminOverviewPage() {
                             // prior-7d cohort, expressed as percentage points
                             // (×100). Drops here = transcription pipeline
                             // silently failing on fresh recordings.
+                            //
+                            // If either cohort is empty, the comparison is
+                            // undefined (a 0-recording week has no "coverage
+                            // rate"). Hide the delta entirely rather than
+                            // pretending coverage is 0% on that side -- that
+                            // would render misleading swings like "+95pp"
+                            // on a brand-new instance.
+                            if (
+                                stats.recordingsLast7 === 0 ||
+                                stats.recordingsPrior7 === 0
+                            ) {
+                                return undefined;
+                            }
                             const cur =
-                                stats.recordingsLast7 > 0
-                                    ? ((stats.recordingsLast7 -
-                                          stats.recordingsWithoutTranscriptionLast7) /
-                                          stats.recordingsLast7) *
-                                      10000
-                                    : 0;
+                                ((stats.recordingsLast7 -
+                                    stats.recordingsWithoutTranscriptionLast7) /
+                                    stats.recordingsLast7) *
+                                10000;
                             const prior =
-                                stats.recordingsPrior7 > 0
-                                    ? ((stats.recordingsPrior7 -
-                                          stats.recordingsWithoutTranscriptionPrior7) /
-                                          stats.recordingsPrior7) *
-                                      10000
-                                    : 0;
+                                ((stats.recordingsPrior7 -
+                                    stats.recordingsWithoutTranscriptionPrior7) /
+                                    stats.recordingsPrior7) *
+                                10000;
                             return {
                                 current: Math.round(cur),
                                 prior: Math.round(prior),

--- a/src/app/(admin)/admin/(gated)/page.tsx
+++ b/src/app/(admin)/admin/(gated)/page.tsx
@@ -1,5 +1,10 @@
 import { fleetOverview } from "@/lib/admin/queries";
-import { formatBytes, formatNumber, MetricCard } from "./_components/metrics";
+import {
+    formatBytes,
+    formatHours,
+    formatNumber,
+    MetricCard,
+} from "./_components/metrics";
 
 export const dynamic = "force-dynamic";
 
@@ -11,8 +16,8 @@ export default async function AdminOverviewPage() {
             <div>
                 <h1 className="text-xl font-semibold">Fleet overview</h1>
                 <p className="text-sm text-muted-foreground">
-                    Cost-shaped metrics. All counts exclude tombstoned
-                    recordings.
+                    Cost-shaped metrics. Deltas compare last 7 days vs the prior
+                    7 days. All counts exclude tombstoned recordings.
                 </p>
             </div>
 
@@ -26,13 +31,19 @@ export default async function AdminOverviewPage() {
                         value={formatNumber(stats.userTotal)}
                     />
                     <MetricCard
-                        label="Active 7d"
-                        value={formatNumber(stats.activeUsers7d)}
-                        sub="synced in last 7 days"
+                        label="New signups (7d)"
+                        value={formatNumber(stats.signupsLast7)}
+                        sub={`${formatNumber(stats.signupsLast30)} in last 30d`}
+                        delta={{
+                            current: stats.signupsLast7,
+                            prior: stats.signupsPrior7,
+                            healthyDirection: "up",
+                        }}
                     />
                     <MetricCard
-                        label="Active 30d"
-                        value={formatNumber(stats.activeUsers30d)}
+                        label="Active 7d"
+                        value={formatNumber(stats.activeUsers7d)}
+                        sub={`${formatNumber(stats.activeUsers30d)} active 30d`}
                     />
                     <MetricCard
                         label="Suspended"
@@ -40,6 +51,30 @@ export default async function AdminOverviewPage() {
                         accent={
                             stats.suspendedUsers > 0 ? "warning" : undefined
                         }
+                        delta={{
+                            current: stats.suspensionsLast7,
+                            prior: stats.suspensionsPrior7,
+                            // More suspensions = abuse spike, treat as bad.
+                            healthyDirection: "down",
+                        }}
+                    />
+                </div>
+            </section>
+
+            <section>
+                <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                    Plaud connections
+                </h2>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                    <MetricCard
+                        label="New connections (7d)"
+                        value={formatNumber(stats.plaudConnectionsLast7)}
+                        sub="signup → connected (real activation)"
+                        delta={{
+                            current: stats.plaudConnectionsLast7,
+                            prior: stats.plaudConnectionsPrior7,
+                            healthyDirection: "up",
+                        }}
                     />
                 </div>
             </section>
@@ -58,9 +93,24 @@ export default async function AdminOverviewPage() {
                         value={formatBytes(stats.storageBytes)}
                     />
                     <MetricCard
-                        label="New 7d"
+                        label="Recordings (7d)"
                         value={formatNumber(stats.recordingsLast7)}
-                        sub={formatBytes(stats.bytesLast7)}
+                        delta={{
+                            current: stats.recordingsLast7,
+                            prior: stats.recordingsPrior7,
+                            healthyDirection: "up",
+                        }}
+                    />
+                    <MetricCard
+                        label="Bytes uploaded (7d)"
+                        value={formatBytes(stats.bytesLast7)}
+                        sub="counts toward storage cost"
+                        delta={{
+                            current: stats.bytesLast7,
+                            prior: stats.bytesPrior7,
+                            healthyDirection: "down",
+                            format: formatBytes,
+                        }}
                     />
                     <MetricCard
                         label="Avg / recording"
@@ -72,6 +122,22 @@ export default async function AdminOverviewPage() {
                                 : "—"
                         }
                     />
+                    <MetricCard
+                        label="Local / S3 split"
+                        value={(() => {
+                            const local = stats.storageByType.local ?? 0;
+                            const s3 = stats.storageByType.s3 ?? 0;
+                            const total = local + s3;
+                            if (total === 0) return "—";
+                            const s3Pct = Math.round((s3 / total) * 100);
+                            return `${100 - s3Pct}% / ${s3Pct}%`;
+                        })()}
+                        sub={`${formatBytes(
+                            stats.storageByType.local ?? 0,
+                        )} local · ${formatBytes(
+                            stats.storageByType.s3 ?? 0,
+                        )} S3`}
+                    />
                 </div>
             </section>
 
@@ -81,9 +147,38 @@ export default async function AdminOverviewPage() {
                 </h2>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                     <MetricCard
-                        label="Server-side (30d)"
-                        value={formatNumber(stats.serverTranscriptionsLast30)}
+                        label="Server tx (7d)"
+                        value={formatNumber(stats.serverTranscriptionsLast7)}
                         sub="our cost"
+                        delta={{
+                            current: stats.serverTranscriptionsLast7,
+                            prior: stats.serverTranscriptionsPrior7,
+                            healthyDirection: "down",
+                        }}
+                    />
+                    <MetricCard
+                        label="Server audio (7d)"
+                        value={formatHours(stats.serverAudioMsLast7)}
+                        sub="Whisper bills by minute"
+                        delta={{
+                            current: stats.serverAudioMsLast7,
+                            prior: stats.serverAudioMsPrior7,
+                            healthyDirection: "down",
+                            format: formatHours,
+                        }}
+                    />
+                    <MetricCard
+                        label="Server tx (30d)"
+                        value={formatNumber(stats.serverTranscriptionsLast30)}
+                    />
+                    <MetricCard
+                        label="AI enhancements (7d)"
+                        value={formatNumber(stats.enhancementsLast7)}
+                        delta={{
+                            current: stats.enhancementsLast7,
+                            prior: stats.enhancementsPrior7,
+                            healthyDirection: "down",
+                        }}
                     />
                     <MetricCard
                         label="Server (all-time)"
@@ -99,8 +194,51 @@ export default async function AdminOverviewPage() {
                         sub="zero cost"
                     />
                     <MetricCard
-                        label="AI enhancements"
+                        label="AI enhancements (total)"
                         value={formatNumber(stats.enhancementTotal)}
+                    />
+                    <MetricCard
+                        label="Transcription coverage"
+                        value={(() => {
+                            if (stats.recordingTotal === 0) return "—";
+                            const covered =
+                                stats.recordingTotal -
+                                stats.recordingsWithoutTranscriptionTotal;
+                            const pct = (covered / stats.recordingTotal) * 100;
+                            return `${pct.toFixed(1)}%`;
+                        })()}
+                        sub={`${formatNumber(
+                            stats.recordingTotal -
+                                stats.recordingsWithoutTranscriptionTotal,
+                        )} of ${formatNumber(stats.recordingTotal)} recordings`}
+                        delta={(() => {
+                            // Compare *coverage rate* of the 7d cohort vs the
+                            // prior-7d cohort, expressed as percentage points
+                            // (×100). Drops here = transcription pipeline
+                            // silently failing on fresh recordings.
+                            const cur =
+                                stats.recordingsLast7 > 0
+                                    ? ((stats.recordingsLast7 -
+                                          stats.recordingsWithoutTranscriptionLast7) /
+                                          stats.recordingsLast7) *
+                                      10000
+                                    : 0;
+                            const prior =
+                                stats.recordingsPrior7 > 0
+                                    ? ((stats.recordingsPrior7 -
+                                          stats.recordingsWithoutTranscriptionPrior7) /
+                                          stats.recordingsPrior7) *
+                                      10000
+                                    : 0;
+                            return {
+                                current: Math.round(cur),
+                                prior: Math.round(prior),
+                                healthyDirection: "up" as const,
+                                format: (n: number) =>
+                                    `${(n / 100).toFixed(1)}pp`,
+                                suppressPercent: true,
+                            };
+                        })()}
                     />
                 </div>
             </section>

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -41,9 +41,39 @@ const DAY_MS = 86_400_000;
 export async function fleetOverview() {
     const now = Date.now();
     const d7 = new Date(now - 7 * DAY_MS);
+    const d14 = new Date(now - 14 * DAY_MS);
     const d30 = new Date(now - 30 * DAY_MS);
 
     const [userTotal] = await db.select({ n: count() }).from(users);
+
+    // New signups: current 7d window vs prior 7d window (days 7-14 ago).
+    const [signups7] = await db
+        .select({ n: count() })
+        .from(users)
+        .where(gte(users.createdAt, d7));
+    const [signupsPrior7] = await db
+        .select({ n: count() })
+        .from(users)
+        .where(and(gte(users.createdAt, d14), lt(users.createdAt, d7)));
+    const [signups30] = await db
+        .select({ n: count() })
+        .from(users)
+        .where(gte(users.createdAt, d30));
+
+    // New Plaud connections (the real activation event after signup).
+    const [plaudConn7] = await db
+        .select({ n: count() })
+        .from(plaudConnections)
+        .where(gte(plaudConnections.createdAt, d7));
+    const [plaudConnPrior7] = await db
+        .select({ n: count() })
+        .from(plaudConnections)
+        .where(
+            and(
+                gte(plaudConnections.createdAt, d14),
+                lt(plaudConnections.createdAt, d7),
+            ),
+        );
     // Some legacy deployments allow more than one plaud_connections row per
     // user; counting rows would overcount the active-user metric. Use
     // countDistinct(userId) so the value tracks distinct people, not
@@ -63,6 +93,18 @@ export async function fleetOverview() {
         // drizzle: isNotNull is the inverse of isNull; here we want suspended only
         .where(sql`${users.suspendedAt} is not null`);
 
+    // Suspensions performed in the current 7d window vs prior 7d window.
+    // Abuse-spike signal -- the cumulative "Suspended" count never
+    // meaningfully decreases, so the trend lives in the delta.
+    const [suspensions7] = await db
+        .select({ n: count() })
+        .from(users)
+        .where(gte(users.suspendedAt, d7));
+    const [suspensionsPrior7] = await db
+        .select({ n: count() })
+        .from(users)
+        .where(and(gte(users.suspendedAt, d14), lt(users.suspendedAt, d7)));
+
     const [recordingTotal] = await db
         .select({ n: count() })
         .from(recordings)
@@ -72,6 +114,17 @@ export async function fleetOverview() {
         .select({ b: sum(recordings.filesize) })
         .from(recordings)
         .where(isNull(recordings.deletedAt));
+
+    // Storage backend split. Hosted cares about S3 spend; self-host cares
+    // about local disk pressure. One row per distinct storageType.
+    const storageByTypeRows = await db
+        .select({
+            type: recordings.storageType,
+            b: sum(recordings.filesize),
+        })
+        .from(recordings)
+        .where(isNull(recordings.deletedAt))
+        .groupBy(recordings.storageType);
 
     const transcriptionByType = await db
         .select({
@@ -91,11 +144,31 @@ export async function fleetOverview() {
         .where(
             and(isNull(recordings.deletedAt), gte(recordings.createdAt, d7)),
         );
+    const [recordingsPrior7] = await db
+        .select({ n: count() })
+        .from(recordings)
+        .where(
+            and(
+                isNull(recordings.deletedAt),
+                gte(recordings.createdAt, d14),
+                lt(recordings.createdAt, d7),
+            ),
+        );
     const [bytesLast7] = await db
         .select({ b: sum(recordings.filesize) })
         .from(recordings)
         .where(
             and(isNull(recordings.deletedAt), gte(recordings.createdAt, d7)),
+        );
+    const [bytesPrior7] = await db
+        .select({ b: sum(recordings.filesize) })
+        .from(recordings)
+        .where(
+            and(
+                isNull(recordings.deletedAt),
+                gte(recordings.createdAt, d14),
+                lt(recordings.createdAt, d7),
+            ),
         );
 
     const [transcriptionsLast30] = await db
@@ -108,20 +181,138 @@ export async function fleetOverview() {
             ),
         );
 
+    // Server transcriptions 7d + prior 7d. The 30d figure is too coarse to
+    // spot a spike; 7d WoW is what we actually look at.
+    const [serverTx7] = await db
+        .select({ n: count() })
+        .from(transcriptions)
+        .where(
+            and(
+                eq(transcriptions.transcriptionType, "server"),
+                gte(transcriptions.createdAt, d7),
+            ),
+        );
+    const [serverTxPrior7] = await db
+        .select({ n: count() })
+        .from(transcriptions)
+        .where(
+            and(
+                eq(transcriptions.transcriptionType, "server"),
+                gte(transcriptions.createdAt, d14),
+                lt(transcriptions.createdAt, d7),
+            ),
+        );
+
+    // Server audio MINUTES transcribed 7d + prior 7d. Whisper bills by
+    // minute, not by row count -- this is the real cost driver. Joined to
+    // recordings to get duration; we do not select any recording PII.
+    const [serverAudioMs7] = await db
+        .select({ ms: sum(recordings.duration) })
+        .from(transcriptions)
+        .innerJoin(recordings, eq(recordings.id, transcriptions.recordingId))
+        .where(
+            and(
+                eq(transcriptions.transcriptionType, "server"),
+                gte(transcriptions.createdAt, d7),
+            ),
+        );
+    const [serverAudioMsPrior7] = await db
+        .select({ ms: sum(recordings.duration) })
+        .from(transcriptions)
+        .innerJoin(recordings, eq(recordings.id, transcriptions.recordingId))
+        .where(
+            and(
+                eq(transcriptions.transcriptionType, "server"),
+                gte(transcriptions.createdAt, d14),
+                lt(transcriptions.createdAt, d7),
+            ),
+        );
+
+    // AI enhancements 7d + prior 7d.
+    const [enhancements7] = await db
+        .select({ n: count() })
+        .from(aiEnhancements)
+        .where(gte(aiEnhancements.createdAt, d7));
+    const [enhancementsPrior7] = await db
+        .select({ n: count() })
+        .from(aiEnhancements)
+        .where(
+            and(
+                gte(aiEnhancements.createdAt, d14),
+                lt(aiEnhancements.createdAt, d7),
+            ),
+        );
+
+    // Transcription coverage. Anti-join via leftJoin + isNull -- the
+    // canonical Drizzle pattern for "parent rows with no matching child."
+    // A recording may have multiple transcription rows, but rows that have
+    // *no* match yield exactly one (null) join row, so count(recordings.id)
+    // is safe here. Excludes tombstoned recordings to match the rest of
+    // this file's conventions.
+    const [missingTxAll] = await db
+        .select({ n: count(recordings.id) })
+        .from(recordings)
+        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
+        .where(and(isNull(recordings.deletedAt), isNull(transcriptions.id)));
+    const [missingTx7] = await db
+        .select({ n: count(recordings.id) })
+        .from(recordings)
+        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
+        .where(
+            and(
+                isNull(recordings.deletedAt),
+                isNull(transcriptions.id),
+                gte(recordings.createdAt, d7),
+            ),
+        );
+    const [missingTxPrior7] = await db
+        .select({ n: count(recordings.id) })
+        .from(recordings)
+        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
+        .where(
+            and(
+                isNull(recordings.deletedAt),
+                isNull(transcriptions.id),
+                gte(recordings.createdAt, d14),
+                lt(recordings.createdAt, d7),
+            ),
+        );
+
     return {
         userTotal: userTotal?.n ?? 0,
         activeUsers7d: activeIn7?.n ?? 0,
         activeUsers30d: activeIn30?.n ?? 0,
         suspendedUsers: suspended?.n ?? 0,
+        signupsLast7: signups7?.n ?? 0,
+        signupsPrior7: signupsPrior7?.n ?? 0,
+        signupsLast30: signups30?.n ?? 0,
+        plaudConnectionsLast7: plaudConn7?.n ?? 0,
+        plaudConnectionsPrior7: plaudConnPrior7?.n ?? 0,
         recordingTotal: recordingTotal?.n ?? 0,
         storageBytes: Number(storageBytes?.b ?? 0),
         bytesLast7: Number(bytesLast7?.b ?? 0),
+        bytesPrior7: Number(bytesPrior7?.b ?? 0),
         recordingsLast7: recordingsLast7?.n ?? 0,
+        recordingsPrior7: recordingsPrior7?.n ?? 0,
         transcriptionByType: Object.fromEntries(
             transcriptionByType.map((r) => [r.type, r.n]),
         ) as Record<string, number>,
         serverTranscriptionsLast30: transcriptionsLast30?.n ?? 0,
+        serverTranscriptionsLast7: serverTx7?.n ?? 0,
+        serverTranscriptionsPrior7: serverTxPrior7?.n ?? 0,
+        serverAudioMsLast7: Number(serverAudioMs7?.ms ?? 0),
+        serverAudioMsPrior7: Number(serverAudioMsPrior7?.ms ?? 0),
         enhancementTotal: enhancementTotal?.n ?? 0,
+        enhancementsLast7: enhancements7?.n ?? 0,
+        enhancementsPrior7: enhancementsPrior7?.n ?? 0,
+        suspensionsLast7: suspensions7?.n ?? 0,
+        suspensionsPrior7: suspensionsPrior7?.n ?? 0,
+        storageByType: Object.fromEntries(
+            storageByTypeRows.map((r) => [r.type, Number(r.b ?? 0)]),
+        ) as Record<string, number>,
+        recordingsWithoutTranscriptionTotal: missingTxAll?.n ?? 0,
+        recordingsWithoutTranscriptionLast7: missingTx7?.n ?? 0,
+        recordingsWithoutTranscriptionPrior7: missingTxPrior7?.n ?? 0,
     };
 }
 


### PR DESCRIPTION
## Description

Adds week-over-week (WoW) deltas and coverage metrics to the admin fleet overview so the dashboard answers "is this number good or bad?" instead of just "what is this number?". All additions are computable from existing schema; no new tables, no new dependencies.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

N/A — internal admin surface improvement.

## Changes Made

**Users**
- New signups (7d) card with WoW delta and 30d sub.
- Suspended card now shows new suspensions WoW (abuse-spike signal).

**Plaud connections (new section)**
- New connections (7d) with WoW delta — the real activation event after signup.

**Recordings & storage**
- Recordings (7d) and Bytes uploaded (7d) promoted to their own cards with WoW deltas.
- Local / S3 storage split card (relevant to both hosted S3 spend and self-host disk pressure).

**Transcription**
- Server tx (7d) with WoW delta (the existing 30d window is too coarse to catch spikes).
- Server audio (7d) in hours via `transcriptions ⋈ recordings` summing `duration` — Whisper bills by minute, this is the real cost driver.
- AI enhancements (7d) with WoW delta.
- Transcription coverage % (overall) with a **percentage-points** delta on the 7d cohort — closest proxy to a "failed sync" metric without a dedicated errors table.

**Component plumbing**
- `MetricCard` gained an optional `delta` prop with healthy-direction coloring (green for healthy moves, amber for unhealthy), neutral within ±5% to suppress noise, and a `suppressPercent` flag for rate-type metrics where percent-change-of-a-percent would mislead.
- New `formatHours(ms)` helper.

## Testing

### Test Environment
- OS: macOS
- Node version: 22.x (pnpm 10.18.1)
- Browser: not exercised in this PR (no UI behavior beyond static rendering)

### Test Steps
1. `pnpm type-check` — clean.
2. `pnpm format-and-lint:fix` — only pre-existing warnings in unrelated test files.
3. `pnpm test src/tests/admin/queries-pii.test.ts` — 9/9 pass; the new `transcriptions` anti-join touches only `id`/`recordingId`, never `.text`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — internal admin surface)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (see "Additional Notes")
- [x] New and existing unit tests pass locally with my changes (`pnpm test src/tests/admin/queries-pii.test.ts`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None. All new queries are additive `count` / `sum` / `leftJoin` patterns on existing indexed columns (`recordings.user_id`, `transcriptions.recording_id`, `users.created_at`, `plaud_connections.created_at`).

## Breaking Changes

None. `MetricCard`'s new `delta` prop is optional; all existing call sites work unchanged.

## Additional Notes

- **No new integration test added.** The repo has no live-DB test fixture (all DB tests mock `@/db`), so a unit test for `fleetOverview()` would only verify mocks, not behavior. The static PII guard in `queries-pii.test.ts` already enforces the column-safety contract for this file. Happy to stand up a pglite-based fixture as a follow-up if reviewers want it.
- **Active 7d intentionally has no delta.** With only `plaudConnections.lastSync` (not a sync-events log), a "prior week active" count would systematically undercount anyone who has since re-synced. Better to omit than mislead.
- **Coverage delta uses percentage points (`pp`), not WoW%.** A percent-change of a percent is confusing; the `suppressPercent` flag was added on `MetricCard` for exactly this case.
- **Transcription coverage will always sit slightly below 100%** because freshly-synced recordings haven't been transcribed yet. The 7d cohort delta is what flags real regressions; the absolute number is just orientation.

## For Reviewers

- Sanity-check the anti-join in `fleetOverview()` (`leftJoin(transcriptions, ...).where(isNull(transcriptions.id))`) and the `transcriptions ⋈ recordings` audio-minutes join — both follow documented Drizzle patterns but worth a second pair of eyes on the cost-driver query.
- Color/threshold rules in `DeltaLine` (±5% neutral band, healthy-direction logic) are a judgment call — easy to tweak.
- Whether the new "Plaud connections" section deserves to live on the overview vs. being folded into Users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds week-over-week deltas (last 7 days vs prior 7 days) and a transcription coverage metric to the admin fleet overview for quick trend and cost signals. Uses existing tables only; no schema or dependency changes.

- **New Features**
  - Users: new signups (7d) with WoW and 30d sub; suspensions WoW; active 7d/30d.
  - Plaud connections: new connections (7d) with WoW.
  - Recordings & storage: recordings (7d) and bytes uploaded (7d) with WoW; local/S3 split.
  - Transcription: server tx (7d) with WoW; server audio (7d) in hours with WoW; AI enhancements (7d) with WoW; coverage % with percentage‑point delta on the 7d cohort.

- **Bug Fixes**
  - formatHours: roll 59m31s–59m59s to 1.0h (no “60m”).
  - Coverage delta: hide when either 7d cohort has 0 recordings to avoid misleading swings.

<sup>Written for commit 09a8e980195977503281823b365f376565f26dec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

