### PR TITLE
feat: automation API, signed webhooks, and personal API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ DATABASE_URL=postgresql://user:password@localhost:5432/openplaud
 
 # Better Auth
 BETTER_AUTH_SECRET=your-secret-key-here-generate-with-openssl-rand-hex-32
+# Optional. Use a separate 32+ character secret if you want to rotate
+# BETTER_AUTH_SECRET without invalidating API token hashes.
+# API_TOKEN_HASH_SECRET=
 APP_URL=http://localhost:3000
 
 # Disable email/password registration. When `true`, the sign-up endpoint
@@ -50,6 +53,16 @@ APP_URL=http://localhost:3000
 # ADMIN_MUTATION_TTL_MINUTES: tighter window required for any admin
 # mutation (suspend, force-disconnect, etc.). Default 10. Range 1..60.
 # ADMIN_MUTATION_TTL_MINUTES=10
+
+# Webhooks default to permissive self-host targets unless IS_HOSTED=true.
+# Set true to require HTTPS public targets with DNS pinning; set false to allow
+# local Docker service URLs such as http://n8n:5678/webhook.
+# WEBHOOKS_REQUIRE_PUBLIC_TARGETS=false
+
+# v1 API IP rate limits ignore forwarding headers by default because clients can
+# spoof them unless a trusted reverse proxy strips or overwrites those headers.
+# Hosted mode requires true; set it only behind a trusted proxy/load balancer.
+# RATE_LIMIT_TRUST_PROXY_HEADERS=false
 
 # Encryption (for API keys, tokens, S3 credentials)
 # Generate with: openssl rand -hex 32

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 ### 📤 Export & Notifications
 - **Multiple Export Formats** - JSON, TXT, SRT, VTT subtitle formats
 - **Full Backups** - Export all your data with one click
+- **Automation API & Webhooks** - API keys, `/api/v1`, and signed webhooks for integrations ([docs](docs/API.md))
 - **Browser Notifications** - Real-time alerts for new recordings
 - **Email Notifications** - SMTP support for email alerts
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,20 @@ http://localhost:3000/api
 
 ## Authentication
 
-All authenticated endpoints require a valid session cookie set by Better Auth.
+Browser endpoints require a valid session cookie set by Better Auth.
+
+Automation endpoints under `/api/v1/` also accept API keys:
+
+```http
+Authorization: Bearer op_...
+```
+
+Keys are created from Settings -> API Keys. The raw key is shown once,
+stored as an HMAC-SHA256 hash, and can be revoked at any time. Hashing uses
+`API_TOKEN_HASH_SECRET` when set, otherwise `BETTER_AUTH_SECRET`; the dedicated
+secret is optional and lets operators rotate auth/session secrets independently
+from API key hashes. `API_TOKEN_HASH_SECRET` must be at least as strong as
+`BETTER_AUTH_SECRET`.
 
 ## Endpoints
 
@@ -229,6 +242,31 @@ Transcribe a recording.
 
 ### Settings
 
+#### GET `/settings/api-keys`
+
+List API keys for the signed-in user. Requires a session cookie; API keys cannot
+manage API keys.
+
+#### POST `/settings/api-keys`
+
+Create a read-only API key. The raw `key` field is returned once.
+
+**Body:**
+```json
+{
+  "name": "Hermes Agent",
+  "expiresAt": "2026-12-31T23:59:59.000Z",
+  "scopes": ["read"]
+}
+```
+
+Scopes use string identifiers. v1 supports only `"read"` today; future scopes
+may be added without invalidating existing read keys.
+
+#### DELETE `/settings/api-keys/[id]`
+
+Revoke an API key.
+
 #### GET `/settings/user`
 
 Get user settings.
@@ -329,6 +367,75 @@ Send test email to verify SMTP configuration.
 
 ---
 
+### Automation API v1
+
+All v1 endpoints accept either a browser session cookie or
+`Authorization: Bearer op_...`.
+
+#### GET `/v1/recordings`
+
+List recordings with cursor pagination and incremental filters.
+
+**Query Parameters:**
+- `cursor`: base64url cursor from `next_cursor`
+- `limit`: 1-100, default 50
+- `created_since`: ISO timestamp
+- `updated_since`: ISO timestamp; includes recording metadata, transcript,
+  summary, and generated-title changes
+- `has_transcription`: `true` or `false`
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "abc123",
+      "title": "Meeting Notes",
+      "created_at": "2026-05-06T12:00:00.000Z",
+      "updated_at": "2026-05-06T12:05:00.000Z",
+      "recorded_at": "2026-05-06T11:30:00.000Z",
+      "duration_ms": 3600000,
+      "filesize_bytes": 15728640,
+      "device": {
+        "serial_number": "888317426694681884",
+        "name": "Plaud Note",
+        "model": "Note"
+      },
+      "has_transcription": true,
+      "has_summary": false,
+      "links": {
+        "self": "/api/v1/recordings/abc123",
+        "transcript": "/api/v1/recordings/abc123/transcript",
+        "audio": "/api/v1/recordings/abc123/audio"
+      }
+    }
+  ],
+  "next_cursor": null,
+  "has_more": false
+}
+```
+
+`updated_at` is the recording resource timestamp for v1 clients. It changes
+when the recording metadata changes and when transcript, summary, or generated
+title state changes.
+
+#### GET `/v1/recordings/[id]`
+
+Return the stable recording shape plus inline `transcript` and `summary`
+objects when present.
+
+#### GET `/v1/recordings/[id]/transcript`
+
+Return transcript text and provider metadata, or `404` when the recording has
+not been transcribed.
+
+#### GET `/v1/recordings/[id]/audio`
+
+Return a `302` redirect to a presigned S3 URL for S3 storage, or stream local
+audio with byte-range support for local storage.
+
+---
+
 ### Export & Backup
 
 #### GET `/export`
@@ -382,11 +489,104 @@ All errors follow this format:
 
 ## Rate Limiting
 
-Rate limiting is not currently enforced but may be added in future versions.
+Automation endpoints under `/api/v1/*` are rate limited with shared server-side
+fixed windows:
+
+- 1,200 requests per minute per client IP.
+- 600 requests per minute per authenticated identity (`op_...` key, or user
+  session for browser-authenticated calls).
+
+Rate-limited requests return `429` with `Retry-After`,
+`X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`
+headers.
+
+Forwarding headers such as `X-Forwarded-For` are ignored unless
+`RATE_LIMIT_TRUST_PROXY_HEADERS=true`; only enable it behind a trusted reverse
+proxy that strips or overwrites client-supplied forwarding headers.
+
+When `RATE_LIMIT_TRUST_PROXY_HEADERS=false` or unset, OpenPlaud cannot derive a
+trusted client IP from the request. The unauthenticated IP limiter therefore
+uses one shared `"unknown"` bucket of 1,200 requests per minute for the whole
+instance. Authenticated identity limits still apply per API key/session at 600
+requests per minute.
 
 ## Webhooks
 
-Webhooks are not currently supported but are planned for a future release.
+Webhooks are configured from Settings -> Webhooks. Target validation is
+controlled by `WEBHOOKS_REQUIRE_PUBLIC_TARGETS ?? IS_HOSTED`.
+
+When strict public targets are required, endpoint URLs must use HTTPS, must not
+include credentials, must use public hostnames/IPs, and are delivered with DNS
+pinning to the resolved public addresses. When strict public targets are not
+required, self-host instances may use HTTP, private IPs, loopback addresses,
+`.local` names, and Docker service hostnames such as
+`http://n8n:5678/webhook`.
+
+Supported events:
+- `recording.synced`
+- `recording.updated`
+- `recording.deleted`
+- `transcription.completed`
+- `transcription.failed`
+
+OpenPlaud signs each request with HMAC-SHA256:
+
+```http
+X-OpenPlaud-Event: transcription.completed
+X-OpenPlaud-Delivery: <delivery-id>
+X-OpenPlaud-Timestamp: 1778078610
+X-OpenPlaud-Signature: t=1778078610,v1=<hex hmac>
+```
+
+The signature input is:
+
+```
+<unix_timestamp>.<raw_json_body>
+```
+
+Verify with the endpoint secret returned on creation. Reject old timestamps
+(five minutes is a reasonable default) and compare signatures in constant time.
+
+Delivery uses an in-process worker started by Next.js `instrumentation.ts`.
+This matches the Docker deployment model. Stateless serverless deployments need
+an external process or cron to run deliveries reliably.
+
+Delivery history stores only minimal event metadata. Recording, transcript, and
+summary data are hydrated at delivery time. Retries and manual redelivery also
+hydrate data at retry/redelivery time, not at original event time. Consumers
+should order events by `delivered_at` and treat `data` as the latest observed
+state at delivery time.
+
+Webhook recording links are absolute API URLs built from `APP_URL`. Normal v1
+API responses keep their documented relative links.
+
+Webhook transcript payloads include a bounded preview instead of the full text:
+
+```json
+{
+  "transcript": {
+    "preview": "first 500 characters...",
+    "truncated": true,
+    "length": 24837,
+    "language": "en",
+    "provider": "openai",
+    "model": "whisper-1",
+    "created_at": "2026-05-06T12:05:00.000Z"
+  },
+  "links": {
+    "transcript": "https://openplaud.example/api/v1/recordings/abc123/transcript"
+  }
+}
+```
+
+`recording.deleted` is the exception to normal latest-state hydration because
+normal v1 recording reads exclude tombstoned rows. Deleted recording payloads
+use tombstoned metadata that is still available, include `deleted_at`, set
+`transcript` and `summary` to `null`, and keep absolute resource/API URLs for
+identity and follow-up handling.
+
+Retries use exponential backoff: 30 seconds, 2 minutes, 10 minutes, 1 hour,
+then 6 hours. After six failed attempts, the delivery is marked `dead`.
 
 ## SDK / Client Libraries
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,11 @@
+type WebhookWorkerModule = {
+    startWebhookWorker: () => void;
+};
+
+export async function register() {
+    if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+    const { startWebhookWorker } =
+        require("./src/lib/webhooks/worker") as WebhookWorkerModule;
+    startWebhookWorker();
+}

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -178,6 +178,25 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
     const didTombstone = await db.transaction(async (tx) => {
         const now = new Date();
 
+        // Lock the parent recording row up front. Without this, a
+        // concurrent transcribe/summary writer (which also re-checks
+        // tombstone under FOR UPDATE) could slip a new transcript or
+        // ai_enhancement row in between our child-row deletes and the
+        // final tombstone, leaving orphan rows pointing at a tombstoned
+        // recording. With the lock, concurrent writers either run before
+        // us (their rows get deleted by the child-row deletes below) or
+        // after us (they observe `deletedAt != null` and bail).
+        const [locked] = await tx
+            .select({ deletedAt: recordings.deletedAt })
+            .from(recordings)
+            .where(and(eq(recordings.id, id), eq(recordings.userId, userId)))
+            .for("update")
+            .limit(1);
+
+        // A concurrent DELETE already tombstoned and committed; nothing
+        // for us to do. Return false so we don't emit a duplicate event.
+        if (!locked || locked.deletedAt) return false;
+
         await tx
             .delete(transcriptions)
             .where(

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -1,11 +1,18 @@
 import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { aiEnhancements, recordings, transcriptions } from "@/db/schema";
+import {
+    aiEnhancements,
+    recordings,
+    transcriptions,
+    webhookDeliveries,
+} from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
 import { decryptText } from "@/lib/encryption/fields";
 import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
 import { createUserStorageProvider } from "@/lib/storage/factory";
+import { emitEvent } from "@/lib/webhooks/emit";
+import { createRedactedWebhookPayload } from "@/lib/webhooks/payload";
 
 type IdContext = { params: Promise<{ id: string }> };
 
@@ -166,8 +173,11 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
         // Object already absent — continue with tombstone.
     }
 
-    // 2. Atomic DB writes: child rows + tombstone in one transaction.
+    // 2. Atomic DB writes: child rows, webhook delivery payload redaction,
+    //    and tombstone in one transaction.
     await db.transaction(async (tx) => {
+        const now = new Date();
+
         await tx
             .delete(transcriptions)
             .where(
@@ -187,8 +197,21 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
             );
 
         await tx
+            .update(webhookDeliveries)
+            .set({
+                payload: createRedactedWebhookPayload(id, now),
+                updatedAt: now,
+            })
+            .where(
+                and(
+                    eq(webhookDeliveries.recordingId, id),
+                    eq(webhookDeliveries.userId, userId),
+                ),
+            );
+
+        await tx
             .update(recordings)
-            .set({ deletedAt: new Date(), updatedAt: new Date() })
+            .set({ deletedAt: now, updatedAt: now })
             .where(
                 and(
                     eq(recordings.id, id),
@@ -197,6 +220,8 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
                 ),
             );
     });
+
+    await emitEvent("recording.deleted", userId, id);
 
     return NextResponse.json({ success: true });
 });

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -175,7 +175,7 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
 
     // 2. Atomic DB writes: child rows, webhook delivery payload redaction,
     //    and tombstone in one transaction.
-    await db.transaction(async (tx) => {
+    const didTombstone = await db.transaction(async (tx) => {
         const now = new Date();
 
         await tx
@@ -209,7 +209,10 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
                 ),
             );
 
-        await tx
+        // Returning lets us tell whether THIS request flipped the
+        // tombstone vs. a concurrent DELETE having already done it. We
+        // only want to emit `recording.deleted` for the winning request.
+        const tombstoned = await tx
             .update(recordings)
             .set({ deletedAt: now, updatedAt: now })
             .where(
@@ -218,10 +221,15 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
                     eq(recordings.userId, userId),
                     isNull(recordings.deletedAt),
                 ),
-            );
+            )
+            .returning({ id: recordings.id });
+
+        return tombstoned.length > 0;
     });
 
-    await emitEvent("recording.deleted", userId, id);
+    if (didTombstone) {
+        await emitEvent("recording.deleted", userId, id);
+    }
 
     return NextResponse.json({ success: true });
 });

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -60,7 +60,12 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
     const [transcription] = await db
         .select()
         .from(transcriptions)
-        .where(eq(transcriptions.recordingId, id))
+        .where(
+            and(
+                eq(transcriptions.recordingId, id),
+                eq(transcriptions.userId, session.user.id),
+            ),
+        )
         .limit(1);
 
     if (!transcription) {
@@ -303,7 +308,12 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                         provider: credentials.provider,
                         model,
                     })
-                    .where(eq(aiEnhancements.id, existing.id));
+                    .where(
+                        and(
+                            eq(aiEnhancements.id, existing.id),
+                            eq(aiEnhancements.userId, session.user.id),
+                        ),
+                    );
             } else {
                 await tx.insert(aiEnhancements).values({
                     recordingId: id,
@@ -315,6 +325,17 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                     model,
                 });
             }
+
+            await tx
+                .update(recordings)
+                .set({ updatedAt: new Date() })
+                .where(
+                    and(
+                        eq(recordings.id, id),
+                        eq(recordings.userId, session.user.id),
+                        isNull(recordings.deletedAt),
+                    ),
+                );
         });
     } catch (txError) {
         if (txError === RECORDING_TOMBSTONED) {
@@ -341,6 +362,26 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
     const session = await requireApiSession(request);
 
     const { id } = await (context as IdContext).params;
+
+    const [recording] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.id, id),
+                eq(recordings.userId, session.user.id),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!recording) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+        );
+    }
 
     const [enhancement] = await db
         .select()
@@ -375,14 +416,30 @@ export const DELETE = apiHandler<IdContext>(async (request, context) => {
 
     const { id } = await (context as IdContext).params;
 
-    await db
-        .delete(aiEnhancements)
-        .where(
-            and(
-                eq(aiEnhancements.recordingId, id),
-                eq(aiEnhancements.userId, session.user.id),
-            ),
-        );
+    await db.transaction(async (tx) => {
+        const deleted = await tx
+            .delete(aiEnhancements)
+            .where(
+                and(
+                    eq(aiEnhancements.recordingId, id),
+                    eq(aiEnhancements.userId, session.user.id),
+                ),
+            )
+            .returning({ id: aiEnhancements.id });
+
+        if (deleted.length > 0) {
+            await tx
+                .update(recordings)
+                .set({ updatedAt: new Date() })
+                .where(
+                    and(
+                        eq(recordings.id, id),
+                        eq(recordings.userId, session.user.id),
+                        isNull(recordings.deletedAt),
+                    ),
+                );
+        }
+    });
 
     return NextResponse.json({ success: true });
 });

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -12,201 +12,217 @@ import {
     getResponseFormat,
     parseTranscriptionResponse,
 } from "@/lib/transcription/format";
+import { emitEvent } from "@/lib/webhooks/emit";
 
 type IdContext = { params: Promise<{ id: string }> };
 
 export const POST = apiHandler<IdContext>(async (request, context) => {
     const session = await requireApiSession(request);
-
     const { id } = await (context as IdContext).params;
-    const body = await request.json().catch(() => ({}));
-    const overrideProviderId = body.providerId as string | undefined;
-    const overrideModel = body.model as string | undefined;
 
-    const [recording] = await db
-        .select()
-        .from(recordings)
-        .where(
-            and(
-                eq(recordings.id, id),
-                eq(recordings.userId, session.user.id),
-                isNull(recordings.deletedAt),
-            ),
-        )
-        .limit(1);
-
-    if (!recording) {
-        throw new AppError(
-            ErrorCode.RECORDING_NOT_FOUND,
-            "Recording not found",
-            404,
-        );
-    }
-
-    // Get user's transcription API credentials
-    // If a specific provider was requested, look it up by ID
-    const [credentials] = overrideProviderId
-        ? await db
-              .select()
-              .from(apiCredentials)
-              .where(
-                  and(
-                      eq(apiCredentials.id, overrideProviderId),
-                      eq(apiCredentials.userId, session.user.id),
-                  ),
-              )
-              .limit(1)
-        : await db
-              .select()
-              .from(apiCredentials)
-              .where(
-                  and(
-                      eq(apiCredentials.userId, session.user.id),
-                      eq(apiCredentials.isDefaultTranscription, true),
-                  ),
-              )
-              .limit(1);
-
-    if (!credentials) {
-        throw new AppError(
-            ErrorCode.NO_TRANSCRIPTION_PROVIDER,
-            "No transcription API configured",
-            400,
-        );
-    }
-
-    // Decrypt API key
-    const apiKey = decrypt(credentials.apiKey);
-
-    // Create OpenAI client (works with all OpenAI-compatible APIs)
-    const openai = new OpenAI({
-        apiKey,
-        baseURL: credentials.baseUrl || undefined,
-    });
-
-    // Get storage provider and download audio
-    const storage = await createUserStorageProvider(session.user.id);
-    const audioBuffer = await storage.downloadFile(recording.storagePath);
-
-    // Create a File object for the transcription API
-    // Detect actual audio format from magic bytes since Plaud files
-    // may have .mp3 extension but contain OGG/Opus data
-    const header = new Uint8Array(audioBuffer.slice(0, 4));
-    const isOgg =
-        header[0] === 0x4f &&
-        header[1] === 0x67 &&
-        header[2] === 0x67 &&
-        header[3] === 0x53; // "OggS"
-
-    const ext = isOgg ? "ogg" : recording.storagePath.split(".").pop() || "mp3";
-    const contentType = isOgg
-        ? "audio/ogg"
-        : recording.storagePath.endsWith(".mp3")
-          ? "audio/mpeg"
-          : "audio/opus";
-
-    // `recording.filename` is encrypted at rest; decrypt before passing
-    // to the transcription provider (which uses the filename hint to
-    // sniff audio format).
-    const decryptedFilename = decryptText(recording.filename);
-    // Ensure filename has a valid extension so the API can detect the format
-    const filename = decryptedFilename.match(/\.\w{2,4}$/)
-        ? decryptedFilename
-        : `${decryptedFilename}.${ext}`;
-
-    const audioFile = new File([new Uint8Array(audioBuffer)], filename, {
-        type: contentType,
-    });
-
-    const model = overrideModel || credentials.defaultModel || "whisper-1";
-    const responseFormat = getResponseFormat(model);
-
-    const transcription = await openai.audio.transcriptions.create({
-        file: audioFile,
-        model,
-        response_format: responseFormat,
-    });
-
-    const { text: transcriptionText, detectedLanguage } =
-        parseTranscriptionResponse(transcription, responseFormat);
-
-    // Atomic tombstone re-check + transcription upsert.
-    //
-    // The user may have deleted the recording while the (long-running)
-    // provider call was in flight. To prevent a delete that lands
-    // *between* our re-check and our upsert from being silently undone,
-    // we run both inside a single transaction that takes a row-level
-    // write lock (`FOR UPDATE`) on the recording. The DELETE handler's
-    // transaction acquires the same lock via its `UPDATE recordings`
-    // tombstone write, so the two transactions serialize: either we
-    // see `deletedAt` set and abort, or our upsert commits before
-    // DELETE runs and DELETE then cleans up our row inside its own tx.
-    // See PR #72.
-    const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
     try {
-        await db.transaction(async (tx) => {
-            const [stillActive] = await tx
-                .select({ deletedAt: recordings.deletedAt })
-                .from(recordings)
-                .where(
-                    and(
-                        eq(recordings.id, id),
-                        eq(recordings.userId, session.user.id),
-                    ),
-                )
-                .for("update")
-                .limit(1);
+        const body = (await request.json().catch(() => ({}))) as Record<
+            string,
+            unknown
+        >;
+        const overrideProviderId =
+            typeof body.providerId === "string" ? body.providerId : undefined;
+        const overrideModel =
+            typeof body.model === "string" ? body.model : undefined;
 
-            if (!stillActive || stillActive.deletedAt) {
-                throw RECORDING_TOMBSTONED;
-            }
+        const [recording] = await db
+            .select()
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, id),
+                    eq(recordings.userId, session.user.id),
+                    isNull(recordings.deletedAt),
+                ),
+            )
+            .limit(1);
 
-            const [existingTranscription] = await tx
-                .select()
-                .from(transcriptions)
-                .where(eq(transcriptions.recordingId, id))
-                .limit(1);
+        if (!recording) {
+            throw new AppError(
+                ErrorCode.RECORDING_NOT_FOUND,
+                "Recording not found",
+                404,
+            );
+        }
 
-            // Encrypt the transcript before persisting; the response
-            // below uses the in-scope plaintext.
-            const encryptedText = encryptText(transcriptionText);
+        const [credentials] = overrideProviderId
+            ? await db
+                  .select()
+                  .from(apiCredentials)
+                  .where(
+                      and(
+                          eq(apiCredentials.id, overrideProviderId),
+                          eq(apiCredentials.userId, session.user.id),
+                      ),
+                  )
+                  .limit(1)
+            : await db
+                  .select()
+                  .from(apiCredentials)
+                  .where(
+                      and(
+                          eq(apiCredentials.userId, session.user.id),
+                          eq(apiCredentials.isDefaultTranscription, true),
+                      ),
+                  )
+                  .limit(1);
 
-            if (existingTranscription) {
-                await tx
-                    .update(transcriptions)
-                    .set({
+        if (!credentials) {
+            throw new AppError(
+                ErrorCode.NO_TRANSCRIPTION_PROVIDER,
+                "No transcription API configured",
+                400,
+            );
+        }
+
+        const apiKey = decrypt(credentials.apiKey);
+        const openai = new OpenAI({
+            apiKey,
+            baseURL: credentials.baseUrl || undefined,
+        });
+
+        const storage = await createUserStorageProvider(session.user.id);
+        const audioBuffer = await storage.downloadFile(recording.storagePath);
+
+        const header = new Uint8Array(audioBuffer.slice(0, 4));
+        const isOgg =
+            header[0] === 0x4f &&
+            header[1] === 0x67 &&
+            header[2] === 0x67 &&
+            header[3] === 0x53;
+
+        const ext = isOgg
+            ? "ogg"
+            : recording.storagePath.split(".").pop() || "mp3";
+        const contentType = isOgg
+            ? "audio/ogg"
+            : recording.storagePath.endsWith(".mp3")
+              ? "audio/mpeg"
+              : "audio/opus";
+
+        const decryptedFilename = decryptText(recording.filename);
+        const filename = decryptedFilename.match(/\.\w{2,4}$/)
+            ? decryptedFilename
+            : `${decryptedFilename}.${ext}`;
+
+        const audioFile = new File([new Uint8Array(audioBuffer)], filename, {
+            type: contentType,
+        });
+
+        const model = overrideModel || credentials.defaultModel || "whisper-1";
+        const responseFormat = getResponseFormat(model);
+
+        const transcription = await openai.audio.transcriptions.create({
+            file: audioFile,
+            model,
+            response_format: responseFormat,
+        });
+
+        const { text: transcriptionText, detectedLanguage } =
+            parseTranscriptionResponse(transcription, responseFormat);
+
+        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
+        try {
+            await db.transaction(async (tx) => {
+                const [stillActive] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, id),
+                            eq(recordings.userId, session.user.id),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
+
+                if (!stillActive || stillActive.deletedAt) {
+                    throw RECORDING_TOMBSTONED;
+                }
+
+                const [existingTranscription] = await tx
+                    .select()
+                    .from(transcriptions)
+                    .where(
+                        and(
+                            eq(transcriptions.recordingId, id),
+                            eq(transcriptions.userId, session.user.id),
+                        ),
+                    )
+                    .limit(1);
+
+                const encryptedText = encryptText(transcriptionText);
+
+                if (existingTranscription) {
+                    await tx
+                        .update(transcriptions)
+                        .set({
+                            text: encryptedText,
+                            detectedLanguage,
+                            transcriptionType: "server",
+                            provider: credentials.provider,
+                            model,
+                        })
+                        .where(
+                            and(
+                                eq(transcriptions.id, existingTranscription.id),
+                                eq(transcriptions.userId, session.user.id),
+                            ),
+                        );
+                } else {
+                    await tx.insert(transcriptions).values({
+                        recordingId: id,
+                        userId: session.user.id,
                         text: encryptedText,
                         detectedLanguage,
                         transcriptionType: "server",
                         provider: credentials.provider,
                         model,
-                    })
-                    .where(eq(transcriptions.id, existingTranscription.id));
-            } else {
-                await tx.insert(transcriptions).values({
-                    recordingId: id,
-                    userId: session.user.id,
-                    text: encryptedText,
-                    detectedLanguage,
-                    transcriptionType: "server",
-                    provider: credentials.provider,
-                    model,
-                });
-            }
-        });
-    } catch (txError) {
-        if (txError === RECORDING_TOMBSTONED) {
-            throw new AppError(
-                ErrorCode.NOT_FOUND,
-                "Recording was deleted",
-                410,
-            );
-        }
-        throw txError;
-    }
+                    });
+                }
 
-    return NextResponse.json({
-        transcription: transcriptionText,
-        detectedLanguage,
-    });
+                await tx
+                    .update(recordings)
+                    .set({ updatedAt: new Date() })
+                    .where(
+                        and(
+                            eq(recordings.id, id),
+                            eq(recordings.userId, session.user.id),
+                            isNull(recordings.deletedAt),
+                        ),
+                    );
+            });
+        } catch (txError) {
+            if (txError === RECORDING_TOMBSTONED) {
+                throw new AppError(
+                    ErrorCode.NOT_FOUND,
+                    "Recording was deleted",
+                    410,
+                );
+            }
+            throw txError;
+        }
+
+        await emitEvent("transcription.completed", session.user.id, id);
+
+        return NextResponse.json({
+            transcription: transcriptionText,
+            detectedLanguage,
+        });
+    } catch (error) {
+        await emitEvent("transcription.failed", session.user.id, id, {
+            error: error instanceof Error ? error.message : String(error),
+        }).catch((eventError) => {
+            console.error(
+                "Failed to emit transcription failure event:",
+                eventError,
+            );
+        });
+        throw error;
+    }
 });

--- a/src/app/api/recordings/route.ts
+++ b/src/app/api/recordings/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
+import { decryptText } from "@/lib/encryption/fields";
 import { apiHandler } from "@/lib/errors";
 
 export const GET = apiHandler(async (request: Request) => {
@@ -19,5 +20,10 @@ export const GET = apiHandler(async (request: Request) => {
         )
         .orderBy(desc(recordings.startTime));
 
-    return NextResponse.json({ recordings: userRecordings });
+    return NextResponse.json({
+        recordings: userRecordings.map((recording) => ({
+            ...recording,
+            filename: decryptText(recording.filename),
+        })),
+    });
 });

--- a/src/app/api/settings/api-keys/[id]/route.ts
+++ b/src/app/api/settings/api-keys/[id]/route.ts
@@ -1,0 +1,28 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { apiKeys } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+export const DELETE = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+
+    const { id } = await (context as IdContext).params;
+    const now = new Date();
+    const [apiKey] = await db
+        .update(apiKeys)
+        .set({ revokedAt: now, updatedAt: now })
+        .where(and(eq(apiKeys.id, id), eq(apiKeys.userId, session.user.id)))
+        .returning({ id: apiKeys.id });
+
+    if (!apiKey) {
+        throw new AppError(ErrorCode.NOT_FOUND, "API key not found", 404, {
+            id,
+        });
+    }
+
+    return NextResponse.json({ success: true });
+});

--- a/src/app/api/settings/api-keys/route.ts
+++ b/src/app/api/settings/api-keys/route.ts
@@ -1,0 +1,121 @@
+import { desc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { apiKeys } from "@/db/schema";
+import {
+    createApiKey,
+    getApiKeyPrefix,
+    hashApiKey,
+    normalizeApiKeyScopes,
+} from "@/lib/auth-request";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+
+function serializeApiKey(apiKey: typeof apiKeys.$inferSelect) {
+    return {
+        id: apiKey.id,
+        name: apiKey.name,
+        keyPrefix: apiKey.keyPrefix,
+        source: apiKey.source,
+        scopes: apiKey.scopes,
+        lastUsedAt: apiKey.lastUsedAt,
+        expiresAt: apiKey.expiresAt,
+        revokedAt: apiKey.revokedAt,
+        createdAt: apiKey.createdAt,
+    };
+}
+
+function parseExpiresAt(value: unknown): Date | null {
+    if (value == null || value === "") return null;
+    if (typeof value !== "string") {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "expiresAt must be a string",
+            400,
+            { field: "expiresAt" },
+        );
+    }
+
+    const expiresAt = new Date(value);
+    if (Number.isNaN(expiresAt.getTime())) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "expiresAt must be an ISO timestamp",
+            400,
+            { field: "expiresAt" },
+        );
+    }
+    return expiresAt;
+}
+
+export const GET = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+
+    const rows = await db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.userId, session.user.id))
+        .orderBy(desc(apiKeys.createdAt));
+
+    return NextResponse.json({ apiKeys: rows.map(serializeApiKey) });
+});
+
+export const POST = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+
+    const body = (await request.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+    >;
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!name) {
+        throw new AppError(
+            ErrorCode.MISSING_REQUIRED_FIELD,
+            "API key name is required",
+            400,
+            { field: "name" },
+        );
+    }
+    if (name.length > 120) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "API key name must be 120 characters or less",
+            400,
+            { field: "name" },
+        );
+    }
+
+    const expiresAt = parseExpiresAt(body.expiresAt);
+    if (expiresAt && expiresAt <= new Date()) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "expiresAt must be in the future",
+            400,
+            { field: "expiresAt" },
+        );
+    }
+
+    const scopes = normalizeApiKeyScopes(body.scopes);
+    const rawKey = createApiKey();
+
+    const [apiKey] = await db
+        .insert(apiKeys)
+        .values({
+            userId: session.user.id,
+            name,
+            keyHash: hashApiKey(rawKey),
+            keyPrefix: getApiKeyPrefix(rawKey),
+            source: "manual",
+            scopes,
+            expiresAt,
+        })
+        .returning();
+
+    return NextResponse.json(
+        {
+            key: rawKey,
+            apiKey: serializeApiKey(apiKey),
+        },
+        { status: 201 },
+    );
+});

--- a/src/app/api/settings/webhooks/[id]/deliveries/[deliveryId]/redeliver/route.ts
+++ b/src/app/api/settings/webhooks/[id]/deliveries/[deliveryId]/redeliver/route.ts
@@ -1,0 +1,89 @@
+import { and, eq, ne } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { signalWebhookWorker } from "@/lib/webhooks/worker";
+
+type DeliveryContext = {
+    params: Promise<{ id: string; deliveryId: string }>;
+};
+
+export const POST = apiHandler<DeliveryContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+
+    const { id, deliveryId } = await (context as DeliveryContext).params;
+    const [endpoint] = await db
+        .select({
+            id: webhookEndpoints.id,
+            enabled: webhookEndpoints.enabled,
+        })
+        .from(webhookEndpoints)
+        .where(
+            and(
+                eq(webhookEndpoints.id, id),
+                eq(webhookEndpoints.userId, session.user.id),
+            ),
+        )
+        .limit(1);
+
+    if (!endpoint) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Webhook not found", 404, {
+            id,
+        });
+    }
+    if (!endpoint.enabled) {
+        throw new AppError(ErrorCode.CONFLICT, "Webhook is disabled", 409, {
+            id,
+        });
+    }
+
+    const [delivery] = await db
+        .update(webhookDeliveries)
+        .set({
+            status: "pending",
+            nextAttemptAt: new Date(),
+            updatedAt: new Date(),
+        })
+        .where(
+            and(
+                eq(webhookDeliveries.id, deliveryId),
+                eq(webhookDeliveries.endpointId, endpoint.id),
+                eq(webhookDeliveries.userId, session.user.id),
+                ne(webhookDeliveries.status, "processing"),
+            ),
+        )
+        .returning({ id: webhookDeliveries.id });
+
+    if (!delivery) {
+        const [existingDelivery] = await db
+            .select({ status: webhookDeliveries.status })
+            .from(webhookDeliveries)
+            .where(
+                and(
+                    eq(webhookDeliveries.id, deliveryId),
+                    eq(webhookDeliveries.endpointId, endpoint.id),
+                    eq(webhookDeliveries.userId, session.user.id),
+                ),
+            )
+            .limit(1);
+
+        if (existingDelivery?.status === "processing") {
+            throw new AppError(
+                ErrorCode.CONFLICT,
+                "Delivery is already processing",
+                409,
+                { id: deliveryId },
+            );
+        }
+
+        throw new AppError(ErrorCode.NOT_FOUND, "Delivery not found", 404, {
+            id: deliveryId,
+        });
+    }
+
+    signalWebhookWorker();
+
+    return NextResponse.json({ success: true });
+});

--- a/src/app/api/settings/webhooks/[id]/deliveries/route.ts
+++ b/src/app/api/settings/webhooks/[id]/deliveries/route.ts
@@ -1,0 +1,56 @@
+import { and, desc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+export const GET = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+
+    const { id } = await (context as IdContext).params;
+    const [endpoint] = await db
+        .select({ id: webhookEndpoints.id })
+        .from(webhookEndpoints)
+        .where(
+            and(
+                eq(webhookEndpoints.id, id),
+                eq(webhookEndpoints.userId, session.user.id),
+            ),
+        )
+        .limit(1);
+
+    if (!endpoint) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Webhook not found", 404, {
+            id,
+        });
+    }
+
+    const deliveries = await db
+        .select({
+            id: webhookDeliveries.id,
+            event: webhookDeliveries.event,
+            status: webhookDeliveries.status,
+            attempts: webhookDeliveries.attempts,
+            lastAttemptAt: webhookDeliveries.lastAttemptAt,
+            nextAttemptAt: webhookDeliveries.nextAttemptAt,
+            lastResponseStatus: webhookDeliveries.lastResponseStatus,
+            lastResponseBody: webhookDeliveries.lastResponseBody,
+            lastError: webhookDeliveries.lastError,
+            createdAt: webhookDeliveries.createdAt,
+            updatedAt: webhookDeliveries.updatedAt,
+        })
+        .from(webhookDeliveries)
+        .where(
+            and(
+                eq(webhookDeliveries.endpointId, endpoint.id),
+                eq(webhookDeliveries.userId, session.user.id),
+            ),
+        )
+        .orderBy(desc(webhookDeliveries.createdAt))
+        .limit(100);
+
+    return NextResponse.json({ deliveries });
+});

--- a/src/app/api/settings/webhooks/[id]/route.ts
+++ b/src/app/api/settings/webhooks/[id]/route.ts
@@ -1,0 +1,109 @@
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { webhookEndpoints } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { encryptWebhookUrl } from "@/lib/webhooks/secrets";
+import {
+    parseWebhookEvents,
+    serializeWebhookEndpoint,
+} from "@/lib/webhooks/settings";
+import { assertWebhookUrlAllowed, parseWebhookUrl } from "@/lib/webhooks/url";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+function webhookValidationError(error: unknown): AppError {
+    return new AppError(
+        ErrorCode.INVALID_INPUT,
+        error instanceof Error ? error.message : "Invalid webhook",
+        400,
+    );
+}
+
+export const PATCH = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+    const body = (await request.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+    >;
+    const updates: Partial<typeof webhookEndpoints.$inferInsert> = {
+        updatedAt: new Date(),
+    };
+
+    try {
+        if (body.url !== undefined) {
+            const url = parseWebhookUrl(body.url);
+            await assertWebhookUrlAllowed(url);
+            updates.url = encryptWebhookUrl(url);
+        }
+        if (body.events !== undefined) {
+            updates.events = parseWebhookEvents(body.events);
+        }
+    } catch (error) {
+        throw webhookValidationError(error);
+    }
+
+    if (body.enabled !== undefined) {
+        if (typeof body.enabled !== "boolean") {
+            throw new AppError(
+                ErrorCode.INVALID_INPUT,
+                "enabled must be a boolean",
+                400,
+                { field: "enabled" },
+            );
+        }
+        updates.enabled = body.enabled;
+    }
+
+    if (body.description !== undefined) {
+        updates.description =
+            typeof body.description === "string" && body.description.trim()
+                ? body.description.trim()
+                : null;
+    }
+
+    const [endpoint] = await db
+        .update(webhookEndpoints)
+        .set(updates)
+        .where(
+            and(
+                eq(webhookEndpoints.id, id),
+                eq(webhookEndpoints.userId, session.user.id),
+            ),
+        )
+        .returning();
+
+    if (!endpoint) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Webhook not found", 404, {
+            id,
+        });
+    }
+
+    return NextResponse.json({
+        webhook: serializeWebhookEndpoint(endpoint),
+    });
+});
+
+export const DELETE = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+    const [endpoint] = await db
+        .delete(webhookEndpoints)
+        .where(
+            and(
+                eq(webhookEndpoints.id, id),
+                eq(webhookEndpoints.userId, session.user.id),
+            ),
+        )
+        .returning({ id: webhookEndpoints.id });
+
+    if (!endpoint) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Webhook not found", 404, {
+            id,
+        });
+    }
+
+    return NextResponse.json({ success: true });
+});

--- a/src/app/api/settings/webhooks/route.ts
+++ b/src/app/api/settings/webhooks/route.ts
@@ -1,0 +1,84 @@
+import { desc, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { webhookEndpoints } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { WEBHOOK_EVENTS } from "@/lib/webhooks/emit";
+import {
+    encryptWebhookSecret,
+    encryptWebhookUrl,
+} from "@/lib/webhooks/secrets";
+import {
+    parseWebhookEvents,
+    serializeWebhookEndpoint,
+} from "@/lib/webhooks/settings";
+import { assertWebhookUrlAllowed, parseWebhookUrl } from "@/lib/webhooks/url";
+
+function webhookValidationError(error: unknown): AppError {
+    return new AppError(
+        ErrorCode.INVALID_INPUT,
+        error instanceof Error ? error.message : "Invalid webhook",
+        400,
+    );
+}
+
+export const GET = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+
+    const endpoints = await db
+        .select()
+        .from(webhookEndpoints)
+        .where(eq(webhookEndpoints.userId, session.user.id))
+        .orderBy(desc(webhookEndpoints.createdAt));
+
+    return NextResponse.json({
+        webhooks: endpoints.map(serializeWebhookEndpoint),
+        events: WEBHOOK_EVENTS,
+    });
+});
+
+export const POST = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+    const body = (await request.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+    >;
+
+    let url: string;
+    let events: string[];
+    try {
+        url = parseWebhookUrl(body.url);
+        await assertWebhookUrlAllowed(url);
+        events = parseWebhookEvents(body.events);
+    } catch (error) {
+        throw webhookValidationError(error);
+    }
+
+    const secret = `whsec_${nanoid(32)}`;
+    const encryptedSecret = encryptWebhookSecret(secret);
+    const encryptedUrl = encryptWebhookUrl(url);
+    const [endpoint] = await db
+        .insert(webhookEndpoints)
+        .values({
+            userId: session.user.id,
+            url: encryptedUrl,
+            secret: encryptedSecret,
+            events,
+            description:
+                typeof body.description === "string" && body.description.trim()
+                    ? body.description.trim()
+                    : null,
+            enabled: typeof body.enabled === "boolean" ? body.enabled : true,
+        })
+        .returning();
+
+    return NextResponse.json(
+        {
+            webhook: serializeWebhookEndpoint(endpoint),
+            secret,
+        },
+        { status: 201 },
+    );
+});

--- a/src/app/api/v1/recordings/[id]/audio/route.ts
+++ b/src/app/api/v1/recordings/[id]/audio/route.ts
@@ -1,0 +1,119 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { recordings } from "@/db/schema";
+import { authenticateRequest } from "@/lib/auth-request";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { createUserStorageProvider } from "@/lib/storage/factory";
+import { getAudioMimeType } from "@/lib/utils";
+import {
+    enforceV1AuthenticatedRateLimit,
+    enforceV1IpRateLimit,
+} from "@/lib/v1/rate-limit";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+export const GET = apiHandler<IdContext>(async (request, context) => {
+    const ipLimitResponse = await enforceV1IpRateLimit(request);
+    if (ipLimitResponse) return ipLimitResponse;
+
+    const authn = await authenticateRequest(request);
+    if (!authn) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, "Unauthorized", 401);
+    }
+
+    const authLimitResponse = await enforceV1AuthenticatedRateLimit(authn);
+    if (authLimitResponse) return authLimitResponse;
+
+    const { id } = await (context as IdContext).params;
+    const [recording] = await db
+        .select()
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.id, id),
+                eq(recordings.userId, authn.user.id),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!recording) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+            { id },
+        );
+    }
+
+    const storage = await createUserStorageProvider(authn.user.id);
+
+    if (recording.storageType === "s3") {
+        const signedUrl = await storage.getSignedUrl(
+            recording.storagePath,
+            300,
+        );
+        return NextResponse.redirect(signedUrl, 302);
+    }
+
+    const audioBuffer = await storage.downloadFile(recording.storagePath);
+    const contentType = getAudioMimeType(recording.storagePath);
+    const fileSize = audioBuffer.length;
+    const rangeHeader = request.headers.get("range");
+
+    if (rangeHeader) {
+        const rangeMatch = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+        if (rangeMatch) {
+            const start = Number.parseInt(rangeMatch[1], 10);
+            const end = rangeMatch[2]
+                ? Number.parseInt(rangeMatch[2], 10)
+                : fileSize - 1;
+
+            if (
+                start < 0 ||
+                start >= fileSize ||
+                end < 0 ||
+                end >= fileSize ||
+                start > end
+            ) {
+                return NextResponse.json(
+                    {
+                        error: "Invalid range",
+                        code: ErrorCode.INVALID_INPUT,
+                        details: { range: rangeHeader, fileSize },
+                    },
+                    {
+                        status: 416,
+                        headers: {
+                            "Content-Range": `bytes */${fileSize}`,
+                        },
+                    },
+                );
+            }
+
+            const chunk = audioBuffer.slice(start, end + 1);
+            const chunkSize = end - start + 1;
+
+            return new NextResponse(new Uint8Array(chunk), {
+                status: 206,
+                headers: {
+                    "Content-Type": contentType,
+                    "Content-Length": chunkSize.toString(),
+                    "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+                    "Accept-Ranges": "bytes",
+                    "Cache-Control": "private, max-age=300",
+                },
+            });
+        }
+    }
+
+    return new NextResponse(new Uint8Array(audioBuffer), {
+        headers: {
+            "Content-Type": contentType,
+            "Content-Length": fileSize.toString(),
+            "Accept-Ranges": "bytes",
+            "Cache-Control": "private, max-age=300",
+        },
+    });
+});

--- a/src/app/api/v1/recordings/[id]/audio/route.ts
+++ b/src/app/api/v1/recordings/[id]/audio/route.ts
@@ -66,17 +66,14 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
         const rangeMatch = rangeHeader.match(/bytes=(\d+)-(\d*)/);
         if (rangeMatch) {
             const start = Number.parseInt(rangeMatch[1], 10);
-            const end = rangeMatch[2]
+            // RFC 7233: clamp an oversized end to fileSize - 1 rather than
+            // 416. Only an unsatisfiable start (past EOF or > end) is 416.
+            const requestedEnd = rangeMatch[2]
                 ? Number.parseInt(rangeMatch[2], 10)
                 : fileSize - 1;
+            const end = Math.min(requestedEnd, fileSize - 1);
 
-            if (
-                start < 0 ||
-                start >= fileSize ||
-                end < 0 ||
-                end >= fileSize ||
-                start > end
-            ) {
+            if (start < 0 || start >= fileSize || start > end) {
                 return NextResponse.json(
                     {
                         error: "Invalid range",

--- a/src/app/api/v1/recordings/[id]/route.ts
+++ b/src/app/api/v1/recordings/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/auth-request";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    enforceV1AuthenticatedRateLimit,
+    enforceV1IpRateLimit,
+} from "@/lib/v1/rate-limit";
+import { getV1RecordingDetailForUser } from "@/lib/v1/serialize";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+export const GET = apiHandler<IdContext>(async (request, context) => {
+    const ipLimitResponse = await enforceV1IpRateLimit(request);
+    if (ipLimitResponse) return ipLimitResponse;
+
+    const authn = await authenticateRequest(request);
+    if (!authn) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, "Unauthorized", 401);
+    }
+
+    const authLimitResponse = await enforceV1AuthenticatedRateLimit(authn);
+    if (authLimitResponse) return authLimitResponse;
+
+    const { id } = await (context as IdContext).params;
+    const recording = await getV1RecordingDetailForUser(authn.user.id, id);
+
+    if (!recording) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+            { id },
+        );
+    }
+
+    return NextResponse.json(recording);
+});

--- a/src/app/api/v1/recordings/[id]/transcript/route.ts
+++ b/src/app/api/v1/recordings/[id]/transcript/route.ts
@@ -1,0 +1,67 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { recordings, transcriptions } from "@/db/schema";
+import { authenticateRequest } from "@/lib/auth-request";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    enforceV1AuthenticatedRateLimit,
+    enforceV1IpRateLimit,
+} from "@/lib/v1/rate-limit";
+import { serializeTranscript } from "@/lib/v1/serialize";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+export const GET = apiHandler<IdContext>(async (request, context) => {
+    const ipLimitResponse = await enforceV1IpRateLimit(request);
+    if (ipLimitResponse) return ipLimitResponse;
+
+    const authn = await authenticateRequest(request);
+    if (!authn) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, "Unauthorized", 401);
+    }
+
+    const authLimitResponse = await enforceV1AuthenticatedRateLimit(authn);
+    if (authLimitResponse) return authLimitResponse;
+
+    const { id } = await (context as IdContext).params;
+    const [recording] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.id, id),
+                eq(recordings.userId, authn.user.id),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!recording) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+            { id },
+        );
+    }
+
+    const [transcription] = await db
+        .select()
+        .from(transcriptions)
+        .where(
+            and(
+                eq(transcriptions.recordingId, recording.id),
+                eq(transcriptions.userId, authn.user.id),
+            ),
+        )
+        .limit(1);
+
+    if (!transcription) {
+        throw new AppError(ErrorCode.NOT_FOUND, "Transcript not found", 404, {
+            id,
+        });
+    }
+
+    return NextResponse.json(serializeTranscript(transcription));
+});

--- a/src/app/api/v1/recordings/route.ts
+++ b/src/app/api/v1/recordings/route.ts
@@ -1,0 +1,182 @@
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, gte, isNotNull, isNull, lt, or } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import {
+    aiEnhancements,
+    plaudDevices,
+    recordings,
+    transcriptions,
+} from "@/db/schema";
+import { authenticateRequest } from "@/lib/auth-request";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    enforceV1AuthenticatedRateLimit,
+    enforceV1IpRateLimit,
+} from "@/lib/v1/rate-limit";
+import {
+    decodeRecordingCursor,
+    encodeRecordingCursor,
+    serializeRecording,
+} from "@/lib/v1/serialize";
+
+function parseLimit(value: string | null): number {
+    if (!value) return 50;
+    const limit = Number.parseInt(value, 10);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "limit must be an integer from 1 to 100",
+            400,
+            { field: "limit" },
+        );
+    }
+    return limit;
+}
+
+function parseDateFilter(value: string | null, field: string): Date | null {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            `${field} must be an ISO timestamp`,
+            400,
+            { field },
+        );
+    }
+    return date;
+}
+
+function parseBooleanFilter(value: string | null): boolean | null {
+    if (value == null) return null;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    throw new AppError(
+        ErrorCode.INVALID_INPUT,
+        "has_transcription must be true or false",
+        400,
+        { field: "has_transcription" },
+    );
+}
+
+export const GET = apiHandler(async (request: Request) => {
+    const ipLimitResponse = await enforceV1IpRateLimit(request);
+    if (ipLimitResponse) return ipLimitResponse;
+
+    const authn = await authenticateRequest(request);
+    if (!authn) {
+        throw new AppError(ErrorCode.UNAUTHORIZED, "Unauthorized", 401);
+    }
+
+    const authLimitResponse = await enforceV1AuthenticatedRateLimit(authn);
+    if (authLimitResponse) return authLimitResponse;
+
+    const url = new URL(request.url);
+    const limit = parseLimit(url.searchParams.get("limit"));
+    const createdSince = parseDateFilter(
+        url.searchParams.get("created_since"),
+        "created_since",
+    );
+    const updatedSince = parseDateFilter(
+        url.searchParams.get("updated_since"),
+        "updated_since",
+    );
+    const hasTranscription = parseBooleanFilter(
+        url.searchParams.get("has_transcription"),
+    );
+
+    const conditions: SQL[] = [
+        eq(recordings.userId, authn.user.id),
+        isNull(recordings.deletedAt),
+    ];
+
+    if (createdSince) {
+        conditions.push(gte(recordings.createdAt, createdSince));
+    }
+    if (updatedSince) {
+        conditions.push(gte(recordings.updatedAt, updatedSince));
+    }
+
+    const cursorRaw = url.searchParams.get("cursor");
+    if (cursorRaw) {
+        const cursor = decodeRecordingCursor(cursorRaw);
+        if (!cursor) {
+            throw new AppError(ErrorCode.INVALID_INPUT, "Invalid cursor", 400, {
+                field: "cursor",
+            });
+        }
+        conditions.push(
+            or(
+                lt(recordings.updatedAt, cursor.updatedAt),
+                and(
+                    eq(recordings.updatedAt, cursor.updatedAt),
+                    lt(recordings.id, cursor.id),
+                ),
+            ) as SQL,
+        );
+    }
+
+    if (hasTranscription === true) {
+        conditions.push(isNotNull(transcriptions.id));
+    }
+    if (hasTranscription === false) {
+        conditions.push(isNull(transcriptions.id));
+    }
+
+    const rows = await db
+        .select({
+            recording: recordings,
+            device: plaudDevices,
+            transcription: transcriptions,
+            enhancement: aiEnhancements,
+        })
+        .from(recordings)
+        .leftJoin(
+            plaudDevices,
+            and(
+                eq(plaudDevices.userId, authn.user.id),
+                eq(plaudDevices.serialNumber, recordings.deviceSn),
+            ),
+        )
+        .leftJoin(
+            transcriptions,
+            and(
+                eq(transcriptions.recordingId, recordings.id),
+                eq(transcriptions.userId, authn.user.id),
+            ),
+        )
+        .leftJoin(
+            aiEnhancements,
+            and(
+                eq(aiEnhancements.recordingId, recordings.id),
+                eq(aiEnhancements.userId, authn.user.id),
+            ),
+        )
+        .where(and(...conditions))
+        .orderBy(desc(recordings.updatedAt), desc(recordings.id))
+        .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+
+    return NextResponse.json({
+        data: pageRows.map((row) =>
+            serializeRecording(
+                row.recording,
+                row.device,
+                row.transcription,
+                row.enhancement,
+            ),
+        ),
+        next_cursor:
+            hasMore && last
+                ? encodeRecordingCursor({
+                      updatedAt: last.recording.updatedAt,
+                      id: last.recording.id,
+                  })
+                : null,
+        has_more: hasMore,
+    });
+});

--- a/src/components/settings-content.tsx
+++ b/src/components/settings-content.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { SettingsSection } from "@/types/settings";
+import { ApiKeysSection } from "./settings/api-keys-section";
+import { WebhooksSection } from "./settings/webhooks-section";
 import { DevSection } from "./settings-sections/dev-section";
 import { DisplaySection } from "./settings-sections/display-section";
 import { ExportSection } from "./settings-sections/export-section";
@@ -44,6 +46,10 @@ export function SettingsContent({
                     isHosted={isHosted}
                 />
             );
+        case "api-keys":
+            return <ApiKeysSection />;
+        case "webhooks":
+            return <WebhooksSection />;
         case "transcription":
             return <TranscriptionSection />;
         case "summary":

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -6,12 +6,14 @@ import {
     Download,
     FileText,
     HardDrive,
+    KeyRound,
     ListChecks,
     Mic,
     Monitor,
     Play,
     RefreshCw,
     Settings as SettingsIcon,
+    Webhook,
     Wrench,
 } from "lucide-react";
 import * as React from "react";
@@ -69,6 +71,12 @@ import type { SettingsSection } from "@/types/settings";
 
 const settingsNav = [
     { name: "AI", id: "providers" as SettingsSection, icon: Bot },
+    {
+        name: "API Keys",
+        id: "api-keys" as SettingsSection,
+        icon: KeyRound,
+    },
+    { name: "Webhooks", id: "webhooks" as SettingsSection, icon: Webhook },
     {
         name: "Transcription",
         id: "transcription" as SettingsSection,

--- a/src/components/settings/api-keys-section.tsx
+++ b/src/components/settings/api-keys-section.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { Check, Clipboard, KeyRound, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getApiErrorMessage } from "@/lib/api-errors";
+
+type ApiKey = {
+    id: string;
+    name: string;
+    keyPrefix: string;
+    source: "manual" | "device-flow";
+    scopes: string[];
+    lastUsedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    createdAt: string;
+};
+
+function formatDate(value: string | null): string {
+    if (!value) return "Never";
+    return new Date(value).toLocaleString();
+}
+
+export function ApiKeysSection() {
+    const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isCreating, setIsCreating] = useState(false);
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [name, setName] = useState("");
+    const [expiresAt, setExpiresAt] = useState("");
+    const [createdKey, setCreatedKey] = useState<string | null>(null);
+
+    const refreshApiKeys = useCallback(async () => {
+        try {
+            const response = await fetch("/api/settings/api-keys");
+            if (!response.ok) {
+                throw new Error(
+                    await getApiErrorMessage(
+                        response,
+                        "Failed to fetch API keys",
+                    ),
+                );
+            }
+            const data = (await response.json()) as { apiKeys: ApiKey[] };
+            setApiKeys(data.apiKeys);
+        } catch {
+            toast.error("Failed to load API keys");
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        refreshApiKeys();
+    }, [refreshApiKeys]);
+
+    const handleCreate = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setIsCreating(true);
+
+        try {
+            const response = await fetch("/api/settings/api-keys", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name,
+                    expiresAt: expiresAt
+                        ? new Date(expiresAt).toISOString()
+                        : null,
+                    scopes: ["read"],
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(
+                    await getApiErrorMessage(
+                        response,
+                        "Failed to create API key",
+                    ),
+                );
+            }
+            const data = (await response.json()) as {
+                key?: string;
+                apiKey?: ApiKey;
+                error?: string;
+            };
+            if (!data.key || !data.apiKey) {
+                throw new Error(data.error || "Failed to create API key");
+            }
+
+            setApiKeys((current) => [data.apiKey as ApiKey, ...current]);
+            setCreatedKey(data.key);
+            setName("");
+            setExpiresAt("");
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to create API key",
+            );
+        } finally {
+            setIsCreating(false);
+        }
+    };
+
+    const handleRevoke = async (apiKeyId: string) => {
+        try {
+            const response = await fetch(`/api/settings/api-keys/${apiKeyId}`, {
+                method: "DELETE",
+            });
+            if (!response.ok) {
+                throw new Error(
+                    await getApiErrorMessage(
+                        response,
+                        "Failed to revoke API key",
+                    ),
+                );
+            }
+            toast.success("API key revoked");
+            await refreshApiKeys();
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to revoke API key",
+            );
+        }
+    };
+
+    const copyCreatedKey = async () => {
+        if (!createdKey) return;
+        await navigator.clipboard.writeText(createdKey);
+        toast.success("API key copied");
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold flex items-center gap-2">
+                    <KeyRound className="w-5 h-5" />
+                    API Keys
+                </h2>
+                <Button
+                    size="sm"
+                    onClick={() => {
+                        setCreatedKey(null);
+                        setIsCreateOpen(true);
+                    }}
+                >
+                    <Plus className="w-4 h-4" />
+                    Create Key
+                </Button>
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                    <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                </div>
+            ) : apiKeys.length === 0 ? (
+                <div className="text-center py-12 border rounded-lg">
+                    <KeyRound className="w-12 h-12 mx-auto mb-3 text-muted-foreground" />
+                    <h3 className="font-semibold mb-2">No API keys</h3>
+                    <Button size="sm" onClick={() => setIsCreateOpen(true)}>
+                        <Plus className="w-4 h-4" />
+                        Create Key
+                    </Button>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {apiKeys.map((apiKey) => (
+                        <div
+                            key={apiKey.id}
+                            className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div className="min-w-0 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <h3 className="font-medium">
+                                        {apiKey.name}
+                                    </h3>
+                                    <span className="rounded border px-2 py-0.5 font-mono text-xs text-muted-foreground">
+                                        {apiKey.keyPrefix}
+                                    </span>
+                                    {apiKey.revokedAt && (
+                                        <span className="rounded border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-xs text-destructive">
+                                            Revoked
+                                        </span>
+                                    )}
+                                </div>
+                                <div className="grid gap-1 text-xs text-muted-foreground sm:grid-cols-3">
+                                    <span>
+                                        Last used:{" "}
+                                        {formatDate(apiKey.lastUsedAt)}
+                                    </span>
+                                    <span>
+                                        Expires: {formatDate(apiKey.expiresAt)}
+                                    </span>
+                                    <span>
+                                        Created: {formatDate(apiKey.createdAt)}
+                                    </span>
+                                </div>
+                            </div>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => handleRevoke(apiKey.id)}
+                                disabled={Boolean(apiKey.revokedAt)}
+                                aria-label={`Revoke ${apiKey.name}`}
+                            >
+                                <Trash2 className="w-4 h-4 text-destructive" />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+                <DialogContent className="max-w-md">
+                    <DialogTitle>Create API Key</DialogTitle>
+                    {createdKey ? (
+                        <div className="space-y-4">
+                            <DialogDescription>
+                                This key is shown once.
+                            </DialogDescription>
+                            <div className="rounded-md border bg-muted p-3 font-mono text-sm break-all">
+                                {createdKey}
+                            </div>
+                            <div className="flex gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="flex-1"
+                                    onClick={copyCreatedKey}
+                                >
+                                    <Clipboard className="w-4 h-4" />
+                                    Copy
+                                </Button>
+                                <Button
+                                    type="button"
+                                    className="flex-1"
+                                    onClick={() => {
+                                        setCreatedKey(null);
+                                        setIsCreateOpen(false);
+                                    }}
+                                >
+                                    <Check className="w-4 h-4" />
+                                    Saved
+                                </Button>
+                            </div>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleCreate} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="api-key-name">Name</Label>
+                                <Input
+                                    id="api-key-name"
+                                    value={name}
+                                    onChange={(event) =>
+                                        setName(event.target.value)
+                                    }
+                                    placeholder="Hermes Agent"
+                                    disabled={isCreating}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="api-key-expires">
+                                    Expiration
+                                </Label>
+                                <Input
+                                    id="api-key-expires"
+                                    type="datetime-local"
+                                    value={expiresAt}
+                                    onChange={(event) =>
+                                        setExpiresAt(event.target.value)
+                                    }
+                                    disabled={isCreating}
+                                />
+                            </div>
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => setIsCreateOpen(false)}
+                                    disabled={isCreating}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    disabled={!name.trim() || isCreating}
+                                >
+                                    Create
+                                </Button>
+                            </div>
+                        </form>
+                    )}
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -304,6 +304,11 @@ export function WebhooksSection() {
                                         variant="outline"
                                         size="sm"
                                         onClick={() => {
+                                            // Clear stale deliveries from a
+                                            // previously opened webhook so
+                                            // the dialog never flashes the
+                                            // wrong endpoint's history.
+                                            setDeliveries([]);
                                             setDeliveryWebhook(webhook);
                                             refreshDeliveries(webhook.id);
                                         }}

--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -1,0 +1,540 @@
+"use client";
+
+import {
+    Check,
+    Clipboard,
+    Pencil,
+    Plus,
+    RotateCcw,
+    Trash2,
+    Webhook,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+type WebhookEndpoint = {
+    id: string;
+    url: string;
+    secret: string;
+    events: string[];
+    description: string | null;
+    enabled: boolean;
+    lastDeliveryAt: string | null;
+    lastDeliveryStatus: string | null;
+    createdAt: string;
+};
+
+type WebhookDelivery = {
+    id: string;
+    event: string;
+    status: string;
+    attempts: number;
+    lastAttemptAt: string | null;
+    nextAttemptAt: string;
+    lastResponseStatus: number | null;
+    lastError: string | null;
+    createdAt: string;
+};
+
+const DEFAULT_EVENTS = [
+    "recording.synced",
+    "recording.updated",
+    "recording.deleted",
+    "transcription.completed",
+    "transcription.failed",
+];
+
+function formatDate(value: string | null): string {
+    if (!value) return "Never";
+    return new Date(value).toLocaleString();
+}
+
+function emptyForm(events = DEFAULT_EVENTS) {
+    return {
+        url: "",
+        description: "",
+        enabled: true,
+        events: [events[0]],
+    };
+}
+
+export function WebhooksSection() {
+    const [webhooks, setWebhooks] = useState<WebhookEndpoint[]>([]);
+    const [events, setEvents] = useState<string[]>(DEFAULT_EVENTS);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [isEditorOpen, setIsEditorOpen] = useState(false);
+    const [editingWebhook, setEditingWebhook] =
+        useState<WebhookEndpoint | null>(null);
+    const [form, setForm] = useState(emptyForm());
+    const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+    const [deliveryWebhook, setDeliveryWebhook] =
+        useState<WebhookEndpoint | null>(null);
+    const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+
+    const refreshWebhooks = useCallback(async () => {
+        try {
+            const response = await fetch("/api/settings/webhooks");
+            if (!response.ok) throw new Error("Failed to fetch webhooks");
+            const data = (await response.json()) as {
+                webhooks: WebhookEndpoint[];
+                events: string[];
+            };
+            setWebhooks(data.webhooks);
+            setEvents(data.events);
+        } catch {
+            toast.error("Failed to load webhooks");
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        refreshWebhooks();
+    }, [refreshWebhooks]);
+
+    const refreshDeliveries = async (webhookId: string) => {
+        try {
+            const response = await fetch(
+                `/api/settings/webhooks/${webhookId}/deliveries`,
+            );
+            if (!response.ok) throw new Error("Failed to fetch deliveries");
+            const data = (await response.json()) as {
+                deliveries: WebhookDelivery[];
+            };
+            setDeliveries(data.deliveries);
+        } catch {
+            toast.error("Failed to load deliveries");
+        }
+    };
+
+    const openEditor = (webhook: WebhookEndpoint | null) => {
+        setCreatedSecret(null);
+        setEditingWebhook(webhook);
+        setForm(
+            webhook
+                ? {
+                      url: webhook.url,
+                      description: webhook.description || "",
+                      enabled: webhook.enabled,
+                      events: webhook.events,
+                  }
+                : emptyForm(events),
+        );
+        setIsEditorOpen(true);
+    };
+
+    const toggleEvent = (event: string) => {
+        setForm((current) => {
+            const hasEvent = current.events.includes(event);
+            const nextEvents = hasEvent
+                ? current.events.filter((item) => item !== event)
+                : [...current.events, event];
+            return { ...current, events: nextEvents };
+        });
+    };
+
+    const handleSubmit = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setIsSaving(true);
+
+        try {
+            const response = await fetch(
+                editingWebhook
+                    ? `/api/settings/webhooks/${editingWebhook.id}`
+                    : "/api/settings/webhooks",
+                {
+                    method: editingWebhook ? "PATCH" : "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(form),
+                },
+            );
+
+            const data = (await response.json()) as {
+                webhook?: WebhookEndpoint;
+                secret?: string;
+                error?: string;
+            };
+            if (!response.ok || !data.webhook) {
+                throw new Error(data.error || "Failed to save webhook");
+            }
+
+            await refreshWebhooks();
+            if (data.secret) {
+                setCreatedSecret(data.secret);
+            } else {
+                setIsEditorOpen(false);
+            }
+            toast.success(editingWebhook ? "Webhook updated" : "Webhook added");
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to save webhook",
+            );
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleDelete = async (webhookId: string) => {
+        if (!confirm("Delete this webhook?")) return;
+        try {
+            const response = await fetch(
+                `/api/settings/webhooks/${webhookId}`,
+                {
+                    method: "DELETE",
+                },
+            );
+            if (!response.ok) throw new Error("Failed to delete webhook");
+            toast.success("Webhook deleted");
+            await refreshWebhooks();
+        } catch {
+            toast.error("Failed to delete webhook");
+        }
+    };
+
+    const copySecret = async () => {
+        if (!createdSecret) return;
+        await navigator.clipboard.writeText(createdSecret);
+        toast.success("Secret copied");
+    };
+
+    const redeliver = async (deliveryId: string) => {
+        if (!deliveryWebhook) return;
+        try {
+            const response = await fetch(
+                `/api/settings/webhooks/${deliveryWebhook.id}/deliveries/${deliveryId}/redeliver`,
+                { method: "POST" },
+            );
+            if (!response.ok) throw new Error("Failed to redeliver");
+            toast.success("Delivery queued");
+            await refreshDeliveries(deliveryWebhook.id);
+        } catch {
+            toast.error("Failed to queue delivery");
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold flex items-center gap-2">
+                    <Webhook className="w-5 h-5" />
+                    Webhooks
+                </h2>
+                <Button size="sm" onClick={() => openEditor(null)}>
+                    <Plus className="w-4 h-4" />
+                    Add Webhook
+                </Button>
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                    <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                </div>
+            ) : webhooks.length === 0 ? (
+                <div className="text-center py-12 border rounded-lg">
+                    <Webhook className="w-12 h-12 mx-auto mb-3 text-muted-foreground" />
+                    <h3 className="font-semibold mb-2">No webhooks</h3>
+                    <Button size="sm" onClick={() => openEditor(null)}>
+                        <Plus className="w-4 h-4" />
+                        Add Webhook
+                    </Button>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {webhooks.map((webhook) => (
+                        <div
+                            key={webhook.id}
+                            className="space-y-3 rounded-lg border p-4"
+                        >
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="min-w-0 space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <h3 className="truncate font-medium">
+                                            {webhook.description || webhook.url}
+                                        </h3>
+                                        <span
+                                            className={`rounded border px-2 py-0.5 text-xs ${
+                                                webhook.enabled
+                                                    ? "text-primary"
+                                                    : "text-muted-foreground"
+                                            }`}
+                                        >
+                                            {webhook.enabled
+                                                ? "Enabled"
+                                                : "Disabled"}
+                                        </span>
+                                        {webhook.lastDeliveryStatus && (
+                                            <span className="rounded border px-2 py-0.5 text-xs">
+                                                {webhook.lastDeliveryStatus}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="truncate font-mono text-xs text-muted-foreground">
+                                        {webhook.url}
+                                    </p>
+                                    <div className="flex flex-wrap gap-1">
+                                        {webhook.events.map((event) => (
+                                            <span
+                                                key={event}
+                                                className="rounded bg-muted px-2 py-0.5 text-xs"
+                                            >
+                                                {event}
+                                            </span>
+                                        ))}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Last delivery:{" "}
+                                        {formatDate(webhook.lastDeliveryAt)}
+                                    </p>
+                                </div>
+                                <div className="flex gap-2">
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => {
+                                            setDeliveryWebhook(webhook);
+                                            refreshDeliveries(webhook.id);
+                                        }}
+                                    >
+                                        Deliveries
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        size="icon"
+                                        onClick={() => openEditor(webhook)}
+                                        aria-label="Edit webhook"
+                                    >
+                                        <Pencil className="w-4 h-4" />
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        size="icon"
+                                        onClick={() => handleDelete(webhook.id)}
+                                        aria-label="Delete webhook"
+                                    >
+                                        <Trash2 className="w-4 h-4 text-destructive" />
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <Dialog open={isEditorOpen} onOpenChange={setIsEditorOpen}>
+                <DialogContent className="max-w-xl">
+                    <DialogTitle>
+                        {editingWebhook ? "Edit Webhook" : "Add Webhook"}
+                    </DialogTitle>
+                    {createdSecret ? (
+                        <div className="space-y-4">
+                            <DialogDescription>
+                                This signing secret is shown once.
+                            </DialogDescription>
+                            <div className="rounded-md border bg-muted p-3 font-mono text-sm break-all">
+                                {createdSecret}
+                            </div>
+                            <div className="flex gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="flex-1"
+                                    onClick={copySecret}
+                                >
+                                    <Clipboard className="w-4 h-4" />
+                                    Copy
+                                </Button>
+                                <Button
+                                    type="button"
+                                    className="flex-1"
+                                    onClick={() => {
+                                        setCreatedSecret(null);
+                                        setIsEditorOpen(false);
+                                    }}
+                                >
+                                    <Check className="w-4 h-4" />
+                                    Saved
+                                </Button>
+                            </div>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="webhook-url">URL</Label>
+                                <Input
+                                    id="webhook-url"
+                                    value={form.url}
+                                    onChange={(event) =>
+                                        setForm((current) => ({
+                                            ...current,
+                                            url: event.target.value,
+                                        }))
+                                    }
+                                    placeholder="https://example.com/webhook"
+                                    disabled={isSaving}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="webhook-description">
+                                    Description
+                                </Label>
+                                <Input
+                                    id="webhook-description"
+                                    value={form.description}
+                                    onChange={(event) =>
+                                        setForm((current) => ({
+                                            ...current,
+                                            description: event.target.value,
+                                        }))
+                                    }
+                                    placeholder="Automation receiver"
+                                    disabled={isSaving}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Events</Label>
+                                <div className="grid gap-2 sm:grid-cols-2">
+                                    {events.map((event) => (
+                                        <label
+                                            key={event}
+                                            className="flex items-center gap-2 rounded-md border p-2 text-sm"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={form.events.includes(
+                                                    event,
+                                                )}
+                                                onChange={() =>
+                                                    toggleEvent(event)
+                                                }
+                                                disabled={
+                                                    isSaving ||
+                                                    (form.events.length === 1 &&
+                                                        form.events.includes(
+                                                            event,
+                                                        ))
+                                                }
+                                            />
+                                            <span>{event}</span>
+                                        </label>
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="flex items-center justify-between rounded-md border p-3">
+                                <Label htmlFor="webhook-enabled">Enabled</Label>
+                                <Switch
+                                    id="webhook-enabled"
+                                    checked={form.enabled}
+                                    onCheckedChange={(checked) =>
+                                        setForm((current) => ({
+                                            ...current,
+                                            enabled: checked,
+                                        }))
+                                    }
+                                    disabled={isSaving}
+                                />
+                            </div>
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => setIsEditorOpen(false)}
+                                    disabled={isSaving}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    disabled={
+                                        isSaving ||
+                                        !form.url.trim() ||
+                                        form.events.length === 0
+                                    }
+                                >
+                                    Save
+                                </Button>
+                            </div>
+                        </form>
+                    )}
+                </DialogContent>
+            </Dialog>
+
+            <Dialog
+                open={Boolean(deliveryWebhook)}
+                onOpenChange={(open) => {
+                    if (!open) setDeliveryWebhook(null);
+                }}
+            >
+                <DialogContent className="max-w-3xl">
+                    <DialogTitle>Webhook Deliveries</DialogTitle>
+                    <div className="max-h-[420px] space-y-2 overflow-y-auto">
+                        {deliveries.length === 0 ? (
+                            <p className="py-8 text-center text-sm text-muted-foreground">
+                                No deliveries yet
+                            </p>
+                        ) : (
+                            deliveries.map((delivery) => (
+                                <div
+                                    key={delivery.id}
+                                    className="grid gap-2 rounded-lg border p-3 text-sm sm:grid-cols-[1fr_auto]"
+                                >
+                                    <div className="space-y-1">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <span className="font-medium">
+                                                {delivery.event}
+                                            </span>
+                                            <span className="rounded border px-2 py-0.5 text-xs">
+                                                {delivery.status}
+                                            </span>
+                                            {delivery.lastResponseStatus && (
+                                                <span className="rounded border px-2 py-0.5 text-xs">
+                                                    HTTP{" "}
+                                                    {
+                                                        delivery.lastResponseStatus
+                                                    }
+                                                </span>
+                                            )}
+                                        </div>
+                                        <p className="text-xs text-muted-foreground">
+                                            Attempts: {delivery.attempts} ·
+                                            Last:{" "}
+                                            {formatDate(delivery.lastAttemptAt)}
+                                        </p>
+                                        {delivery.lastError && (
+                                            <p className="text-xs text-destructive">
+                                                {delivery.lastError}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={
+                                            delivery.status === "processing"
+                                        }
+                                        onClick={() => redeliver(delivery.id)}
+                                    >
+                                        <RotateCcw className="w-4 h-4" />
+                                        Redeliver
+                                    </Button>
+                                </div>
+                            ))
+                        )}
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/src/db/migrations/0019_lucky_swordsman.sql
+++ b/src/db/migrations/0019_lucky_swordsman.sql
@@ -62,7 +62,6 @@ ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_user_id_user
 ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_recording_id_recordings_id_fk" FOREIGN KEY ("recording_id") REFERENCES "public"."recordings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "webhook_endpoints" ADD CONSTRAINT "webhook_endpoints_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "api_keys_user_id_idx" ON "api_keys" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "api_keys_key_hash_idx" ON "api_keys" USING btree ("key_hash");--> statement-breakpoint
 CREATE INDEX "api_rate_limit_buckets_reset_at_idx" ON "api_rate_limit_buckets" USING btree ("reset_at");--> statement-breakpoint
 CREATE INDEX "webhook_deliveries_pending_idx" ON "webhook_deliveries" USING btree ("status","next_attempt_at");--> statement-breakpoint
 CREATE INDEX "webhook_deliveries_endpoint_id_idx" ON "webhook_deliveries" USING btree ("endpoint_id");--> statement-breakpoint

--- a/src/db/migrations/0019_massive_spectrum.sql
+++ b/src/db/migrations/0019_massive_spectrum.sql
@@ -1,0 +1,71 @@
+CREATE TYPE "public"."api_key_source" AS ENUM('manual', 'device-flow');--> statement-breakpoint
+CREATE TABLE "api_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"key_hash" text NOT NULL,
+	"key_prefix" varchar(16) NOT NULL,
+	"source" "api_key_source" DEFAULT 'manual' NOT NULL,
+	"scopes" jsonb DEFAULT '["read"]'::jsonb NOT NULL,
+	"last_used_at" timestamp,
+	"expires_at" timestamp,
+	"revoked_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "api_keys_key_hash_unique" UNIQUE("key_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "api_rate_limit_buckets" (
+	"key" text PRIMARY KEY NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"reset_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "webhook_deliveries" (
+	"id" text PRIMARY KEY NOT NULL,
+	"endpoint_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"recording_id" text,
+	"event" varchar(64) NOT NULL,
+	"payload" jsonb NOT NULL,
+	"status" varchar(16) NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"last_attempt_at" timestamp,
+	"next_attempt_at" timestamp DEFAULT now() NOT NULL,
+	"last_response_status" integer,
+	"last_response_body" text,
+	"last_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "webhook_endpoints" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"url" text NOT NULL,
+	"secret" text NOT NULL,
+	"events" jsonb NOT NULL,
+	"description" text,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"last_delivery_at" timestamp,
+	"last_delivery_status" varchar(16),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "recordings" DROP CONSTRAINT "recordings_plaud_file_id_unique";--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk" FOREIGN KEY ("endpoint_id") REFERENCES "public"."webhook_endpoints"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_recording_id_recordings_id_fk" FOREIGN KEY ("recording_id") REFERENCES "public"."recordings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "webhook_endpoints" ADD CONSTRAINT "webhook_endpoints_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "api_keys_user_id_idx" ON "api_keys" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "api_keys_key_hash_idx" ON "api_keys" USING btree ("key_hash");--> statement-breakpoint
+CREATE INDEX "api_rate_limit_buckets_reset_at_idx" ON "api_rate_limit_buckets" USING btree ("reset_at");--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_pending_idx" ON "webhook_deliveries" USING btree ("status","next_attempt_at");--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_endpoint_id_idx" ON "webhook_deliveries" USING btree ("endpoint_id");--> statement-breakpoint
+CREATE INDEX "webhook_deliveries_recording_id_idx" ON "webhook_deliveries" USING btree ("recording_id");--> statement-breakpoint
+CREATE INDEX "webhook_endpoints_user_id_idx" ON "webhook_endpoints" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "recordings" ADD CONSTRAINT "recordings_user_id_plaud_file_id_unique" UNIQUE("user_id","plaud_file_id");

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2166 @@
+{
+  "id": "7635e8f7-3031-4549-9634-8be2f7358ee4",
+  "prevId": "01aaa935-3328-41d7-be4e-d3da9243014b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_action_log": {
+      "name": "admin_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_action_log_created_idx": {
+          "name": "admin_action_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_action_log_target_user_idx": {
+          "name": "admin_action_log_target_user_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_action_log_admin_user_id_users_id_fk": {
+          "name": "admin_action_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_action_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_created_idx": {
+          "name": "admin_audit_log_admin_created_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "api_key_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"read\"]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limit_buckets": {
+      "name": "api_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_buckets_reset_at_idx": {
+          "name": "api_rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_user_id_plaud_file_id_unique": {
+          "name": "recordings_user_id_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_id_idx": {
+          "name": "webhook_deliveries_endpoint_id_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recording_id_idx": {
+          "name": "webhook_deliveries_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_user_id_users_id_fk": {
+          "name": "webhook_deliveries_user_id_users_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_recording_id_recordings_id_fk": {
+          "name": "webhook_deliveries_recording_id_recordings_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_status": {
+          "name": "last_delivery_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_user_id_idx": {
+          "name": "webhook_endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_user_id_users_id_fk": {
+          "name": "webhook_endpoints_user_id_users_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_source": {
+      "name": "api_key_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "device-flow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "7635e8f7-3031-4549-9634-8be2f7358ee4",
+  "id": "209d88fb-7a8d-4d72-8d6a-4de05016f589",
   "prevId": "01aaa935-3328-41d7-be4e-d3da9243014b",
   "version": "7",
   "dialect": "postgresql",
@@ -620,21 +620,6 @@
           "columns": [
             {
               "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "api_keys_key_hash_idx": {
-          "name": "api_keys_key_hash_idx",
-          "columns": [
-            {
-              "expression": "key_hash",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778352807229,
       "tag": "0018_quick_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778405407164,
+      "tag": "0019_massive_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -138,8 +138,8 @@
     {
       "idx": 19,
       "version": "7",
-      "when": 1778405407164,
-      "tag": "0019_massive_spectrum",
+      "when": 1778428394706,
+      "tag": "0019_lucky_swordsman",
       "breakpoints": true
     }
   ]

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
     index,
     integer,
     jsonb,
+    pgEnum,
     pgTable,
     real,
     text,
@@ -209,10 +210,8 @@ export const recordings = pgTable(
             .notNull()
             .references(() => users.id, { onDelete: "cascade" }),
         deviceSn: varchar("device_sn", { length: 255 }).notNull(),
-        // Unique ID from Plaud API
-        plaudFileId: varchar("plaud_file_id", { length: 255 })
-            .notNull()
-            .unique(),
+        // Unique ID from Plaud API, scoped per OpenPlaud user.
+        plaudFileId: varchar("plaud_file_id", { length: 255 }).notNull(),
         filename: text("filename").notNull(),
         duration: integer("duration").notNull(), // milliseconds
         startTime: timestamp("start_time").notNull(),
@@ -251,6 +250,9 @@ export const recordings = pgTable(
             table.userId,
             table.startTime,
         ),
+        userPlaudFileUnique: unique(
+            "recordings_user_id_plaud_file_id_unique",
+        ).on(table.userId, table.plaudFileId),
     }),
 );
 
@@ -433,3 +435,118 @@ export const userSettings = pgTable("user_settings", {
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
+
+export const apiKeySourceEnum = pgEnum("api_key_source", [
+    "manual",
+    "device-flow",
+]);
+
+export const apiKeys = pgTable(
+    "api_keys",
+    {
+        id: text("id")
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: text("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        name: text("name").notNull(),
+        keyHash: text("key_hash").notNull().unique(),
+        keyPrefix: varchar("key_prefix", { length: 16 }).notNull(),
+        source: apiKeySourceEnum("source").notNull().default("manual"),
+        scopes: jsonb("scopes").$type<string[]>().notNull().default(["read"]),
+        lastUsedAt: timestamp("last_used_at"),
+        expiresAt: timestamp("expires_at"),
+        revokedAt: timestamp("revoked_at"),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        userIdIdx: index("api_keys_user_id_idx").on(table.userId),
+        keyHashIdx: index("api_keys_key_hash_idx").on(table.keyHash),
+    }),
+);
+
+export const webhookEndpoints = pgTable(
+    "webhook_endpoints",
+    {
+        id: text("id")
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: text("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        // Encrypted target URL. Receiver URLs can contain path/query secrets.
+        url: text("url").notNull(),
+        secret: text("secret").notNull(),
+        events: jsonb("events").$type<string[]>().notNull(),
+        description: text("description"),
+        enabled: boolean("enabled").notNull().default(true),
+        lastDeliveryAt: timestamp("last_delivery_at"),
+        lastDeliveryStatus: varchar("last_delivery_status", {
+            length: 16,
+        }),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        userIdIdx: index("webhook_endpoints_user_id_idx").on(table.userId),
+    }),
+);
+
+export const webhookDeliveries = pgTable(
+    "webhook_deliveries",
+    {
+        id: text("id")
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        endpointId: text("endpoint_id")
+            .notNull()
+            .references(() => webhookEndpoints.id, { onDelete: "cascade" }),
+        userId: text("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        recordingId: text("recording_id").references(() => recordings.id, {
+            onDelete: "cascade",
+        }),
+        event: varchar("event", { length: 64 }).notNull(),
+        payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+        status: varchar("status", { length: 16 }).notNull(),
+        attempts: integer("attempts").notNull().default(0),
+        lastAttemptAt: timestamp("last_attempt_at"),
+        nextAttemptAt: timestamp("next_attempt_at").notNull().defaultNow(),
+        lastResponseStatus: integer("last_response_status"),
+        lastResponseBody: text("last_response_body"),
+        lastError: text("last_error"),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        pendingScanIdx: index("webhook_deliveries_pending_idx").on(
+            table.status,
+            table.nextAttemptAt,
+        ),
+        endpointIdIdx: index("webhook_deliveries_endpoint_id_idx").on(
+            table.endpointId,
+        ),
+        recordingIdIdx: index("webhook_deliveries_recording_id_idx").on(
+            table.recordingId,
+        ),
+    }),
+);
+
+export const apiRateLimitBuckets = pgTable(
+    "api_rate_limit_buckets",
+    {
+        key: text("key").primaryKey(),
+        count: integer("count").notNull().default(0),
+        resetAt: timestamp("reset_at").notNull(),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        resetAtIdx: index("api_rate_limit_buckets_reset_at_idx").on(
+            table.resetAt,
+        ),
+    }),
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -463,7 +463,11 @@ export const apiKeys = pgTable(
     },
     (table) => ({
         userIdIdx: index("api_keys_user_id_idx").on(table.userId),
-        keyHashIdx: index("api_keys_key_hash_idx").on(table.keyHash),
+        // No explicit index on `key_hash`: the unique constraint above
+        // already creates an implicit btree index Postgres uses for the
+        // `where key_hash = ?` lookup in `authenticateRequest`. A second
+        // explicit index would just double the write cost on every issue
+        // / revoke.
     }),
 );
 

--- a/src/lib/admin/guard.ts
+++ b/src/lib/admin/guard.ts
@@ -4,6 +4,7 @@ import { db } from "@/db";
 import { adminAuditLog } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { env } from "@/lib/env";
+import { AppError, ErrorCode } from "@/lib/errors";
 import {
     ADMIN_ELEVATED_COOKIE,
     isWithinMutationTtl,
@@ -179,7 +180,9 @@ export async function requireAdminApi(
     opts: Omit<AssertOptions, "mutation">,
 ): Promise<AdminGuardOk> {
     const res = await evaluateAdminGate({ ...opts, mutation: false });
-    if (!res || res.mode !== "ok") notFound();
+    if (!res || res.mode !== "ok") {
+        throw new AppError(ErrorCode.NOT_FOUND, "Not found", 404);
+    }
     return res;
 }
 
@@ -190,7 +193,9 @@ export async function requireAdminMutation(
     opts: Omit<AssertOptions, "mutation">,
 ): Promise<AdminGuardOk> {
     const res = await evaluateAdminGate({ ...opts, mutation: true });
-    if (!res || res.mode !== "ok") notFound();
+    if (!res || res.mode !== "ok") {
+        throw new AppError(ErrorCode.NOT_FOUND, "Not found", 404);
+    }
     return res;
 }
 

--- a/src/lib/auth-request.ts
+++ b/src/lib/auth-request.ts
@@ -1,0 +1,134 @@
+import { createHmac } from "node:crypto";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "@/db";
+import { apiKeys, users } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { env } from "@/lib/env";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+export type AuthenticatedRequest = {
+    user: { id: string };
+    via: "session" | "api-key";
+    apiKeyId?: string;
+};
+
+export type ApiKeyRow = typeof apiKeys.$inferSelect;
+
+const API_KEY_PREFIX = "op_";
+const API_KEY_RANDOM_LENGTH = 24;
+const DISPLAY_PREFIX_LENGTH = 12;
+
+export function createApiKey(): string {
+    return `${API_KEY_PREFIX}${nanoid(API_KEY_RANDOM_LENGTH)}`;
+}
+
+export function hashApiKey(apiKey: string): string {
+    const key = env.API_TOKEN_HASH_SECRET ?? env.BETTER_AUTH_SECRET;
+    if (!key) {
+        throw new Error("API key hash secret is not configured");
+    }
+    return createHmac("sha256", key).update(apiKey).digest("hex");
+}
+
+export function getApiKeyPrefix(apiKey: string): string {
+    return apiKey.slice(0, DISPLAY_PREFIX_LENGTH);
+}
+
+export function isApiKeyActive(
+    apiKey: Pick<ApiKeyRow, "expiresAt" | "revokedAt">,
+    now = new Date(),
+): boolean {
+    if (apiKey.revokedAt) return false;
+    if (apiKey.expiresAt && apiKey.expiresAt <= now) return false;
+    return true;
+}
+
+export function normalizeApiKeyScopes(scopes: unknown): string[] {
+    if (!Array.isArray(scopes)) return ["read"];
+    const normalized = scopes.filter((scope): scope is string => {
+        return scope === "read";
+    });
+    return normalized.length > 0 ? normalized : ["read"];
+}
+
+function getBearerToken(request: Request): string | null {
+    const authorization = request.headers.get("authorization");
+    if (!authorization) return null;
+
+    const match = authorization.match(/^Bearer\s+(.+)$/i);
+    return match?.[1]?.trim() || null;
+}
+
+async function assertUserNotSuspended(userId: string): Promise<void> {
+    const [user] = await db
+        .select({ suspendedAt: users.suspendedAt })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1);
+
+    if (user?.suspendedAt) {
+        throw new AppError(
+            ErrorCode.ACCOUNT_SUSPENDED,
+            "Account suspended",
+            403,
+        );
+    }
+}
+
+export async function authenticateRequest(
+    request: Request,
+): Promise<AuthenticatedRequest | null> {
+    const bearerToken = getBearerToken(request);
+
+    if (bearerToken?.startsWith(API_KEY_PREFIX)) {
+        const keyHash = hashApiKey(bearerToken);
+        const now = new Date();
+
+        const [apiKey] = await db
+            .select()
+            .from(apiKeys)
+            .where(
+                and(
+                    eq(apiKeys.keyHash, keyHash),
+                    isNull(apiKeys.revokedAt),
+                    or(isNull(apiKeys.expiresAt), gt(apiKeys.expiresAt, now)),
+                ),
+            )
+            .limit(1);
+
+        if (!apiKey) return null;
+        await assertUserNotSuspended(apiKey.userId);
+
+        void db
+            .update(apiKeys)
+            .set({ lastUsedAt: now, updatedAt: now })
+            .where(
+                and(
+                    eq(apiKeys.id, apiKey.id),
+                    eq(apiKeys.userId, apiKey.userId),
+                ),
+            )
+            .catch((error) => {
+                console.error("Failed to update API key last_used_at:", error);
+            });
+
+        return {
+            user: { id: apiKey.userId },
+            via: "api-key",
+            apiKeyId: apiKey.id,
+        };
+    }
+
+    const session = await auth.api.getSession({
+        headers: request.headers,
+    });
+
+    if (!session?.user) return null;
+    await assertUserNotSuspended(session.user.id);
+
+    return {
+        user: { id: session.user.id },
+        via: "session",
+    };
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,5 +1,20 @@
 import { z } from "zod";
 
+const optionalStrictBoolean = z
+    .string()
+    .optional()
+    .transform((val, ctx) => {
+        if (val === undefined || val === "") return undefined;
+        if (val === "true") return true;
+        if (val === "false") return false;
+
+        ctx.addIssue({
+            code: "custom",
+            message: 'must be either "true" or "false"',
+        });
+        return z.NEVER;
+    });
+
 export const envSchema = z.object({
     // Deployment mode. `true` means this instance is the OpenPlaud-operated
     // hosted product (marketing landing visible at `/`). Default `false`:
@@ -26,7 +41,22 @@ export const envSchema = z.object({
     DATABASE_URL: z.string().optional(),
 
     BETTER_AUTH_SECRET: z.string().optional(),
+    API_TOKEN_HASH_SECRET: z
+        .string()
+        .optional()
+        .transform((val) => (val === "" ? undefined : val))
+        .refine((val) => val === undefined || val.length >= 32, {
+            message: "API_TOKEN_HASH_SECRET must be at least 32 characters",
+        }),
     APP_URL: z.string().url("APP_URL must be a valid URL").optional(),
+
+    // Webhook target hardening. Unset means default to IS_HOSTED; explicit
+    // false keeps self-host integrations like Docker service hostnames working.
+    WEBHOOKS_REQUIRE_PUBLIC_TARGETS: optionalStrictBoolean,
+
+    // Only enable when a trusted reverse proxy strips or overwrites incoming
+    // client-supplied forwarding headers before requests reach Next.js.
+    RATE_LIMIT_TRUST_PROXY_HEADERS: optionalStrictBoolean,
 
     // Encryption
     // Optional at env-schema level so that builds don't fail if it's missing;
@@ -148,7 +178,12 @@ function validateEnv(): Env {
             DISABLE_REGISTRATION: process.env.DISABLE_REGISTRATION,
             DATABASE_URL: process.env.DATABASE_URL,
             BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+            API_TOKEN_HASH_SECRET: process.env.API_TOKEN_HASH_SECRET,
             APP_URL: process.env.APP_URL,
+            WEBHOOKS_REQUIRE_PUBLIC_TARGETS:
+                process.env.WEBHOOKS_REQUIRE_PUBLIC_TARGETS,
+            RATE_LIMIT_TRUST_PROXY_HEADERS:
+                process.env.RATE_LIMIT_TRUST_PROXY_HEADERS,
             ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
             DEFAULT_STORAGE_TYPE: process.env.DEFAULT_STORAGE_TYPE,
             LOCAL_STORAGE_PATH: process.env.LOCAL_STORAGE_PATH,
@@ -199,6 +234,15 @@ function validateEnv(): Env {
             if (!parsed.APP_URL) {
                 throw new Error(
                     "APP_URL must be set in non-build runtime (dev/prod server)",
+                );
+            }
+
+            if (
+                parsed.IS_HOSTED &&
+                parsed.RATE_LIMIT_TRUST_PROXY_HEADERS !== true
+            ) {
+                throw new Error(
+                    "RATE_LIMIT_TRUST_PROXY_HEADERS=true must be set when IS_HOSTED=true so /api/v1/* rate limits use a per-client IP bucket",
                 );
             }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,91 @@
+import { createHmac } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+import { apiRateLimitBuckets } from "@/db/schema";
+import { env } from "@/lib/env";
+
+export type RateLimitResult = {
+    allowed: boolean;
+    limit: number;
+    remaining: number;
+    resetAt: Date;
+};
+
+type RateLimitConfig = {
+    limit: number;
+    windowMs: number;
+    now?: Date;
+};
+
+function rateLimitSecret(): string {
+    const secret = env.API_TOKEN_HASH_SECRET ?? env.BETTER_AUTH_SECRET;
+    if (!secret) {
+        throw new Error("Rate limit secret is not configured");
+    }
+    return secret;
+}
+
+function bucketKey(rawKey: string): string {
+    return createHmac("sha256", rateLimitSecret()).update(rawKey).digest("hex");
+}
+
+function firstForwardedForIp(value: string | null): string | null {
+    const parts = value
+        ?.split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+    return parts?.[0] ?? null;
+}
+
+export function getClientIp(request: Request): string {
+    if (!env.RATE_LIMIT_TRUST_PROXY_HEADERS) {
+        return "unknown";
+    }
+
+    const cloudflareIp = request.headers.get("cf-connecting-ip")?.trim();
+    if (cloudflareIp) return cloudflareIp;
+
+    const realIp = request.headers.get("x-real-ip")?.trim();
+    if (realIp) return realIp;
+
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    return firstForwardedForIp(forwardedFor) ?? "unknown";
+}
+
+export async function consumeRateLimitBucket(
+    rawKey: string,
+    { limit, windowMs, now = new Date() }: RateLimitConfig,
+): Promise<RateLimitResult> {
+    const resetAt = new Date(now.getTime() + windowMs);
+    const [bucket] = await db
+        .insert(apiRateLimitBuckets)
+        .values({
+            key: bucketKey(rawKey),
+            count: 1,
+            resetAt,
+            createdAt: now,
+            updatedAt: now,
+        })
+        .onConflictDoUpdate({
+            target: apiRateLimitBuckets.key,
+            set: {
+                count: sql<number>`case when ${apiRateLimitBuckets.resetAt} <= ${now} then 1 else ${apiRateLimitBuckets.count} + 1 end`,
+                resetAt: sql<Date>`case when ${apiRateLimitBuckets.resetAt} <= ${now} then ${resetAt} else ${apiRateLimitBuckets.resetAt} end`,
+                updatedAt: now,
+            },
+        })
+        .returning({
+            count: apiRateLimitBuckets.count,
+            resetAt: apiRateLimitBuckets.resetAt,
+        });
+
+    const count = bucket?.count ?? limit + 1;
+    const bucketResetAt = bucket?.resetAt ?? resetAt;
+
+    return {
+        allowed: count <= limit,
+        limit,
+        remaining: Math.max(limit - count, 0),
+        resetAt: bucketResetAt,
+    };
+}

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -193,6 +193,19 @@ async function processRecording(
             });
 
             if (!updated) {
+                // Concurrent DELETE tombstoned the recording while we
+                // were downloading/uploading. The just-uploaded blob
+                // would otherwise be orphaned because we're no longer
+                // writing the recordings row that references it. Best
+                // effort cleanup; storage "already gone" is acceptable.
+                try {
+                    await storage.deleteFile(storageKey);
+                } catch (cleanupError) {
+                    console.error(
+                        `Failed to clean up orphaned storage object ${storageKey} after concurrent delete:`,
+                        cleanupError,
+                    );
+                }
                 return { status: "skipped" };
             }
 

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -8,6 +8,7 @@ import { sendNewRecordingEmail } from "@/lib/notifications/email";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+import { emitEvent } from "@/lib/webhooks/emit";
 import type { PlaudRecording } from "@/types/plaud";
 
 /**
@@ -60,6 +61,7 @@ async function uniqueStorageKey(
             .from(recordings)
             .where(
                 and(
+                    eq(recordings.userId, userId),
                     eq(recordings.storagePath, key),
                     ne(recordings.plaudFileId, plaudFileId),
                 ),
@@ -89,7 +91,12 @@ async function processRecording(
         const [existingRecording] = await db
             .select()
             .from(recordings)
-            .where(eq(recordings.plaudFileId, plaudRecording.id))
+            .where(
+                and(
+                    eq(recordings.plaudFileId, plaudRecording.id),
+                    eq(recordings.userId, context.userId),
+                ),
+            )
             .limit(1);
 
         const versionKey = plaudRecording.version_ms.toString();
@@ -157,7 +164,17 @@ async function processRecording(
             await db
                 .update(recordings)
                 .set({ ...recordingData, updatedAt: new Date() })
-                .where(eq(recordings.id, existingRecording.id));
+                .where(
+                    and(
+                        eq(recordings.id, existingRecording.id),
+                        eq(recordings.userId, context.userId),
+                    ),
+                );
+            await emitEvent(
+                "recording.updated",
+                context.userId,
+                existingRecording.id,
+            );
             return {
                 status: "updated",
                 recordingId: existingRecording.id,
@@ -170,6 +187,8 @@ async function processRecording(
             .insert(recordings)
             .values(recordingData)
             .returning({ id: recordings.id });
+
+        await emitEvent("recording.synced", context.userId, newRecording.id);
 
         return {
             status: "new",

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -160,16 +160,42 @@ async function processRecording(
         };
 
         if (existingRecording) {
-            // Update existing recording
-            await db
-                .update(recordings)
-                .set({ ...recordingData, updatedAt: new Date() })
-                .where(
-                    and(
-                        eq(recordings.id, existingRecording.id),
-                        eq(recordings.userId, context.userId),
-                    ),
-                );
+            // The pre-download `select` happened before the slow
+            // download/upload above. A concurrent DELETE could have
+            // tombstoned the row in the meantime. Re-check under a row
+            // lock so we don't resurrect a deleted recording, and only
+            // emit `recording.updated` when we actually wrote.
+            const updated = await db.transaction(async (tx) => {
+                const [locked] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, existingRecording.id),
+                            eq(recordings.userId, context.userId),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
+
+                if (!locked || locked.deletedAt) return false;
+
+                await tx
+                    .update(recordings)
+                    .set({ ...recordingData, updatedAt: new Date() })
+                    .where(
+                        and(
+                            eq(recordings.id, existingRecording.id),
+                            eq(recordings.userId, context.userId),
+                        ),
+                    );
+                return true;
+            });
+
+            if (!updated) {
+                return { status: "skipped" };
+            }
+
             await emitEvent(
                 "recording.updated",
                 context.userId,
@@ -182,7 +208,9 @@ async function processRecording(
             };
         }
 
-        // Insert new recording
+        // Insert new recording. Concurrent inserts of the same plaud_file_id
+        // by parallel sync runs are caught by the (user_id, plaud_file_id)
+        // unique constraint and surface as an error to the caller.
         const [newRecording] = await db
             .insert(recordings)
             .values(recordingData)

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -17,6 +17,7 @@ import {
     getResponseFormat,
     parseTranscriptionResponse,
 } from "@/lib/transcription/format";
+import { emitEvent } from "@/lib/webhooks/emit";
 
 export async function transcribeRecording(
     userId: string,
@@ -47,7 +48,12 @@ export async function transcribeRecording(
         const [existingTranscription] = await db
             .select()
             .from(transcriptions)
-            .where(eq(transcriptions.recordingId, recordingId))
+            .where(
+                and(
+                    eq(transcriptions.recordingId, recordingId),
+                    eq(transcriptions.userId, userId),
+                ),
+            )
             .limit(1);
 
         if (existingTranscription?.text) {
@@ -120,50 +126,86 @@ export async function transcribeRecording(
         const { text: transcriptionText, detectedLanguage } =
             parseTranscriptionResponse(transcription, responseFormat);
 
-        // Re-check tombstone after the provider call. The user may have
-        // deleted the recording while we were waiting on the transcription
-        // API; abort before writing so we don't recreate child rows the
-        // DELETE handler has already cleaned up.
-        const [stillActive] = await db
-            .select({ deletedAt: recordings.deletedAt })
-            .from(recordings)
-            .where(
-                and(
-                    eq(recordings.id, recordingId),
-                    eq(recordings.userId, userId),
-                ),
-            )
-            .limit(1);
-        if (!stillActive || stillActive.deletedAt) {
-            return {
-                success: false,
-                error: "Recording was deleted before transcription finished",
-            };
-        }
+        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
+        try {
+            await db.transaction(async (tx) => {
+                const [stillActive] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, recordingId),
+                            eq(recordings.userId, userId),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
 
-        // Encrypt the transcript before persisting.
-        const encryptedTranscriptionText = encryptText(transcriptionText);
-        if (existingTranscription) {
-            await db
-                .update(transcriptions)
-                .set({
-                    text: encryptedTranscriptionText,
-                    detectedLanguage,
-                    transcriptionType: "server",
-                    provider: credentials.provider,
-                    model: credentials.defaultModel || "whisper-1",
-                })
-                .where(eq(transcriptions.id, existingTranscription.id));
-        } else {
-            await db.insert(transcriptions).values({
-                recordingId,
-                userId,
-                text: encryptedTranscriptionText,
-                detectedLanguage,
-                transcriptionType: "server",
-                provider: credentials.provider,
-                model: credentials.defaultModel || "whisper-1",
+                if (!stillActive || stillActive.deletedAt) {
+                    throw RECORDING_TOMBSTONED;
+                }
+
+                const [currentTranscription] = await tx
+                    .select()
+                    .from(transcriptions)
+                    .where(
+                        and(
+                            eq(transcriptions.recordingId, recordingId),
+                            eq(transcriptions.userId, userId),
+                        ),
+                    )
+                    .limit(1);
+
+                const encryptedTranscriptionText =
+                    encryptText(transcriptionText);
+
+                if (currentTranscription) {
+                    await tx
+                        .update(transcriptions)
+                        .set({
+                            text: encryptedTranscriptionText,
+                            detectedLanguage,
+                            transcriptionType: "server",
+                            provider: credentials.provider,
+                            model: credentials.defaultModel || "whisper-1",
+                        })
+                        .where(
+                            and(
+                                eq(transcriptions.id, currentTranscription.id),
+                                eq(transcriptions.userId, userId),
+                            ),
+                        );
+                } else {
+                    await tx.insert(transcriptions).values({
+                        recordingId,
+                        userId,
+                        text: encryptedTranscriptionText,
+                        detectedLanguage,
+                        transcriptionType: "server",
+                        provider: credentials.provider,
+                        model: credentials.defaultModel || "whisper-1",
+                    });
+                }
+
+                await tx
+                    .update(recordings)
+                    .set({ updatedAt: new Date() })
+                    .where(
+                        and(
+                            eq(recordings.id, recordingId),
+                            eq(recordings.userId, userId),
+                            isNull(recordings.deletedAt),
+                        ),
+                    );
             });
+        } catch (txError) {
+            if (txError === RECORDING_TOMBSTONED) {
+                return {
+                    success: false,
+                    error: "Recording was deleted before transcription finished",
+                };
+            }
+            throw txError;
         }
 
         if (autoGenerateTitle && transcriptionText.trim()) {
@@ -183,7 +225,13 @@ export async function transcribeRecording(
                             filename: encryptText(generatedTitle),
                             updatedAt: new Date(),
                         })
-                        .where(eq(recordings.id, recordingId));
+                        .where(
+                            and(
+                                eq(recordings.id, recordingId),
+                                eq(recordings.userId, userId),
+                                isNull(recordings.deletedAt),
+                            ),
+                        );
 
                     if (syncTitleToPlaud) {
                         try {
@@ -241,9 +289,14 @@ export async function transcribeRecording(
             }
         }
 
+        await emitEvent("transcription.completed", userId, recordingId);
+
         return { success: true };
     } catch (error) {
         console.error("Error transcribing recording:", error);
+        await emitEvent("transcription.failed", userId, recordingId, {
+            error: error instanceof Error ? error.message : String(error),
+        });
         return {
             success: false,
             error:

--- a/src/lib/v1/rate-limit.ts
+++ b/src/lib/v1/rate-limit.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import type { AuthenticatedRequest } from "@/lib/auth-request";
+import { ErrorCode } from "@/lib/errors";
+import {
+    consumeRateLimitBucket,
+    getClientIp,
+    type RateLimitResult,
+} from "@/lib/rate-limit";
+
+const WINDOW_MS = 60_000;
+const IP_LIMIT = 1_200;
+const AUTHENTICATED_LIMIT = 600;
+
+export { getClientIp };
+
+function rateLimitResponse(result: RateLimitResult): NextResponse {
+    const retryAfter = Math.max(
+        1,
+        Math.ceil((result.resetAt.getTime() - Date.now()) / 1000),
+    );
+    const resetAt = Math.ceil(result.resetAt.getTime() / 1000);
+
+    return NextResponse.json(
+        {
+            error: "Rate limit exceeded",
+            code: ErrorCode.RATE_LIMITED,
+            details: {
+                retryAfter,
+                limit: result.limit,
+                remaining: result.remaining,
+                resetAt,
+            },
+        },
+        {
+            status: 429,
+            headers: {
+                "Retry-After": retryAfter.toString(),
+                "X-RateLimit-Limit": result.limit.toString(),
+                "X-RateLimit-Remaining": result.remaining.toString(),
+                "X-RateLimit-Reset": resetAt.toString(),
+            },
+        },
+    );
+}
+
+export async function enforceV1IpRateLimit(
+    request: Request,
+): Promise<NextResponse | null> {
+    const result = await consumeRateLimitBucket(
+        `v1:ip:${getClientIp(request)}`,
+        {
+            limit: IP_LIMIT,
+            windowMs: WINDOW_MS,
+        },
+    );
+    return result.allowed ? null : rateLimitResponse(result);
+}
+
+export async function enforceV1AuthenticatedRateLimit(
+    authn: AuthenticatedRequest,
+): Promise<NextResponse | null> {
+    const identity =
+        authn.via === "api-key" && authn.apiKeyId
+            ? `api-key:${authn.apiKeyId}`
+            : `user:${authn.user.id}`;
+    const result = await consumeRateLimitBucket(`v1:auth:${identity}`, {
+        limit: AUTHENTICATED_LIMIT,
+        windowMs: WINDOW_MS,
+    });
+    return result.allowed ? null : rateLimitResponse(result);
+}

--- a/src/lib/v1/serialize.ts
+++ b/src/lib/v1/serialize.ts
@@ -1,0 +1,237 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import {
+    aiEnhancements,
+    plaudDevices,
+    recordings,
+    transcriptions,
+} from "@/db/schema";
+import { decryptJsonField, decryptText } from "@/lib/encryption/fields";
+
+type RecordingRow = typeof recordings.$inferSelect;
+type DeviceRow = typeof plaudDevices.$inferSelect;
+type TranscriptionRow = typeof transcriptions.$inferSelect;
+type AiEnhancementRow = typeof aiEnhancements.$inferSelect;
+
+export type RecordingCursor = {
+    updatedAt: Date;
+    id: string;
+};
+
+export type V1Transcript = {
+    language: string | null;
+    text: string;
+    provider: string;
+    model: string;
+    created_at: string;
+};
+
+export type V1Summary = {
+    text: string | null;
+    action_items: string[] | null;
+    key_points: string[] | null;
+    provider: string;
+    model: string;
+    created_at: string;
+};
+
+export type V1Recording = {
+    id: string;
+    title: string;
+    created_at: string;
+    updated_at: string;
+    recorded_at: string;
+    duration_ms: number;
+    filesize_bytes: number;
+    device: {
+        serial_number: string;
+        name: string | null;
+        model: string | null;
+    } | null;
+    has_transcription: boolean;
+    has_summary: boolean;
+    links: {
+        self: string;
+        transcript: string;
+        audio: string;
+    };
+};
+
+export type V1RecordingDetail = V1Recording & {
+    transcript: V1Transcript | null;
+    summary: V1Summary | null;
+};
+
+function toIso(value: Date): string {
+    return value.toISOString();
+}
+
+function stringArrayOrNull(value: unknown): string[] | null {
+    if (!Array.isArray(value)) return null;
+    const strings = value.filter((item): item is string => {
+        return typeof item === "string";
+    });
+    return strings.length > 0 ? strings : [];
+}
+
+export function encodeRecordingCursor(cursor: RecordingCursor): string {
+    return Buffer.from(
+        JSON.stringify({
+            updatedAt: toIso(cursor.updatedAt),
+            id: cursor.id,
+        }),
+    ).toString("base64url");
+}
+
+export function decodeRecordingCursor(cursor: string): RecordingCursor | null {
+    try {
+        const raw = JSON.parse(
+            Buffer.from(cursor, "base64url").toString("utf8"),
+        ) as unknown;
+        if (!raw || typeof raw !== "object") return null;
+
+        const payload = raw as Record<string, unknown>;
+        if (
+            typeof payload.updatedAt !== "string" ||
+            typeof payload.id !== "string"
+        ) {
+            return null;
+        }
+
+        const updatedAt = new Date(payload.updatedAt);
+        if (Number.isNaN(updatedAt.getTime()) || !payload.id) return null;
+
+        return { updatedAt, id: payload.id };
+    } catch {
+        return null;
+    }
+}
+
+export function serializeTranscript(
+    transcription: TranscriptionRow | null,
+): V1Transcript | null {
+    if (!transcription) return null;
+
+    return {
+        language: transcription.detectedLanguage,
+        text: decryptText(transcription.text),
+        provider: transcription.provider,
+        model: transcription.model,
+        created_at: toIso(transcription.createdAt),
+    };
+}
+
+export function serializeSummary(
+    enhancement: AiEnhancementRow | null,
+): V1Summary | null {
+    if (!enhancement) return null;
+    const actionItems = decryptJsonField<unknown>(enhancement.actionItems);
+    const keyPoints = decryptJsonField<unknown>(enhancement.keyPoints);
+
+    return {
+        text: decryptText(enhancement.summary) ?? null,
+        action_items: stringArrayOrNull(actionItems),
+        key_points: stringArrayOrNull(keyPoints),
+        provider: enhancement.provider,
+        model: enhancement.model,
+        created_at: toIso(enhancement.createdAt),
+    };
+}
+
+export function serializeRecording(
+    recording: RecordingRow,
+    device: DeviceRow | null,
+    transcription: TranscriptionRow | null,
+    enhancement: AiEnhancementRow | null,
+): V1Recording {
+    const self = `/api/v1/recordings/${recording.id}`;
+
+    return {
+        id: recording.id,
+        title: decryptText(recording.filename),
+        created_at: toIso(recording.createdAt),
+        updated_at: toIso(recording.updatedAt),
+        recorded_at: toIso(recording.startTime),
+        duration_ms: recording.duration,
+        filesize_bytes: recording.filesize,
+        device: device
+            ? {
+                  serial_number: device.serialNumber,
+                  name: device.name,
+                  model: device.model,
+              }
+            : null,
+        has_transcription: Boolean(transcription),
+        has_summary: Boolean(enhancement),
+        links: {
+            self,
+            transcript: `${self}/transcript`,
+            audio: `${self}/audio`,
+        },
+    };
+}
+
+export function serializeRecordingDetail(
+    recording: RecordingRow,
+    device: DeviceRow | null,
+    transcription: TranscriptionRow | null,
+    enhancement: AiEnhancementRow | null,
+): V1RecordingDetail {
+    return {
+        ...serializeRecording(recording, device, transcription, enhancement),
+        transcript: serializeTranscript(transcription),
+        summary: serializeSummary(enhancement),
+    };
+}
+
+export async function getV1RecordingDetailForUser(
+    userId: string,
+    recordingId: string,
+): Promise<V1RecordingDetail | null> {
+    const [row] = await db
+        .select({
+            recording: recordings,
+            device: plaudDevices,
+            transcription: transcriptions,
+            enhancement: aiEnhancements,
+        })
+        .from(recordings)
+        .leftJoin(
+            plaudDevices,
+            and(
+                eq(plaudDevices.userId, userId),
+                eq(plaudDevices.serialNumber, recordings.deviceSn),
+            ),
+        )
+        .leftJoin(
+            transcriptions,
+            and(
+                eq(transcriptions.recordingId, recordings.id),
+                eq(transcriptions.userId, userId),
+            ),
+        )
+        .leftJoin(
+            aiEnhancements,
+            and(
+                eq(aiEnhancements.recordingId, recordings.id),
+                eq(aiEnhancements.userId, userId),
+            ),
+        )
+        .where(
+            and(
+                eq(recordings.id, recordingId),
+                eq(recordings.userId, userId),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!row) return null;
+
+    return serializeRecordingDetail(
+        row.recording,
+        row.device,
+        row.transcription,
+        row.enhancement,
+    );
+}

--- a/src/lib/webhooks/emit.ts
+++ b/src/lib/webhooks/emit.ts
@@ -1,0 +1,59 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
+import { createStoredWebhookPayload } from "@/lib/webhooks/payload";
+import { signalWebhookWorker } from "@/lib/webhooks/worker";
+
+export const WEBHOOK_EVENTS = [
+    "recording.synced",
+    "recording.updated",
+    "recording.deleted",
+    "transcription.completed",
+    "transcription.failed",
+] as const;
+
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+export function isWebhookEvent(value: string): value is WebhookEvent {
+    return WEBHOOK_EVENTS.includes(value as WebhookEvent);
+}
+
+export async function emitEvent(
+    event: WebhookEvent,
+    userId: string,
+    recordingId: string,
+    options: { error?: string } = {},
+): Promise<void> {
+    try {
+        const endpoints = await db
+            .select({ id: webhookEndpoints.id })
+            .from(webhookEndpoints)
+            .where(
+                and(
+                    eq(webhookEndpoints.userId, userId),
+                    eq(webhookEndpoints.enabled, true),
+                    sql`${webhookEndpoints.events} @> ${JSON.stringify([event])}::jsonb`,
+                ),
+            );
+
+        if (endpoints.length === 0) return;
+
+        const payload = createStoredWebhookPayload(event, recordingId, options);
+
+        await db.insert(webhookDeliveries).values(
+            endpoints.map((endpoint) => ({
+                endpointId: endpoint.id,
+                userId,
+                recordingId,
+                event,
+                payload,
+                status: "pending",
+                nextAttemptAt: new Date(),
+            })),
+        );
+
+        signalWebhookWorker();
+    } catch (error) {
+        console.error(`Failed to emit webhook event ${event}:`, error);
+    }
+}

--- a/src/lib/webhooks/payload.ts
+++ b/src/lib/webhooks/payload.ts
@@ -1,0 +1,106 @@
+export type StoredWebhookPayload = Record<string, unknown>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return null;
+    }
+    return value as Record<string, unknown>;
+}
+
+export function createStoredWebhookPayload(
+    event: string,
+    recordingId: string,
+    options: { deliveredAt?: Date; error?: string } = {},
+): StoredWebhookPayload {
+    const payload: StoredWebhookPayload = {
+        event,
+        delivered_at: (options.deliveredAt ?? new Date()).toISOString(),
+        recording_id: recordingId,
+    };
+
+    if (options.error) {
+        payload.error = { message: options.error };
+    }
+
+    return payload;
+}
+
+export function createRedactedWebhookPayload(
+    recordingId: string,
+    redactedAt = new Date(),
+): StoredWebhookPayload {
+    return {
+        recording_id: recordingId,
+        redacted: true,
+        redacted_at: redactedAt.toISOString(),
+    };
+}
+
+export function createUnavailableWebhookPayload(
+    recordingId: string | null,
+    reason: string,
+    redactedAt = new Date(),
+): StoredWebhookPayload {
+    return {
+        recording_id: recordingId,
+        redacted: true,
+        redacted_at: redactedAt.toISOString(),
+        error: { message: reason },
+    };
+}
+
+export function getWebhookPayloadRecordingId(payload: unknown): string | null {
+    const record = asRecord(payload);
+    if (!record) return null;
+
+    if (typeof record.recording_id === "string" && record.recording_id.trim()) {
+        return record.recording_id;
+    }
+
+    const data = asRecord(record.data);
+    if (typeof data?.id === "string" && data.id.trim()) {
+        return data.id;
+    }
+
+    return null;
+}
+
+export function getWebhookPayloadDeliveredAt(
+    payload: unknown,
+    fallback: Date,
+): Date {
+    const record = asRecord(payload);
+    if (typeof record?.delivered_at !== "string") return fallback;
+
+    const deliveredAt = new Date(record.delivered_at);
+    if (Number.isNaN(deliveredAt.getTime())) return fallback;
+    return deliveredAt;
+}
+
+export function getWebhookPayloadError(payload: unknown): string | null {
+    const record = asRecord(payload);
+    const error = asRecord(record?.error);
+    if (typeof error?.message !== "string" || !error.message.trim()) {
+        return null;
+    }
+    return error.message;
+}
+
+export function createOutboundWebhookPayload(
+    event: string,
+    deliveredAt: Date,
+    recording: unknown,
+    error: string | null,
+): StoredWebhookPayload {
+    const payload: StoredWebhookPayload = {
+        event,
+        delivered_at: deliveredAt.toISOString(),
+        data: recording,
+    };
+
+    if (error) {
+        payload.error = { message: error };
+    }
+
+    return payload;
+}

--- a/src/lib/webhooks/recording.ts
+++ b/src/lib/webhooks/recording.ts
@@ -1,0 +1,122 @@
+import { and, eq, isNotNull } from "drizzle-orm";
+import { db } from "@/db";
+import { plaudDevices, recordings } from "@/db/schema";
+import { env } from "@/lib/env";
+import {
+    getV1RecordingDetailForUser,
+    serializeRecordingDetail,
+    type V1RecordingDetail,
+    type V1Transcript,
+} from "@/lib/v1/serialize";
+
+const TRANSCRIPT_PREVIEW_CHARS = 500;
+
+type WebhookTranscript = Omit<V1Transcript, "text"> & {
+    preview: string;
+    truncated: boolean;
+    length: number;
+};
+
+type WebhookRecordingDetail = Omit<V1RecordingDetail, "transcript"> & {
+    api_url: string;
+    links: V1RecordingDetail["links"];
+    transcript: WebhookTranscript | null;
+    deleted_at?: string;
+};
+
+function absoluteApiUrl(path: string): string {
+    return new URL(path, env.APP_URL).toString();
+}
+
+function serializeWebhookTranscript(
+    transcript: V1Transcript | null,
+): WebhookTranscript | null {
+    if (!transcript) return null;
+    const text = transcript.text;
+
+    return {
+        preview: text.slice(0, TRANSCRIPT_PREVIEW_CHARS),
+        truncated: text.length > TRANSCRIPT_PREVIEW_CHARS,
+        length: text.length,
+        language: transcript.language,
+        provider: transcript.provider,
+        model: transcript.model,
+        created_at: transcript.created_at,
+    };
+}
+
+function serializeWebhookRecording(
+    recording: V1RecordingDetail,
+    deletedAt?: Date,
+): WebhookRecordingDetail {
+    const links = {
+        self: absoluteApiUrl(recording.links.self),
+        transcript: absoluteApiUrl(recording.links.transcript),
+        audio: absoluteApiUrl(recording.links.audio),
+    };
+
+    const payload: WebhookRecordingDetail = {
+        ...recording,
+        api_url: links.self,
+        links,
+        transcript: serializeWebhookTranscript(recording.transcript),
+    };
+
+    if (deletedAt) {
+        payload.deleted_at = deletedAt.toISOString();
+        payload.transcript = null;
+        payload.summary = null;
+    }
+
+    return payload;
+}
+
+// recording.deleted hydration depends on soft-delete tombstones.
+async function getDeletedWebhookRecordingDetailForUser(
+    userId: string,
+    recordingId: string,
+): Promise<WebhookRecordingDetail | null> {
+    const [row] = await db
+        .select({
+            recording: recordings,
+            device: plaudDevices,
+        })
+        .from(recordings)
+        .leftJoin(
+            plaudDevices,
+            and(
+                eq(plaudDevices.userId, userId),
+                eq(plaudDevices.serialNumber, recordings.deviceSn),
+            ),
+        )
+        .where(
+            and(
+                eq(recordings.id, recordingId),
+                eq(recordings.userId, userId),
+                isNotNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!row?.recording.deletedAt) return null;
+
+    return serializeWebhookRecording(
+        serializeRecordingDetail(row.recording, row.device, null, null),
+        row.recording.deletedAt,
+    );
+}
+
+export async function getWebhookRecordingDetailForUser(
+    userId: string,
+    recordingId: string,
+    event: string,
+): Promise<WebhookRecordingDetail | null> {
+    if (event === "recording.deleted") {
+        return getDeletedWebhookRecordingDetailForUser(userId, recordingId);
+    }
+
+    const recording = await getV1RecordingDetailForUser(userId, recordingId);
+    if (!recording) return null;
+
+    return serializeWebhookRecording(recording);
+}

--- a/src/lib/webhooks/secrets.ts
+++ b/src/lib/webhooks/secrets.ts
@@ -1,0 +1,25 @@
+import { decrypt, encrypt } from "@/lib/encryption";
+
+export function encryptWebhookSecret(secret: string): string {
+    return encrypt(secret);
+}
+
+export function decryptWebhookSecret(storedSecret: string): string {
+    return decrypt(storedSecret);
+}
+
+export function encryptWebhookUrl(url: string): string {
+    return encrypt(url);
+}
+
+export function decryptWebhookUrl(storedUrl: string): string {
+    return decrypt(storedUrl);
+}
+
+export function maskWebhookSecret(secret: string): string {
+    return `whsec_****${secret.slice(-4)}`;
+}
+
+export function maskStoredWebhookSecret(storedSecret: string): string {
+    return maskWebhookSecret(decryptWebhookSecret(storedSecret));
+}

--- a/src/lib/webhooks/settings.ts
+++ b/src/lib/webhooks/settings.ts
@@ -1,0 +1,39 @@
+import type { webhookEndpoints } from "@/db/schema";
+import { isWebhookEvent, WEBHOOK_EVENTS } from "@/lib/webhooks/emit";
+import {
+    decryptWebhookUrl,
+    maskStoredWebhookSecret,
+} from "@/lib/webhooks/secrets";
+
+export function serializeWebhookEndpoint(
+    endpoint: typeof webhookEndpoints.$inferSelect,
+) {
+    return {
+        id: endpoint.id,
+        url: decryptWebhookUrl(endpoint.url),
+        secret: maskStoredWebhookSecret(endpoint.secret),
+        events: endpoint.events,
+        description: endpoint.description,
+        enabled: endpoint.enabled,
+        lastDeliveryAt: endpoint.lastDeliveryAt,
+        lastDeliveryStatus: endpoint.lastDeliveryStatus,
+        createdAt: endpoint.createdAt,
+        updatedAt: endpoint.updatedAt,
+    };
+}
+
+export function parseWebhookEvents(value: unknown): string[] {
+    if (!Array.isArray(value)) throw new Error("events must be an array");
+
+    const events = value.filter((event): event is string => {
+        return typeof event === "string" && isWebhookEvent(event);
+    });
+
+    if (events.length === 0) {
+        throw new Error(
+            `events must include at least one of: ${WEBHOOK_EVENTS.join(", ")}`,
+        );
+    }
+
+    return Array.from(new Set(events));
+}

--- a/src/lib/webhooks/settings.ts
+++ b/src/lib/webhooks/settings.ts
@@ -25,10 +25,19 @@ export function serializeWebhookEndpoint(
 export function parseWebhookEvents(value: unknown): string[] {
     if (!Array.isArray(value)) throw new Error("events must be an array");
 
-    const events = value.filter((event): event is string => {
-        return typeof event === "string" && isWebhookEvent(event);
-    });
+    // Reject unknown / typo'd event names rather than silently dropping
+    // them. A user typing "transcription.complete" (missing 'd') would
+    // otherwise see an empty selection and never receive that event.
+    const unknown = value.filter(
+        (event) => typeof event !== "string" || !isWebhookEvent(event),
+    );
+    if (unknown.length > 0) {
+        throw new Error(
+            `unknown events: ${unknown.join(", ")}. supported events: ${WEBHOOK_EVENTS.join(", ")}`,
+        );
+    }
 
+    const events = value as string[];
     if (events.length === 0) {
         throw new Error(
             `events must include at least one of: ${WEBHOOK_EVENTS.join(", ")}`,

--- a/src/lib/webhooks/signature.ts
+++ b/src/lib/webhooks/signature.ts
@@ -1,0 +1,48 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export function createWebhookSignature(
+    secret: string,
+    timestamp: number,
+    body: string,
+): string {
+    const payload = `${timestamp}.${body}`;
+    return createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export function formatWebhookSignatureHeader(
+    secret: string,
+    timestamp: number,
+    body: string,
+): string {
+    return `t=${timestamp},v1=${createWebhookSignature(secret, timestamp, body)}`;
+}
+
+export function verifyWebhookSignature(
+    secret: string,
+    header: string,
+    body: string,
+    toleranceSeconds = 300,
+    nowSeconds = Math.floor(Date.now() / 1000),
+): boolean {
+    const parts = new Map(
+        header.split(",").map((part) => {
+            const [key, value] = part.split("=");
+            return [key, value] as const;
+        }),
+    );
+
+    const timestampRaw = parts.get("t");
+    const signature = parts.get("v1");
+    if (!timestampRaw || !signature) return false;
+
+    const timestamp = Number(timestampRaw);
+    if (!Number.isFinite(timestamp)) return false;
+    if (Math.abs(nowSeconds - timestamp) > toleranceSeconds) return false;
+
+    const expected = createWebhookSignature(secret, timestamp, body);
+    const expectedBuffer = Buffer.from(expected, "hex");
+    const actualBuffer = Buffer.from(signature, "hex");
+    if (expectedBuffer.length !== actualBuffer.length) return false;
+
+    return timingSafeEqual(expectedBuffer, actualBuffer);
+}

--- a/src/lib/webhooks/url.ts
+++ b/src/lib/webhooks/url.ts
@@ -1,0 +1,268 @@
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { env } from "@/lib/env";
+
+const BIG_ZERO = BigInt(0);
+const BIG_ONE = BigInt(1);
+const BIG_16 = BigInt(16);
+const IPV6_UNIQUE_LOCAL_PREFIX = BigInt(0x7e);
+const IPV6_LINK_LOCAL_PREFIX = BigInt(0x3fa);
+const IPV6_MULTICAST_PREFIX = BigInt(0xff);
+const IPV6_DOCUMENTATION_PREFIX = BigInt(0x20010db8);
+
+export type PublicWebhookAddress = {
+    address: string;
+    family: 4 | 6;
+};
+
+export type PublicWebhookTarget = {
+    url: URL;
+    addresses: PublicWebhookAddress[] | null;
+};
+
+export function webhookTargetsRequirePublic(): boolean {
+    return env.WEBHOOKS_REQUIRE_PUBLIC_TARGETS ?? env.IS_HOSTED;
+}
+
+function assertHttpOrHttpsWebhookUrl(url: URL): void {
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error("Webhook URL must use HTTP or HTTPS");
+    }
+}
+
+function assertHttpsWebhookUrl(url: URL): void {
+    if (url.protocol !== "https:") {
+        throw new Error("Webhook URL must use HTTPS");
+    }
+}
+
+export function parseWebhookUrl(value: unknown): string {
+    if (typeof value !== "string") throw new Error("URL is required");
+
+    const trimmed = value.trim();
+    const url = new URL(trimmed);
+    assertHttpOrHttpsWebhookUrl(url);
+    if (url.username || url.password) {
+        throw new Error("Webhook URL must not include credentials");
+    }
+    if (webhookTargetsRequirePublic()) {
+        assertHttpsWebhookUrl(url);
+        assertAllowedWebhookHostname(url.hostname);
+    }
+    return url.toString();
+}
+
+function normalizedHostname(hostname: string): string {
+    const lower = hostname.toLowerCase().replace(/\.$/, "");
+    if (lower.startsWith("[") && lower.endsWith("]")) {
+        return lower.slice(1, -1);
+    }
+    return lower;
+}
+
+function parseIpv4(address: string): [number, number, number, number] | null {
+    const parts = address.split(".").map((part) => Number.parseInt(part, 10));
+    if (
+        parts.length !== 4 ||
+        parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+    ) {
+        return null;
+    }
+    return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+function isPrivateIpv4(address: string): boolean {
+    const parts = parseIpv4(address);
+    if (!parts) return true;
+
+    const [a, b, c] = parts;
+    return (
+        a === 0 ||
+        a === 10 ||
+        a === 127 ||
+        (a === 100 && b >= 64 && b <= 127) ||
+        (a === 169 && b === 254) ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        (a === 192 && b === 0 && (c === 0 || c === 2)) ||
+        (a === 198 && (b === 18 || b === 19)) ||
+        (a === 198 && b === 51 && c === 100) ||
+        (a === 203 && b === 0 && c === 113) ||
+        a >= 224
+    );
+}
+
+function mappedIpv4FromIpv6(address: string): string | null {
+    const dottedIpv4 = address.includes(".")
+        ? address.slice(address.lastIndexOf(":") + 1)
+        : null;
+    if (dottedIpv4 && parseIpv4(dottedIpv4)) return dottedIpv4;
+
+    const tail = address.startsWith("::ffff:")
+        ? address.slice("::ffff:".length)
+        : address.startsWith("0:0:0:0:0:ffff:")
+          ? address.slice("0:0:0:0:0:ffff:".length)
+          : null;
+    if (!tail) return null;
+
+    const parts = tail.split(":");
+    if (parts.length !== 2) return null;
+
+    const high = Number.parseInt(parts[0], 16);
+    const low = Number.parseInt(parts[1], 16);
+    if (
+        !Number.isInteger(high) ||
+        !Number.isInteger(low) ||
+        high < 0 ||
+        high > 0xffff ||
+        low < 0 ||
+        low > 0xffff
+    ) {
+        return null;
+    }
+
+    return [
+        (high >> 8) & 0xff,
+        high & 0xff,
+        (low >> 8) & 0xff,
+        low & 0xff,
+    ].join(".");
+}
+
+function ipv6ToBigInt(address: string): bigint | null {
+    if (address.includes(".")) return null;
+
+    const parts = address.split("::");
+    if (parts.length > 2) return null;
+
+    const left = parts[0] ? parts[0].split(":") : [];
+    const right = parts.length === 2 && parts[1] ? parts[1].split(":") : [];
+    const zeroCount = parts.length === 2 ? 8 - left.length - right.length : 0;
+    if (zeroCount < 0) return null;
+
+    const hextets =
+        parts.length === 2
+            ? [...left, ...Array(zeroCount).fill("0"), ...right]
+            : left;
+    if (hextets.length !== 8) return null;
+
+    let result = BIG_ZERO;
+    for (const hextet of hextets) {
+        if (!/^[0-9a-f]{1,4}$/i.test(hextet)) return null;
+        const value = Number.parseInt(hextet, 16);
+        if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+            return null;
+        }
+        result = (result << BIG_16) + BigInt(value);
+    }
+    return result;
+}
+
+function isPrivateIpv6(address: string): boolean {
+    const normalized = address.toLowerCase().split("%", 1)[0];
+    const mappedIpv4 = mappedIpv4FromIpv6(normalized);
+
+    if (mappedIpv4) {
+        return isPrivateIpv4(mappedIpv4);
+    }
+    const ip = ipv6ToBigInt(normalized);
+    if (ip === null) return true;
+
+    return (
+        ip === BIG_ZERO ||
+        ip === BIG_ONE ||
+        ip >> BigInt(121) === IPV6_UNIQUE_LOCAL_PREFIX ||
+        ip >> BigInt(118) === IPV6_LINK_LOCAL_PREFIX ||
+        ip >> BigInt(120) === IPV6_MULTICAST_PREFIX ||
+        ip >> BigInt(96) === IPV6_DOCUMENTATION_PREFIX
+    );
+}
+
+function isPrivateIpAddress(address: string): boolean {
+    const normalized = normalizedHostname(address);
+    const ipVersion = isIP(normalized);
+    if (ipVersion === 4) return isPrivateIpv4(normalized);
+    if (ipVersion === 6) return isPrivateIpv6(normalized);
+    return false;
+}
+
+function assertAllowedWebhookHostname(hostname: string): void {
+    const normalized = normalizedHostname(hostname);
+    if (
+        normalized === "localhost" ||
+        normalized.endsWith(".localhost") ||
+        normalized.endsWith(".local") ||
+        normalized.endsWith(".internal") ||
+        normalized.endsWith(".home.arpa") ||
+        normalized.endsWith(".lan") ||
+        isPrivateIpAddress(normalized)
+    ) {
+        throw new Error("Webhook URL must use a public hostname or IP address");
+    }
+}
+
+export function isWebhookUrlPolicyError(message: string): boolean {
+    return (
+        message === "URL is required" ||
+        message === "Webhook URL must use HTTP or HTTPS" ||
+        message === "Webhook URL must use HTTPS" ||
+        message === "Webhook URL must not include credentials" ||
+        message === "Webhook URL must use a public hostname or IP address" ||
+        message === "Webhook URL must resolve to public IP addresses"
+    );
+}
+
+export async function assertWebhookUrlAllowed(
+    urlString: string,
+): Promise<void> {
+    await resolveWebhookUrl(urlString);
+}
+
+export async function resolveWebhookUrl(
+    urlString: string,
+): Promise<PublicWebhookTarget> {
+    const url = new URL(parseWebhookUrl(urlString));
+    if (!webhookTargetsRequirePublic()) {
+        return {
+            url,
+            addresses: null,
+        };
+    }
+
+    assertHttpsWebhookUrl(url);
+    assertAllowedWebhookHostname(url.hostname);
+
+    const hostname = normalizedHostname(url.hostname);
+    const ipVersion = isIP(hostname);
+    if (ipVersion === 4 || ipVersion === 6) {
+        return {
+            url,
+            addresses: [{ address: hostname, family: ipVersion }],
+        };
+    }
+
+    let addresses: Array<{ address: string; family: number }>;
+    try {
+        addresses = await lookup(hostname, {
+            all: true,
+            verbatim: true,
+        } as const);
+    } catch {
+        throw new Error("Webhook URL host could not be resolved");
+    }
+
+    if (addresses.length === 0) {
+        throw new Error("Webhook URL host could not be resolved");
+    }
+    if (addresses.some((address) => isPrivateIpAddress(address.address))) {
+        throw new Error("Webhook URL must resolve to public IP addresses");
+    }
+
+    return {
+        url,
+        addresses: addresses.map((address) => ({
+            address: address.address,
+            family: address.family === 6 ? 6 : 4,
+        })),
+    };
+}

--- a/src/lib/webhooks/worker.ts
+++ b/src/lib/webhooks/worker.ts
@@ -1,0 +1,544 @@
+import type { IncomingMessage, RequestOptions } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import type { LookupFunction } from "node:net";
+import { and, eq, inArray, lte, or, type SQL, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
+import {
+    createOutboundWebhookPayload,
+    createStoredWebhookPayload,
+    createUnavailableWebhookPayload,
+    getWebhookPayloadDeliveredAt,
+    getWebhookPayloadError,
+    getWebhookPayloadRecordingId,
+    type StoredWebhookPayload,
+} from "@/lib/webhooks/payload";
+import { getWebhookRecordingDetailForUser } from "@/lib/webhooks/recording";
+import {
+    decryptWebhookSecret,
+    decryptWebhookUrl,
+} from "@/lib/webhooks/secrets";
+import { formatWebhookSignatureHeader } from "@/lib/webhooks/signature";
+import {
+    isWebhookUrlPolicyError,
+    type PublicWebhookAddress,
+    type PublicWebhookTarget,
+    resolveWebhookUrl,
+} from "@/lib/webhooks/url";
+
+const TICK_MS = 30_000;
+const DELIVERY_LIMIT = 50;
+const PER_USER_DELIVERY_LIMIT = 10;
+const TIMEOUT_MS = 10_000;
+const PROCESSING_LEASE_MS = 15 * 60_000;
+const BACKOFF_MS = [30_000, 120_000, 600_000, 3_600_000, 21_600_000] as const;
+
+let started = false;
+let running = false;
+
+type WebhookDeliveryResult = {
+    ok: boolean;
+    responseStatus: number | null;
+    responseBody: string | null;
+    error: string | null;
+    storedPayload: StoredWebhookPayload;
+    permanentFailure?: boolean;
+};
+
+type ClaimedDelivery = {
+    delivery: typeof webhookDeliveries.$inferSelect;
+    endpoint: typeof webhookEndpoints.$inferSelect;
+};
+
+type CandidateDeliveryRow = {
+    id: string;
+};
+
+type QueryResultRows<T> = T[] | { rows: T[] };
+
+export function getWebhookBackoffMs(attemptNumber: number): number {
+    return BACKOFF_MS[
+        Math.min(Math.max(attemptNumber, 1), BACKOFF_MS.length) - 1
+    ];
+}
+
+function rowsFromQueryResult<T>(result: QueryResultRows<T>): T[] {
+    return Array.isArray(result) ? result : result.rows;
+}
+
+function dueDeliveryPredicate(now: Date): SQL {
+    return or(
+        and(
+            eq(webhookDeliveries.status, "pending"),
+            lte(webhookDeliveries.nextAttemptAt, now),
+        ),
+        and(
+            eq(webhookDeliveries.status, "processing"),
+            lte(webhookDeliveries.nextAttemptAt, now),
+        ),
+    ) as SQL;
+}
+
+async function readResponseBody(response: IncomingMessage): Promise<string> {
+    return new Promise((resolve) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk: string) => {
+            if (body.length < 4096) {
+                body += chunk.slice(0, 4096 - body.length);
+            }
+        });
+        response.on("end", () => resolve(body));
+        response.on("error", () => resolve(body));
+    });
+}
+
+function createPinnedLookup(addresses: PublicWebhookAddress[]): LookupFunction {
+    return (_hostname, options, callback) => {
+        if (options.all) {
+            callback(null, addresses);
+            return;
+        }
+
+        const family =
+            options.family === 4 || options.family === 6
+                ? options.family
+                : null;
+        const selected =
+            (family
+                ? addresses.find((address) => address.family === family)
+                : undefined) ?? addresses[0];
+        callback(null, selected.address, selected.family);
+    };
+}
+
+async function postWebhookRequest(
+    target: PublicWebhookTarget,
+    headers: Record<string, string>,
+    body: string,
+): Promise<{
+    ok: boolean;
+    responseStatus: number | null;
+    responseBody: string | null;
+    error: string | null;
+}> {
+    const hostname = target.url.hostname.replace(/^\[(.*)\]$/, "$1");
+    const options: RequestOptions = {
+        protocol: target.url.protocol,
+        hostname,
+        port: target.url.port || undefined,
+        path: `${target.url.pathname}${target.url.search}`,
+        method: "POST",
+        headers,
+    };
+    if (target.addresses) {
+        options.lookup = createPinnedLookup(target.addresses);
+    }
+    const requestFn =
+        target.url.protocol === "http:" ? httpRequest : httpsRequest;
+
+    return new Promise((resolve) => {
+        const request = requestFn(options, async (response) => {
+            const status = response.statusCode ?? 0;
+            const responseBody = await readResponseBody(response);
+            const ok = status >= 200 && status < 300;
+
+            resolve({
+                ok,
+                responseStatus: status || null,
+                responseBody,
+                error: ok ? null : `HTTP ${status}`,
+            });
+        });
+
+        const timeout = setTimeout(() => {
+            request.destroy(new Error("Webhook delivery timed out"));
+        }, TIMEOUT_MS);
+
+        request.on("error", (error) => {
+            clearTimeout(timeout);
+            resolve({
+                ok: false,
+                responseStatus: null,
+                responseBody: null,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        });
+        request.on("close", () => clearTimeout(timeout));
+        request.write(body);
+        request.end();
+    });
+}
+
+async function postDelivery(
+    delivery: typeof webhookDeliveries.$inferSelect,
+    endpoint: typeof webhookEndpoints.$inferSelect,
+): Promise<WebhookDeliveryResult> {
+    const recordingId =
+        delivery.recordingId ?? getWebhookPayloadRecordingId(delivery.payload);
+    const deliveredAt = getWebhookPayloadDeliveredAt(
+        delivery.payload,
+        delivery.createdAt,
+    );
+    const payloadError = getWebhookPayloadError(delivery.payload);
+    const storedPayload = recordingId
+        ? createStoredWebhookPayload(delivery.event, recordingId, {
+              deliveredAt,
+              error: payloadError ?? undefined,
+          })
+        : createUnavailableWebhookPayload(
+              null,
+              "Webhook delivery has no recording reference",
+          );
+
+    if (!recordingId) {
+        return {
+            ok: false,
+            responseStatus: null,
+            responseBody: null,
+            error: "Webhook delivery has no recording reference",
+            storedPayload,
+            permanentFailure: true,
+        };
+    }
+
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    try {
+        const target = await resolveWebhookUrl(decryptWebhookUrl(endpoint.url));
+        const recording = await getWebhookRecordingDetailForUser(
+            delivery.userId,
+            recordingId,
+            delivery.event,
+        );
+        if (!recording) {
+            return {
+                ok: false,
+                responseStatus: null,
+                responseBody: null,
+                error: "Recording is no longer available",
+                storedPayload: createUnavailableWebhookPayload(
+                    recordingId,
+                    "Recording is no longer available",
+                ),
+                permanentFailure: true,
+            };
+        }
+
+        const body = JSON.stringify(
+            createOutboundWebhookPayload(
+                delivery.event,
+                deliveredAt,
+                recording,
+                payloadError,
+            ),
+        );
+        const secret = decryptWebhookSecret(endpoint.secret);
+        const result = await postWebhookRequest(
+            target,
+            {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(body).toString(),
+                "User-Agent": "OpenPlaud-Webhooks/1",
+                "X-OpenPlaud-Event": delivery.event,
+                "X-OpenPlaud-Delivery": delivery.id,
+                "X-OpenPlaud-Timestamp": String(timestamp),
+                "X-OpenPlaud-Signature": formatWebhookSignatureHeader(
+                    secret,
+                    timestamp,
+                    body,
+                ),
+            },
+            body,
+        );
+
+        return { ...result, storedPayload };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+            ok: false,
+            responseStatus: null,
+            responseBody: null,
+            error: message,
+            storedPayload,
+            permanentFailure: isWebhookUrlPolicyError(message),
+        };
+    }
+}
+
+async function markDeliveryAttempt(
+    delivery: typeof webhookDeliveries.$inferSelect,
+    endpoint: typeof webhookEndpoints.$inferSelect,
+    result: Awaited<ReturnType<typeof postDelivery>>,
+): Promise<void> {
+    const now = new Date();
+    const attempts = delivery.attempts + 1;
+
+    if (result.ok) {
+        await db.transaction(async (tx) => {
+            const [updatedDelivery] = await tx
+                .update(webhookDeliveries)
+                .set({
+                    status: "success",
+                    payload: result.storedPayload,
+                    attempts,
+                    lastAttemptAt: now,
+                    lastResponseStatus: result.responseStatus,
+                    lastResponseBody: result.responseBody,
+                    lastError: null,
+                    updatedAt: now,
+                })
+                .where(
+                    and(
+                        eq(webhookDeliveries.id, delivery.id),
+                        eq(webhookDeliveries.userId, delivery.userId),
+                        eq(webhookDeliveries.status, "processing"),
+                    ),
+                )
+                .returning({ id: webhookDeliveries.id });
+
+            if (!updatedDelivery) return;
+
+            await tx
+                .update(webhookEndpoints)
+                .set({
+                    lastDeliveryAt: now,
+                    lastDeliveryStatus: "success",
+                    updatedAt: now,
+                })
+                .where(
+                    and(
+                        eq(webhookEndpoints.id, endpoint.id),
+                        eq(webhookEndpoints.userId, endpoint.userId),
+                    ),
+                );
+        });
+        return;
+    }
+
+    const dead = result.permanentFailure || attempts > BACKOFF_MS.length;
+    const nextAttemptAt = dead
+        ? now
+        : new Date(now.getTime() + getWebhookBackoffMs(attempts));
+
+    await db.transaction(async (tx) => {
+        const [updatedDelivery] = await tx
+            .update(webhookDeliveries)
+            .set({
+                status: dead ? "dead" : "pending",
+                payload: result.storedPayload,
+                attempts,
+                lastAttemptAt: now,
+                nextAttemptAt,
+                lastResponseStatus: result.responseStatus,
+                lastResponseBody: result.responseBody,
+                lastError: result.error,
+                updatedAt: now,
+            })
+            .where(
+                and(
+                    eq(webhookDeliveries.id, delivery.id),
+                    eq(webhookDeliveries.userId, delivery.userId),
+                    eq(webhookDeliveries.status, "processing"),
+                ),
+            )
+            .returning({ id: webhookDeliveries.id });
+
+        if (!updatedDelivery) return;
+
+        await tx
+            .update(webhookEndpoints)
+            .set({
+                lastDeliveryAt: now,
+                lastDeliveryStatus: "failed",
+                updatedAt: now,
+            })
+            .where(
+                and(
+                    eq(webhookEndpoints.id, endpoint.id),
+                    eq(webhookEndpoints.userId, endpoint.userId),
+                ),
+            );
+    });
+}
+
+async function claimDueWebhookDeliveries(): Promise<ClaimedDelivery[]> {
+    const now = new Date();
+
+    const candidateResult = await db.execute(sql`
+        select id
+        from (
+            select
+                ${webhookDeliveries.id} as id,
+                ${webhookDeliveries.nextAttemptAt} as next_attempt_at,
+                row_number() over (
+                    partition by ${webhookDeliveries.userId}
+                    order by ${webhookDeliveries.nextAttemptAt} asc, ${webhookDeliveries.id} asc
+                ) as user_rank
+            from ${webhookDeliveries}
+            inner join ${webhookEndpoints}
+                on ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
+            where (
+                (${webhookDeliveries.status} = 'pending' and ${webhookDeliveries.nextAttemptAt} <= ${now})
+                or (${webhookDeliveries.status} = 'processing' and ${webhookDeliveries.nextAttemptAt} <= ${now})
+            )
+            and ${webhookEndpoints.enabled} = true
+        ) ranked_deliveries
+        where user_rank <= ${PER_USER_DELIVERY_LIMIT}
+        order by next_attempt_at asc, id asc
+        limit ${DELIVERY_LIMIT}
+    `);
+
+    const candidateRows = rowsFromQueryResult(
+        candidateResult as unknown as QueryResultRows<CandidateDeliveryRow>,
+    );
+
+    if (candidateRows.length === 0) return [];
+
+    const ids = candidateRows.map((row) => row.id);
+    const claimExpiresAt = new Date(now.getTime() + PROCESSING_LEASE_MS);
+    const claimedRows = await db
+        .update(webhookDeliveries)
+        .set({
+            status: "processing",
+            nextAttemptAt: claimExpiresAt,
+            updatedAt: now,
+        })
+        .where(
+            and(
+                inArray(webhookDeliveries.id, ids),
+                dueDeliveryPredicate(now),
+                sql`exists (
+                    select 1
+                    from ${webhookEndpoints}
+                    where ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
+                    and ${webhookEndpoints.enabled} = true
+                )`,
+            ),
+        )
+        .returning({ id: webhookDeliveries.id });
+
+    const claimedIds = new Set(claimedRows.map((row) => row.id));
+    if (claimedIds.size === 0) return [];
+
+    const rows = await db
+        .select({
+            delivery: webhookDeliveries,
+            endpoint: webhookEndpoints,
+        })
+        .from(webhookDeliveries)
+        .innerJoin(
+            webhookEndpoints,
+            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
+        )
+        .where(
+            and(
+                inArray(webhookDeliveries.id, Array.from(claimedIds)),
+                eq(webhookEndpoints.enabled, true),
+            ),
+        );
+
+    const order = new Map(ids.map((id, index) => [id, index]));
+    return rows.sort((a, b) => {
+        return (
+            (order.get(a.delivery.id) ?? Number.MAX_SAFE_INTEGER) -
+            (order.get(b.delivery.id) ?? Number.MAX_SAFE_INTEGER)
+        );
+    });
+}
+
+async function reloadClaimedDeliveryForSend(
+    claimed: ClaimedDelivery,
+): Promise<ClaimedDelivery | null> {
+    const [row] = await db
+        .select({
+            delivery: webhookDeliveries,
+            endpoint: webhookEndpoints,
+        })
+        .from(webhookDeliveries)
+        .innerJoin(
+            webhookEndpoints,
+            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
+        )
+        .where(
+            and(
+                eq(webhookDeliveries.id, claimed.delivery.id),
+                eq(webhookDeliveries.userId, claimed.delivery.userId),
+                eq(webhookDeliveries.endpointId, claimed.endpoint.id),
+                eq(webhookDeliveries.status, "processing"),
+                eq(webhookEndpoints.id, claimed.endpoint.id),
+                eq(webhookEndpoints.userId, claimed.endpoint.userId),
+                eq(webhookEndpoints.enabled, true),
+            ),
+        )
+        .limit(1);
+
+    return row ?? null;
+}
+
+async function releaseClaimedDelivery(
+    delivery: typeof webhookDeliveries.$inferSelect,
+): Promise<void> {
+    const now = new Date();
+    await db
+        .update(webhookDeliveries)
+        .set({
+            status: "pending",
+            nextAttemptAt: now,
+            updatedAt: now,
+        })
+        .where(
+            and(
+                eq(webhookDeliveries.id, delivery.id),
+                eq(webhookDeliveries.userId, delivery.userId),
+                eq(webhookDeliveries.status, "processing"),
+            ),
+        );
+}
+
+export async function deliverDueWebhooks(): Promise<void> {
+    if (running) return;
+    running = true;
+
+    try {
+        const rows = await claimDueWebhookDeliveries();
+
+        for (const row of rows) {
+            const current = await reloadClaimedDeliveryForSend(row);
+            if (!current) {
+                await releaseClaimedDelivery(row.delivery);
+                continue;
+            }
+
+            const result = await postDelivery(
+                current.delivery,
+                current.endpoint,
+            );
+            await markDeliveryAttempt(
+                current.delivery,
+                current.endpoint,
+                result,
+            );
+        }
+    } catch (error) {
+        console.error("Webhook delivery worker failed:", error);
+    } finally {
+        running = false;
+    }
+}
+
+export function signalWebhookWorker(): void {
+    if (!started) return;
+    void deliverDueWebhooks();
+}
+
+export function startWebhookWorker(): void {
+    if (started) return;
+    started = true;
+    const interval = setInterval(() => {
+        void deliverDueWebhooks();
+    }, TICK_MS);
+    interval.unref?.();
+    void deliverDueWebhooks();
+}

--- a/src/tests/admin/guard.test.ts
+++ b/src/tests/admin/guard.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        IS_HOSTED: false,
+        ADMIN_EMAILS: [],
+        ADMIN_IP_ALLOWLIST: [],
+        ADMIN_REAUTH_TTL_MINUTES: 30,
+        ADMIN_MUTATION_TTL_MINUTES: 10,
+        BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+import { requireAdminApi, requireAdminMutation } from "@/lib/admin/guard";
+import { ErrorCode } from "@/lib/errors";
+
+describe("admin API guard", () => {
+    it("throws a JSON-mappable 404 AppError for failed API reads", async () => {
+        await expect(
+            requireAdminApi({
+                route: "/api/admin/example",
+                method: "GET",
+            }),
+        ).rejects.toMatchObject({
+            code: ErrorCode.NOT_FOUND,
+            statusCode: 404,
+        });
+    });
+
+    it("throws a JSON-mappable 404 AppError for failed mutations", async () => {
+        await expect(
+            requireAdminMutation({
+                route: "/api/admin/actions/example",
+                method: "POST",
+            }),
+        ).rejects.toMatchObject({
+            code: ErrorCode.NOT_FOUND,
+            statusCode: 404,
+        });
+    });
+});

--- a/src/tests/api-keys.test.ts
+++ b/src/tests/api-keys.test.ts
@@ -1,0 +1,122 @@
+import { createHmac } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+    API_TOKEN_HASH_SECRET: undefined as string | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+import {
+    createApiKey,
+    getApiKeyPrefix,
+    hashApiKey,
+    isApiKeyActive,
+    normalizeApiKeyScopes,
+} from "@/lib/auth-request";
+
+describe("API keys", () => {
+    beforeEach(() => {
+        mockEnv.BETTER_AUTH_SECRET = "better-auth-secret-with-32-chars";
+        mockEnv.API_TOKEN_HASH_SECRET = undefined;
+    });
+
+    it("generates op-prefixed keys and display prefixes", () => {
+        const key = createApiKey();
+
+        expect(key).toMatch(/^op_[A-Za-z0-9_-]{24}$/);
+        expect(getApiKeyPrefix(key)).toBe(key.slice(0, 12));
+    });
+
+    it("hashes keys deterministically without storing the raw key", () => {
+        const key = "op_testkey";
+        const hash = hashApiKey(key);
+
+        expect(hash).toHaveLength(64);
+        expect(hash).toBe(hashApiKey(key));
+        expect(hash).not.toContain(key);
+        expect(hash).toBe(
+            createHmac("sha256", mockEnv.BETTER_AUTH_SECRET)
+                .update(key)
+                .digest("hex"),
+        );
+    });
+
+    it("hashes the same key differently when the HMAC key changes", () => {
+        const key = "op_testkey";
+        const first = hashApiKey(key);
+
+        mockEnv.BETTER_AUTH_SECRET = "different-better-auth-secret-32-chars";
+        const second = hashApiKey(key);
+
+        expect(second).not.toBe(first);
+    });
+
+    it("uses API_TOKEN_HASH_SECRET before BETTER_AUTH_SECRET", () => {
+        const key = "op_testkey";
+        mockEnv.API_TOKEN_HASH_SECRET = "api-token-hash-secret-32-characters";
+
+        const hash = hashApiKey(key);
+
+        expect(hash).toBe(
+            createHmac("sha256", mockEnv.API_TOKEN_HASH_SECRET)
+                .update(key)
+                .digest("hex"),
+        );
+        expect(hash).not.toBe(
+            createHmac("sha256", mockEnv.BETTER_AUTH_SECRET)
+                .update(key)
+                .digest("hex"),
+        );
+    });
+
+    it("treats revoked and expired keys as inactive", () => {
+        const now = new Date("2026-05-06T12:00:00.000Z");
+
+        expect(isApiKeyActive({ revokedAt: null, expiresAt: null }, now)).toBe(
+            true,
+        );
+        expect(
+            isApiKeyActive(
+                {
+                    revokedAt: new Date("2026-05-06T11:00:00.000Z"),
+                    expiresAt: null,
+                },
+                now,
+            ),
+        ).toBe(false);
+        expect(
+            isApiKeyActive(
+                {
+                    revokedAt: null,
+                    expiresAt: new Date("2026-05-06T11:00:00.000Z"),
+                },
+                now,
+            ),
+        ).toBe(false);
+    });
+
+    it("normalizes scopes to read-only", () => {
+        expect(normalizeApiKeyScopes(["read", "write", 1])).toEqual(["read"]);
+        expect(normalizeApiKeyScopes([])).toEqual(["read"]);
+        expect(normalizeApiKeyScopes("read")).toEqual(["read"]);
+    });
+});

--- a/src/tests/recordings-route.test.ts
+++ b/src/tests/recordings-route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-1" },
+    }),
+}));
+
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: vi.fn((value: string | null | undefined) =>
+        typeof value === "string" ? value.replace(/^encrypted:/, "") : value,
+    ),
+}));
+
+import { GET as listRecordings } from "@/app/api/recordings/route";
+import { db } from "@/db";
+import { requireApiSession } from "@/lib/auth-server";
+
+const now = new Date("2026-05-06T12:00:00.000Z");
+
+function selectRows(rows: unknown[]) {
+    return {
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockResolvedValue(rows),
+            }),
+        }),
+    };
+}
+
+describe("GET /api/recordings", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (requireApiSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-1" },
+        });
+    });
+
+    it("returns plaintext filenames when recordings are encrypted at rest", async () => {
+        (db.select as Mock).mockReturnValueOnce(
+            selectRows([
+                {
+                    id: "rec-1",
+                    userId: "user-1",
+                    deviceSn: "SN-1",
+                    plaudFileId: "plaud-1",
+                    filename: "encrypted:Planning Call",
+                    duration: 120000,
+                    startTime: now,
+                    endTime: now,
+                    filesize: 12345,
+                    fileMd5: "abc",
+                    storageType: "local",
+                    storagePath: "user-1/rec.mp3",
+                    downloadedAt: now,
+                    plaudVersion: "1",
+                    timezone: null,
+                    zonemins: null,
+                    scene: null,
+                    isTrash: false,
+                    deletedAt: null,
+                    createdAt: now,
+                    updatedAt: now,
+                },
+            ]),
+        );
+
+        const response = await listRecordings(
+            new Request("http://localhost/api/recordings"),
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+            recordings: [{ id: "rec-1", filename: "Planning Call" }],
+        });
+    });
+});

--- a/src/tests/regressions/108-api-keys-polish.test.ts
+++ b/src/tests/regressions/108-api-keys-polish.test.ts
@@ -1,0 +1,176 @@
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+        API_TOKEN_HASH_SECRET: undefined,
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+import { db } from "@/db";
+import { apiKeys } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import {
+    authenticateRequest,
+    createApiKey,
+    hashApiKey,
+} from "@/lib/auth-request";
+import { ErrorCode } from "@/lib/errors";
+
+describe("Issue #108 - API keys polish", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (auth.api.getSession as unknown as Mock).mockResolvedValue(null);
+    });
+
+    it("uses the api_keys schema with source and usage metadata", () => {
+        const config = getTableConfig(apiKeys);
+        const columns = config.columns.map((column) => column.name);
+        const indexes = config.indexes.map((index) => index.config.name);
+
+        expect(config.name).toBe("api_keys");
+        expect(columns).toEqual(
+            expect.arrayContaining([
+                "name",
+                "source",
+                "last_used_at",
+                "key_hash",
+                "key_prefix",
+            ]),
+        );
+        expect(indexes).toEqual(
+            expect.arrayContaining([
+                "api_keys_user_id_idx",
+                "api_keys_key_hash_idx",
+            ]),
+        );
+    });
+
+    it("only accepts op-prefixed keys and updates lastUsedAt on successful auth", async () => {
+        const legacyResult = await authenticateRequest(
+            new Request("http://localhost/api/v1/recordings", {
+                headers: { Authorization: "Bearer opp_legacy" },
+            }),
+        );
+
+        expect(legacyResult).toBeNull();
+        expect(db.select).not.toHaveBeenCalled();
+
+        const key = createApiKey();
+        const keyHash = hashApiKey(key);
+        const updateSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        (db.update as unknown as Mock).mockReturnValue({ set: updateSet });
+        (db.select as unknown as Mock).mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([
+                        {
+                            id: "api-key-108",
+                            userId: "user-108",
+                            name: "Hermes",
+                            keyHash,
+                            keyPrefix: key.slice(0, 12),
+                            source: "manual",
+                            scopes: ["read"],
+                            lastUsedAt: null,
+                            expiresAt: null,
+                            revokedAt: null,
+                            createdAt: new Date("2026-05-06T12:00:00.000Z"),
+                            updatedAt: new Date("2026-05-06T12:00:00.000Z"),
+                        },
+                    ]),
+                }),
+            }),
+        });
+
+        const result = await authenticateRequest(
+            new Request("http://localhost/api/v1/recordings", {
+                headers: { Authorization: `Bearer ${key}` },
+            }),
+        );
+
+        expect(result).toEqual({
+            user: { id: "user-108" },
+            via: "api-key",
+            apiKeyId: "api-key-108",
+        });
+        expect(updateSet).toHaveBeenCalledWith(
+            expect.objectContaining({
+                lastUsedAt: expect.any(Date) as Date,
+                updatedAt: expect.any(Date) as Date,
+            }),
+        );
+    });
+
+    it("rejects API-key authentication when the owning user is suspended", async () => {
+        const key = createApiKey();
+        const keyHash = hashApiKey(key);
+
+        (db.select as unknown as Mock)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                id: "api-key-108",
+                                userId: "user-108",
+                                name: "Hermes",
+                                keyHash,
+                                keyPrefix: key.slice(0, 12),
+                                source: "manual",
+                                scopes: ["read"],
+                                lastUsedAt: null,
+                                expiresAt: null,
+                                revokedAt: null,
+                                createdAt: new Date("2026-05-06T12:00:00.000Z"),
+                                updatedAt: new Date("2026-05-06T12:00:00.000Z"),
+                            },
+                        ]),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                suspendedAt: new Date(
+                                    "2026-05-06T12:00:00.000Z",
+                                ),
+                            },
+                        ]),
+                    }),
+                }),
+            });
+
+        await expect(
+            authenticateRequest(
+                new Request("http://localhost/api/v1/recordings", {
+                    headers: { Authorization: `Bearer ${key}` },
+                }),
+            ),
+        ).rejects.toMatchObject({
+            code: ErrorCode.ACCOUNT_SUSPENDED,
+            statusCode: 403,
+        });
+        expect(db.update).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/regressions/108-api-keys-polish.test.ts
+++ b/src/tests/regressions/108-api-keys-polish.test.ts
@@ -54,12 +54,14 @@ describe("Issue #108 - API keys polish", () => {
                 "key_prefix",
             ]),
         );
+        // No explicit `api_keys_key_hash_idx` — the unique constraint
+        // creates an implicit btree index that the bearer-token lookup
+        // already uses. A second explicit index would just double the
+        // write cost on every key issue / revoke.
         expect(indexes).toEqual(
-            expect.arrayContaining([
-                "api_keys_user_id_idx",
-                "api_keys_key_hash_idx",
-            ]),
+            expect.arrayContaining(["api_keys_user_id_idx"]),
         );
+        expect(indexes).not.toContain("api_keys_key_hash_idx");
     });
 
     it("only accepts op-prefixed keys and updates lastUsedAt on successful auth", async () => {

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -95,6 +95,10 @@ vi.mock("@/lib/transcription/transcribe-recording", () => ({
     transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { db } from "@/db";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
@@ -245,9 +249,11 @@ import {
     aiEnhancements,
     recordings as recordingsTable,
     transcriptions as transcriptionsTable,
+    webhookDeliveries,
 } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { createUserStorageProvider as createStorage } from "@/lib/storage/factory";
+import { emitEvent } from "@/lib/webhooks/emit";
 
 describe("DELETE /api/recordings/[id]", () => {
     const userId = "user-123";
@@ -261,10 +267,12 @@ describe("DELETE /api/recordings/[id]", () => {
         });
 
     let txCalls: Array<{ table: string; op: "delete" | "update" }>;
+    let txSets: Array<{ table: string; values: Record<string, unknown> }>;
 
     beforeEach(() => {
         vi.clearAllMocks();
         txCalls = [];
+        txSets = [];
 
         (auth.api.getSession as unknown as Mock).mockResolvedValue({
             user: { id: userId },
@@ -280,7 +288,9 @@ describe("DELETE /api/recordings/[id]", () => {
                   ? "ai_enhancements"
                   : t === recordingsTable
                     ? "recordings"
-                    : "unknown";
+                    : t === webhookDeliveries
+                      ? "webhook_deliveries"
+                      : "unknown";
 
         (db.transaction as Mock).mockImplementation(
             async (cb: (tx: unknown) => Promise<void>) => {
@@ -295,15 +305,19 @@ describe("DELETE /api/recordings/[id]", () => {
                         }),
                     })),
                     update: vi.fn((table: unknown) => ({
-                        set: vi.fn().mockReturnValue({
+                        set: vi.fn((values: Record<string, unknown>) => ({
                             where: vi.fn().mockImplementation(() => {
                                 txCalls.push({
                                     table: tableName(table),
                                     op: "update",
                                 });
+                                txSets.push({
+                                    table: tableName(table),
+                                    values,
+                                });
                                 return Promise.resolve(undefined);
                             }),
-                        }),
+                        })),
                     })),
                 };
                 await cb(tx);
@@ -390,7 +404,7 @@ describe("DELETE /api/recordings/[id]", () => {
         );
     });
 
-    it("deletes storage, then child rows + tombstone in one tx", async () => {
+    it("deletes storage, then child rows + webhook payloads + tombstone in one tx", async () => {
         const deleteFile = vi.fn().mockResolvedValue(undefined);
         (createStorage as Mock).mockResolvedValue({
             uploadFile: vi.fn(),
@@ -408,14 +422,30 @@ describe("DELETE /api/recordings/[id]", () => {
         expect(deleteFile.mock.invocationCallOrder[0]).toBeLessThan(
             (db.transaction as Mock).mock.invocationCallOrder[0],
         );
-        // All three writes ran in the same transaction…
-        expect(txCalls).toHaveLength(3);
-        // …in this order: transcriptions → ai_enhancements → recordings.
+        // All writes ran in the same transaction…
+        expect(txCalls).toHaveLength(4);
+        // …in this order: transcriptions → ai_enhancements → webhook redaction → recordings.
         expect(txCalls.map((c) => `${c.op}:${c.table}`)).toEqual([
             "delete:transcriptions",
             "delete:ai_enhancements",
+            "update:webhook_deliveries",
             "update:recordings",
         ]);
+        const webhookUpdate = txSets.find(
+            (entry) => entry.table === "webhook_deliveries",
+        );
+        expect(webhookUpdate?.values.payload).toMatchObject({
+            recording_id: recordingId,
+            redacted: true,
+        });
+        expect(emitEvent).toHaveBeenCalledWith(
+            "recording.deleted",
+            userId,
+            recordingId,
+        );
+        expect(
+            (db.transaction as Mock).mock.invocationCallOrder[0],
+        ).toBeLessThan((emitEvent as Mock).mock.invocationCallOrder[0]);
     });
 
     it("refuses to tombstone when storage delete fails for a non-not-found reason", async () => {
@@ -435,6 +465,7 @@ describe("DELETE /api/recordings/[id]", () => {
         expect(res.status).toBe(500);
         // No tombstone, no orphan: retry is safe.
         expect(db.transaction).not.toHaveBeenCalled();
+        expect(emitEvent).not.toHaveBeenCalled();
     });
 
     it("still tombstones when storage reports the object is already gone", async () => {
@@ -458,7 +489,13 @@ describe("DELETE /api/recordings/[id]", () => {
         expect(txCalls.map((c) => `${c.op}:${c.table}`)).toEqual([
             "delete:transcriptions",
             "delete:ai_enhancements",
+            "update:webhook_deliveries",
             "update:recordings",
         ]);
+        expect(emitEvent).toHaveBeenCalledWith(
+            "recording.deleted",
+            userId,
+            recordingId,
+        );
     });
 });

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -231,12 +231,42 @@ describe("Issue #56 — delete recording tombstone", () => {
             [],
         ]);
 
+        // Sync now performs the update inside a tombstone-rechecking
+        // transaction. Stub the tx so the inner select returns a
+        // non-tombstoned row and the inner update resolves; cb returns
+        // true so emitEvent and the updated counter both fire.
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (tx: unknown) => Promise<boolean>) => {
+                const tx = {
+                    select: vi.fn().mockReturnValue({
+                        from: vi.fn().mockReturnValue({
+                            where: vi.fn().mockReturnValue({
+                                for: vi.fn().mockReturnValue({
+                                    limit: vi
+                                        .fn()
+                                        .mockResolvedValue([
+                                            { deletedAt: null },
+                                        ]),
+                                }),
+                            }),
+                        }),
+                    }),
+                    update: vi.fn().mockReturnValue({
+                        set: vi.fn().mockReturnValue({
+                            where: vi.fn().mockResolvedValue(undefined),
+                        }),
+                    }),
+                };
+                return cb(tx);
+            },
+        );
+
         const result = await syncRecordingsForUser(mockUserId);
 
         expect(result.updatedRecordings).toBe(1);
         expect(result.newRecordings).toBe(0);
         expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
-        expect(db.update).toHaveBeenCalled();
+        expect(db.transaction).toHaveBeenCalled();
     });
 });
 
@@ -293,7 +323,7 @@ describe("DELETE /api/recordings/[id]", () => {
                       : "unknown";
 
         (db.transaction as Mock).mockImplementation(
-            async (cb: (tx: unknown) => Promise<void>) => {
+            async (cb: (tx: unknown) => Promise<unknown>) => {
                 const tx = {
                     delete: vi.fn((table: unknown) => ({
                         where: vi.fn().mockImplementation(() => {
@@ -305,8 +335,14 @@ describe("DELETE /api/recordings/[id]", () => {
                         }),
                     })),
                     update: vi.fn((table: unknown) => ({
-                        set: vi.fn((values: Record<string, unknown>) => ({
-                            where: vi.fn().mockImplementation(() => {
+                        set: vi.fn((values: Record<string, unknown>) => {
+                            // The recordings tombstone update now chains
+                            // .returning(...) so the handler can tell
+                            // whether it actually flipped the row (and
+                            // therefore should emit `recording.deleted`).
+                            // Other tx.update calls in this transaction
+                            // (webhook_deliveries) still resolve directly.
+                            const recordWrite = () => {
                                 txCalls.push({
                                     table: tableName(table),
                                     op: "update",
@@ -315,12 +351,29 @@ describe("DELETE /api/recordings/[id]", () => {
                                     table: tableName(table),
                                     values,
                                 });
+                            };
+                            const wherePromise = (): Promise<unknown> => {
+                                recordWrite();
                                 return Promise.resolve(undefined);
-                            }),
-                        })),
+                            };
+                            return {
+                                where: vi.fn().mockImplementation(() => {
+                                    const whereResult = wherePromise();
+                                    return Object.assign(whereResult, {
+                                        returning: vi
+                                            .fn()
+                                            .mockResolvedValue(
+                                                table === recordingsTable
+                                                    ? [{ id: recordingId }]
+                                                    : [],
+                                            ),
+                                    });
+                                }),
+                            };
+                        }),
                     })),
                 };
-                await cb(tx);
+                return cb(tx);
             },
         );
     });

--- a/src/tests/regressions/56-delete-recording.test.ts
+++ b/src/tests/regressions/56-delete-recording.test.ts
@@ -325,6 +325,23 @@ describe("DELETE /api/recordings/[id]", () => {
         (db.transaction as Mock).mockImplementation(
             async (cb: (tx: unknown) => Promise<unknown>) => {
                 const tx = {
+                    // FOR UPDATE lock on the parent recording at the top
+                    // of the tombstone transaction. The default stub
+                    // returns a non-tombstoned row so the handler
+                    // proceeds; individual tests can override.
+                    select: vi.fn().mockReturnValue({
+                        from: vi.fn().mockReturnValue({
+                            where: vi.fn().mockReturnValue({
+                                for: vi.fn().mockReturnValue({
+                                    limit: vi
+                                        .fn()
+                                        .mockResolvedValue([
+                                            { deletedAt: null },
+                                        ]),
+                                }),
+                            }),
+                        }),
+                    }),
                     delete: vi.fn((table: unknown) => ({
                         where: vi.fn().mockImplementation(() => {
                             txCalls.push({
@@ -550,5 +567,55 @@ describe("DELETE /api/recordings/[id]", () => {
             userId,
             recordingId,
         );
+    });
+
+    it("bails out cleanly when a concurrent DELETE has already tombstoned the row", async () => {
+        // Both DELETE requests pass the pre-transaction read because the
+        // recording is still active when they each look it up. The
+        // tombstone-detection happens under FOR UPDATE inside the
+        // transaction: the loser sees `deletedAt != null` and returns
+        // false from the cb so no child-row deletes, no webhook payload
+        // redaction, no second `recording.deleted` emit fire.
+        const deleteFile = vi.fn().mockResolvedValue(undefined);
+        (createStorage as Mock).mockResolvedValue({
+            uploadFile: vi.fn(),
+            downloadFile: vi.fn(),
+            deleteFile,
+        });
+        stubRecordingLookup([
+            { id: recordingId, userId, storagePath, deletedAt: null },
+        ]);
+
+        // Override the default tx.select stub so the FOR UPDATE re-check
+        // returns an already-tombstoned row.
+        (db.transaction as Mock).mockImplementationOnce(
+            async (cb: (tx: unknown) => Promise<unknown>) => {
+                const tx = {
+                    select: vi.fn().mockReturnValue({
+                        from: vi.fn().mockReturnValue({
+                            where: vi.fn().mockReturnValue({
+                                for: vi.fn().mockReturnValue({
+                                    limit: vi.fn().mockResolvedValue([
+                                        {
+                                            deletedAt: new Date(
+                                                "2024-02-01T00:00:00Z",
+                                            ),
+                                        },
+                                    ]),
+                                }),
+                            }),
+                        }),
+                    }),
+                    delete: vi.fn(),
+                    update: vi.fn(),
+                };
+                return cb(tx);
+            },
+        );
+
+        const res = await deleteRecording(makeRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(txCalls).toHaveLength(0);
+        expect(emitEvent).not.toHaveBeenCalled();
     });
 });

--- a/src/tests/regressions/70-is-hosted.test.ts
+++ b/src/tests/regressions/70-is-hosted.test.ts
@@ -17,7 +17,7 @@
  * so other tests sharing the worker aren't affected.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 type EnvSchema = typeof import("@/lib/env")["envSchema"];
 let envSchema: EnvSchema;
@@ -53,5 +53,109 @@ describe("issue #70: IS_HOSTED env contract", () => {
     it("is true only for the literal string 'true'", () => {
         const parsed = envSchema.parse({ IS_HOSTED: "true" });
         expect(parsed.IS_HOSTED).toBe(true);
+    });
+
+    it("preserves unset WEBHOOKS_REQUIRE_PUBLIC_TARGETS", () => {
+        const parsed = envSchema.parse({});
+        expect(parsed.WEBHOOKS_REQUIRE_PUBLIC_TARGETS).toBeUndefined();
+    });
+
+    it("parses WEBHOOKS_REQUIRE_PUBLIC_TARGETS as a strict optional boolean", () => {
+        expect(
+            envSchema.parse({ WEBHOOKS_REQUIRE_PUBLIC_TARGETS: "true" })
+                .WEBHOOKS_REQUIRE_PUBLIC_TARGETS,
+        ).toBe(true);
+        expect(
+            envSchema.parse({ WEBHOOKS_REQUIRE_PUBLIC_TARGETS: "false" })
+                .WEBHOOKS_REQUIRE_PUBLIC_TARGETS,
+        ).toBe(false);
+
+        expect(
+            envSchema.parse({ WEBHOOKS_REQUIRE_PUBLIC_TARGETS: "" })
+                .WEBHOOKS_REQUIRE_PUBLIC_TARGETS,
+        ).toBeUndefined();
+
+        for (const v of ["0", "1", "yes", "TRUE", "False"]) {
+            expect(() =>
+                envSchema.parse({ WEBHOOKS_REQUIRE_PUBLIC_TARGETS: v }),
+            ).toThrow();
+        }
+    });
+
+    it("parses RATE_LIMIT_TRUST_PROXY_HEADERS as a strict optional boolean", () => {
+        expect(
+            envSchema.parse({ RATE_LIMIT_TRUST_PROXY_HEADERS: "true" })
+                .RATE_LIMIT_TRUST_PROXY_HEADERS,
+        ).toBe(true);
+        expect(
+            envSchema.parse({ RATE_LIMIT_TRUST_PROXY_HEADERS: "false" })
+                .RATE_LIMIT_TRUST_PROXY_HEADERS,
+        ).toBe(false);
+        expect(
+            envSchema.parse({ RATE_LIMIT_TRUST_PROXY_HEADERS: "" })
+                .RATE_LIMIT_TRUST_PROXY_HEADERS,
+        ).toBeUndefined();
+
+        for (const v of ["0", "1", "yes", "TRUE", "False"]) {
+            expect(() =>
+                envSchema.parse({ RATE_LIMIT_TRUST_PROXY_HEADERS: v }),
+            ).toThrow();
+        }
+    });
+
+    it("requires API_TOKEN_HASH_SECRET to be strong when set", () => {
+        expect(envSchema.parse({}).API_TOKEN_HASH_SECRET).toBeUndefined();
+        expect(
+            envSchema.parse({ API_TOKEN_HASH_SECRET: "" })
+                .API_TOKEN_HASH_SECRET,
+        ).toBeUndefined();
+        expect(() =>
+            envSchema.parse({ API_TOKEN_HASH_SECRET: "short" }),
+        ).toThrow();
+        expect(
+            envSchema.parse({
+                API_TOKEN_HASH_SECRET: "token-hash-secret-with-32-characters",
+            }).API_TOKEN_HASH_SECRET,
+        ).toBe("token-hash-secret-with-32-characters");
+    });
+
+    it("requires trusted proxy IP headers when hosted mode serves runtime requests", async () => {
+        const originalEnv = { ...process.env };
+        const runtimeEnv = {
+            APP_URL: "http://localhost:3000",
+            BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+            DATABASE_URL: "postgresql://user:password@localhost:5432/openplaud",
+            ENCRYPTION_KEY:
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            IS_HOSTED: "true",
+            NEXT_PHASE: undefined,
+        };
+
+        try {
+            process.env = {
+                ...originalEnv,
+                ...runtimeEnv,
+            } as NodeJS.ProcessEnv;
+            delete process.env.NEXT_PHASE;
+            delete process.env.RATE_LIMIT_TRUST_PROXY_HEADERS;
+            vi.resetModules();
+
+            await expect(import("@/lib/env")).rejects.toThrow(
+                "RATE_LIMIT_TRUST_PROXY_HEADERS=true must be set when IS_HOSTED=true",
+            );
+
+            process.env.RATE_LIMIT_TRUST_PROXY_HEADERS = "true";
+            vi.resetModules();
+
+            await expect(import("@/lib/env")).resolves.toMatchObject({
+                env: expect.objectContaining({
+                    IS_HOSTED: true,
+                    RATE_LIMIT_TRUST_PROXY_HEADERS: true,
+                }),
+            });
+        } finally {
+            process.env = originalEnv;
+            vi.resetModules();
+        }
     });
 });

--- a/src/tests/regressions/79-api-keys-v1.test.ts
+++ b/src/tests/regressions/79-api-keys-v1.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+        API_TOKEN_HASH_SECRET: undefined,
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+        select: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-79" },
+    }),
+}));
+
+vi.mock("@/lib/v1/rate-limit", () => ({
+    enforceV1IpRateLimit: vi.fn().mockResolvedValue(null),
+    enforceV1AuthenticatedRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+import { POST as createApiKey } from "@/app/api/settings/api-keys/route";
+import { GET as listV1Recordings } from "@/app/api/v1/recordings/route";
+import { db } from "@/db";
+import { recordings } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+const now = new Date("2026-05-06T12:00:00.000Z");
+
+function routeRequest(url: string, init?: RequestInit) {
+    return new Request(url, init);
+}
+
+function exprReferencesColumn(
+    expr: unknown,
+    col: unknown,
+    seen = new Set<unknown>(),
+): boolean {
+    if (expr == null || typeof expr !== "object") return false;
+    if (expr === col) return true;
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+
+    for (const key of [
+        "queryChunks",
+        "sql",
+        "left",
+        "right",
+        "value",
+        "args",
+        "chunks",
+        "expr",
+    ]) {
+        const value = (expr as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+            if (value.some((item) => exprReferencesColumn(item, col, seen))) {
+                return true;
+            }
+        } else if (exprReferencesColumn(value, col, seen)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+describe("Issue #79 - API keys and v1 recordings", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (requireApiSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-79" },
+        });
+        (auth.api.getSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-79" },
+        });
+    });
+
+    it("refuses API key creation for suspended users", async () => {
+        (requireApiSession as unknown as Mock).mockRejectedValueOnce(
+            new AppError(ErrorCode.ACCOUNT_SUSPENDED, "Account suspended", 403),
+        );
+
+        const response = await createApiKey(
+            routeRequest("http://localhost/api/settings/api-keys", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: "Hermes" }),
+            }),
+        );
+
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.ACCOUNT_SUSPENDED,
+        });
+        expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it("creates a key once, accepts it on v1 routes, and scopes recordings by userId", async () => {
+        let insertedHash = "";
+        (db.insert as Mock).mockReturnValue({
+            values: vi.fn((values: { keyHash: string; source: string }) => {
+                insertedHash = values.keyHash;
+                expect(values.source).toBe("manual");
+                return {
+                    returning: vi.fn().mockResolvedValue([
+                        {
+                            id: "api-key-1",
+                            userId: "user-79",
+                            name: "Hermes",
+                            keyHash: values.keyHash,
+                            keyPrefix: "op_abcdef12",
+                            source: "manual",
+                            scopes: ["read"],
+                            lastUsedAt: null,
+                            expiresAt: null,
+                            revokedAt: null,
+                            createdAt: now,
+                            updatedAt: now,
+                        },
+                    ]),
+                };
+            }),
+        });
+
+        const createResponse = await createApiKey(
+            routeRequest("http://localhost/api/settings/api-keys", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: "Hermes" }),
+            }),
+        );
+
+        expect(createResponse.status).toBe(201);
+        const created = (await createResponse.json()) as {
+            key: string;
+            apiKey: { keyPrefix: string; source: string };
+        };
+        expect(created.key).toMatch(/^op_/);
+        expect(created.apiKey).toMatchObject({
+            keyPrefix: "op_abcdef12",
+            source: "manual",
+        });
+
+        (auth.api.getSession as unknown as Mock).mockResolvedValue(null);
+        const updateSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        (db.update as Mock).mockReturnValue({
+            set: updateSet,
+        });
+
+        const authSelectChain = {
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([
+                        {
+                            id: "api-key-1",
+                            userId: "user-79",
+                            name: "Hermes",
+                            keyHash: insertedHash,
+                            keyPrefix: "op_abcdef12",
+                            source: "manual",
+                            scopes: ["read"],
+                            lastUsedAt: null,
+                            expiresAt: null,
+                            revokedAt: null,
+                            createdAt: now,
+                            updatedAt: now,
+                        },
+                    ]),
+                }),
+            }),
+        };
+        const userSelectChain = {
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([{ suspendedAt: null }]),
+                }),
+            }),
+        };
+
+        let whereExpr: unknown;
+        const listChain = {
+            leftJoin: vi.fn(),
+            where: vi.fn((expr: unknown) => {
+                whereExpr = expr;
+                return {
+                    orderBy: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                recording: {
+                                    id: "rec-1",
+                                    userId: "user-79",
+                                    deviceSn: "SN-1",
+                                    plaudFileId: "plaud-1",
+                                    filename: "Scoped Recording",
+                                    duration: 1000,
+                                    startTime: now,
+                                    endTime: now,
+                                    filesize: 100,
+                                    fileMd5: "md5",
+                                    storageType: "local",
+                                    storagePath: "user-79/rec.mp3",
+                                    downloadedAt: now,
+                                    plaudVersion: "1",
+                                    timezone: null,
+                                    zonemins: null,
+                                    scene: null,
+                                    isTrash: false,
+                                    deletedAt: null,
+                                    createdAt: now,
+                                    updatedAt: now,
+                                },
+                                device: null,
+                                transcription: null,
+                                enhancement: null,
+                            },
+                        ]),
+                    }),
+                };
+            }),
+        };
+        listChain.leftJoin.mockReturnValue(listChain);
+
+        (db.select as Mock)
+            .mockReturnValueOnce(authSelectChain)
+            .mockReturnValueOnce(userSelectChain)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue(listChain),
+            });
+
+        const listResponse = await listV1Recordings(
+            routeRequest("http://localhost/api/v1/recordings?limit=1", {
+                headers: { Authorization: `Bearer ${created.key}` },
+            }),
+        );
+
+        expect(listResponse.status).toBe(200);
+        const listBody = (await listResponse.json()) as {
+            data: Array<{ id: string }>;
+        };
+        expect(listBody.data.map((recording) => recording.id)).toEqual([
+            "rec-1",
+        ]);
+        expect(updateSet).toHaveBeenCalledWith(
+            expect.objectContaining({
+                lastUsedAt: expect.any(Date) as Date,
+                updatedAt: expect.any(Date) as Date,
+            }),
+        );
+        expect(exprReferencesColumn(whereExpr, recordings.userId)).toBe(true);
+    });
+});

--- a/src/tests/regressions/79-user-scoped-plaud-file-id.test.ts
+++ b/src/tests/regressions/79-user-scoped-plaud-file-id.test.ts
@@ -1,0 +1,25 @@
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { recordings } from "@/db/schema";
+
+describe("Issue #79 - hosted sync schema", () => {
+    it("scopes Plaud file id uniqueness per user", () => {
+        const config = getTableConfig(recordings);
+        const plaudFileColumn = config.columns.find(
+            (column) => column.name === "plaud_file_id",
+        ) as { isUnique?: boolean } | undefined;
+
+        const uniqueConstraints = config.uniqueConstraints.map(
+            (constraint) => ({
+                name: constraint.getName(),
+                columns: constraint.columns.map((column) => column.name),
+            }),
+        );
+
+        expect(plaudFileColumn?.isUnique).toBe(false);
+        expect(uniqueConstraints).toContainEqual({
+            name: "recordings_user_id_plaud_file_id_unique",
+            columns: ["user_id", "plaud_file_id"],
+        });
+    });
+});

--- a/src/tests/regressions/79-v1-incremental-updates.test.ts
+++ b/src/tests/regressions/79-v1-incremental-updates.test.ts
@@ -1,0 +1,460 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const openAiMocks = vi.hoisted(() => ({
+    audioCreate: vi.fn(),
+    chatCreate: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-79" },
+    }),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    decrypt: vi.fn().mockReturnValue("fake-api-key"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("audio-data")),
+    }),
+}));
+
+vi.mock("openai", () => {
+    // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+    const MockOpenAI = vi.fn(function () {
+        return {
+            audio: {
+                transcriptions: {
+                    create: openAiMocks.audioCreate,
+                },
+            },
+            chat: {
+                completions: {
+                    create: openAiMocks.chatCreate,
+                },
+            },
+        };
+    });
+    return { OpenAI: MockOpenAI };
+});
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+    DELETE as deleteSummary,
+    POST as generateSummary,
+    GET as getSummary,
+} from "@/app/api/recordings/[id]/summary/route";
+import { POST as transcribeRecordingRoute } from "@/app/api/recordings/[id]/transcribe/route";
+import { db } from "@/db";
+import { aiEnhancements, recordings, transcriptions } from "@/db/schema";
+import { auth } from "@/lib/auth";
+import { ErrorCode } from "@/lib/errors";
+
+const userId = "user-79";
+const recordingId = "rec-79";
+
+function routeRequest(path: string, init?: RequestInit) {
+    return new Request(`http://localhost${path}`, init);
+}
+
+function routeParams() {
+    return { params: Promise.resolve({ id: recordingId }) };
+}
+
+function exprReferencesColumn(
+    expr: unknown,
+    col: unknown,
+    seen = new Set<unknown>(),
+): boolean {
+    if (expr == null || typeof expr !== "object") return false;
+    if (expr === col) return true;
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+
+    for (const key of [
+        "queryChunks",
+        "sql",
+        "left",
+        "right",
+        "value",
+        "args",
+        "chunks",
+        "expr",
+    ]) {
+        const value = (expr as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+            if (value.some((item) => exprReferencesColumn(item, col, seen))) {
+                return true;
+            }
+        } else if (exprReferencesColumn(value, col, seen)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function selectRows(rows: unknown[], captureWhere?: (expr: unknown) => void) {
+    return {
+        from: vi.fn().mockReturnValue({
+            where: vi.fn((expr: unknown) => {
+                captureWhere?.(expr);
+                return {
+                    limit: vi.fn().mockResolvedValue(rows),
+                };
+            }),
+        }),
+    };
+}
+
+function lockedRecordingRows(rows: unknown[]) {
+    return {
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                for: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue(rows),
+                }),
+            }),
+        }),
+    };
+}
+
+describe("Issue #79 - v1 incremental update timestamps", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (auth.api.getSession as unknown as Mock).mockResolvedValue({
+            user: { id: userId },
+        });
+        openAiMocks.audioCreate.mockResolvedValue({
+            text: "Manual transcript",
+            language: "en",
+        });
+        openAiMocks.chatCreate.mockResolvedValue({
+            choices: [
+                {
+                    message: {
+                        content: JSON.stringify({
+                            summary: "Summary",
+                            keyPoints: ["One"],
+                            actionItems: [],
+                        }),
+                    },
+                },
+            ],
+        });
+    });
+
+    it("bumps recording updatedAt inside the manual transcription transaction", async () => {
+        (db.select as Mock)
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        id: recordingId,
+                        userId,
+                        filename: "Manual Recording",
+                        storagePath: "recording.mp3",
+                        deletedAt: null,
+                    },
+                ]),
+            )
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        id: "creds-1",
+                        provider: "openai",
+                        apiKey: "encrypted-key",
+                        baseUrl: null,
+                        defaultModel: "whisper-1",
+                    },
+                ]),
+            );
+
+        const txInsertValues = vi.fn().mockResolvedValue(undefined);
+        const recordingBumpSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce(lockedRecordingRows([{ deletedAt: null }]))
+                .mockReturnValueOnce(selectRows([])),
+            insert: vi.fn().mockReturnValue({ values: txInsertValues }),
+            update: vi.fn().mockReturnValue({ set: recordingBumpSet }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (
+                callback: (
+                    transaction: typeof tx,
+                ) => Promise<unknown> | unknown,
+            ) => callback(tx),
+        );
+
+        const response = await transcribeRecordingRoute(
+            routeRequest(`/api/recordings/${recordingId}/transcribe`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(tx.update).toHaveBeenCalledWith(recordings);
+        expect(recordingBumpSet).toHaveBeenCalledWith({
+            updatedAt: expect.any(Date),
+        });
+    });
+
+    it("scopes summary transcription lookup by user and bumps updatedAt on create", async () => {
+        let transcriptionWhere: unknown;
+        (db.select as Mock)
+            .mockReturnValueOnce(
+                selectRows([{ id: recordingId, deletedAt: null }]),
+            )
+            .mockReturnValueOnce(
+                selectRows(
+                    [
+                        {
+                            id: "tr-1",
+                            userId,
+                            recordingId,
+                            text: "Transcript",
+                        },
+                    ],
+                    (expr) => {
+                        transcriptionWhere = expr;
+                    },
+                ),
+            )
+            .mockReturnValueOnce(selectRows([]))
+            .mockReturnValueOnce(selectRows([]))
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        id: "creds-1",
+                        provider: "openai",
+                        apiKey: "encrypted-key",
+                        baseUrl: null,
+                        defaultModel: "gpt-4o-mini",
+                    },
+                ]),
+            );
+
+        const txInsertValues = vi.fn().mockResolvedValue(undefined);
+        const recordingBumpSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce(lockedRecordingRows([{ deletedAt: null }]))
+                .mockReturnValueOnce(selectRows([])),
+            insert: vi.fn().mockReturnValue({ values: txInsertValues }),
+            update: vi.fn().mockReturnValue({ set: recordingBumpSet }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (
+                callback: (
+                    transaction: typeof tx,
+                ) => Promise<unknown> | unknown,
+            ) => callback(tx),
+        );
+
+        const response = await generateSummary(
+            routeRequest(`/api/recordings/${recordingId}/summary`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(
+            exprReferencesColumn(transcriptionWhere, transcriptions.userId),
+        ).toBe(true);
+        expect(txInsertValues).toHaveBeenCalled();
+        expect(tx.update).toHaveBeenCalledWith(recordings);
+        expect(recordingBumpSet).toHaveBeenCalledWith({
+            updatedAt: expect.any(Date),
+        });
+    });
+
+    it("scopes summary update by user and bumps recording updatedAt", async () => {
+        (db.select as Mock)
+            .mockReturnValueOnce(
+                selectRows([{ id: recordingId, deletedAt: null }]),
+            )
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        id: "tr-1",
+                        userId,
+                        recordingId,
+                        text: "Transcript",
+                    },
+                ]),
+            )
+            .mockReturnValueOnce(selectRows([]))
+            .mockReturnValueOnce(selectRows([]))
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        id: "creds-1",
+                        provider: "openai",
+                        apiKey: "encrypted-key",
+                        baseUrl: null,
+                        defaultModel: "gpt-4o-mini",
+                    },
+                ]),
+            );
+
+        let enhancementUpdateWhere: unknown;
+        const enhancementUpdateSet = vi.fn().mockReturnValue({
+            where: vi.fn((expr: unknown) => {
+                enhancementUpdateWhere = expr;
+                return Promise.resolve();
+            }),
+        });
+        const recordingBumpSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce(lockedRecordingRows([{ deletedAt: null }]))
+                .mockReturnValueOnce(selectRows([{ id: "enh-1", userId }])),
+            insert: vi.fn(),
+            update: vi
+                .fn()
+                .mockReturnValueOnce({ set: enhancementUpdateSet })
+                .mockReturnValueOnce({ set: recordingBumpSet }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (
+                callback: (
+                    transaction: typeof tx,
+                ) => Promise<unknown> | unknown,
+            ) => callback(tx),
+        );
+
+        const response = await generateSummary(
+            routeRequest(`/api/recordings/${recordingId}/summary`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(tx.update).toHaveBeenCalledWith(aiEnhancements);
+        expect(
+            exprReferencesColumn(enhancementUpdateWhere, aiEnhancements.userId),
+        ).toBe(true);
+        expect(tx.update).toHaveBeenCalledWith(recordings);
+        expect(recordingBumpSet).toHaveBeenCalledWith({
+            updatedAt: expect.any(Date),
+        });
+    });
+
+    it("bumps recording updatedAt when a summary row is deleted", async () => {
+        const recordingBumpSet = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        const tx = {
+            delete: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    returning: vi.fn().mockResolvedValue([{ id: "enh-1" }]),
+                }),
+            }),
+            update: vi.fn().mockReturnValue({ set: recordingBumpSet }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (
+                callback: (
+                    transaction: typeof tx,
+                ) => Promise<unknown> | unknown,
+            ) => callback(tx),
+        );
+
+        const response = await deleteSummary(
+            routeRequest(`/api/recordings/${recordingId}/summary`, {
+                method: "DELETE",
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(tx.update).toHaveBeenCalledWith(recordings);
+        expect(recordingBumpSet).toHaveBeenCalledWith({
+            updatedAt: expect.any(Date),
+        });
+    });
+
+    it("does not bump recording updatedAt when no summary row is deleted", async () => {
+        const tx = {
+            delete: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    returning: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+            update: vi.fn(),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (
+                callback: (
+                    transaction: typeof tx,
+                ) => Promise<unknown> | unknown,
+            ) => callback(tx),
+        );
+
+        const response = await deleteSummary(
+            routeRequest(`/api/recordings/${recordingId}/summary`, {
+                method: "DELETE",
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(tx.update).not.toHaveBeenCalled();
+    });
+
+    it("does not return summaries for deleted recordings", async () => {
+        (db.select as Mock).mockReturnValueOnce(selectRows([]));
+
+        const response = await getSummary(
+            routeRequest(`/api/recordings/${recordingId}/summary`),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.RECORDING_NOT_FOUND,
+        });
+    });
+});

--- a/src/tests/regressions/79-webhooks.test.ts
+++ b/src/tests/regressions/79-webhooks.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        APP_URL: "https://openplaud.example",
+        IS_HOSTED: false,
+        WEBHOOKS_REQUIRE_PUBLIC_TARGETS: undefined,
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+    decrypt: vi.fn((ciphertext: string) =>
+        ciphertext.replace(/^encrypted:/, ""),
+    ),
+}));
+
+import { db } from "@/db";
+import { webhookDeliveries } from "@/db/schema";
+import { emitEvent } from "@/lib/webhooks/emit";
+
+describe("Issue #79 — webhook emission", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("creates pending deliveries with minimal stored payload metadata", async () => {
+        (db.select as Mock).mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue([{ id: "wh-1" }]),
+            }),
+        });
+
+        const valuesSpy = vi.fn().mockResolvedValue(undefined);
+        (db.insert as Mock).mockImplementation((table: unknown) => {
+            expect(table).toBe(webhookDeliveries);
+            return { values: valuesSpy };
+        });
+
+        await emitEvent("recording.synced", "user-79", "rec-1");
+
+        expect(valuesSpy).toHaveBeenCalledTimes(1);
+        const values = valuesSpy.mock.calls[0][0] as Array<{
+            endpointId: string;
+            userId: string;
+            recordingId: string;
+            event: string;
+            status: string;
+            payload: Record<string, unknown>;
+        }>;
+        expect(values).toHaveLength(1);
+        expect(values[0].endpointId).toBe("wh-1");
+        expect(values[0].userId).toBe("user-79");
+        expect(values[0].recordingId).toBe("rec-1");
+        expect(values[0].event).toBe("recording.synced");
+        expect(values[0].status).toBe("pending");
+        expect(values[0].payload.event).toBe("recording.synced");
+        expect(values[0].payload.recording_id).toBe("rec-1");
+        expect(values[0].payload).not.toHaveProperty("data");
+        expect(JSON.stringify(values[0].payload)).not.toContain("transcript");
+        expect(JSON.stringify(values[0].payload)).not.toContain("summary");
+    });
+
+    it("creates pending recording.deleted deliveries", async () => {
+        (db.select as Mock).mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue([{ id: "wh-1" }]),
+            }),
+        });
+
+        const valuesSpy = vi.fn().mockResolvedValue(undefined);
+        (db.insert as Mock).mockReturnValue({
+            values: valuesSpy,
+        });
+
+        await emitEvent("recording.deleted", "user-79", "rec-1");
+
+        const values = valuesSpy.mock.calls[0][0] as Array<{
+            event: string;
+            payload: Record<string, unknown>;
+        }>;
+        expect(values[0].event).toBe("recording.deleted");
+        expect(values[0].payload.event).toBe("recording.deleted");
+        expect(values[0].payload.recording_id).toBe("rec-1");
+    });
+});

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -39,6 +39,10 @@ vi.mock("@/lib/transcription/transcribe-recording", () => ({
     transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { db } from "@/db";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/db", () => ({
         select: vi.fn(),
         insert: vi.fn(),
         update: vi.fn(),
+        transaction: vi.fn(),
     },
 }));
 
@@ -241,6 +242,37 @@ describe("Sync", () => {
                     where: vi.fn().mockResolvedValue(undefined),
                 }),
             });
+
+            // sync-recordings now wraps the update path in a transaction
+            // that re-checks the tombstone under FOR UPDATE before writing.
+            // Stub the tx so the inner select returns a non-tombstoned row
+            // and the inner update resolves; cb returns true so the caller
+            // proceeds to emit `recording.updated`.
+            (db.transaction as Mock).mockImplementation(
+                async (cb: (tx: unknown) => Promise<boolean>) => {
+                    const tx = {
+                        select: vi.fn().mockReturnValue({
+                            from: vi.fn().mockReturnValue({
+                                where: vi.fn().mockReturnValue({
+                                    for: vi.fn().mockReturnValue({
+                                        limit: vi
+                                            .fn()
+                                            .mockResolvedValue([
+                                                { deletedAt: null },
+                                            ]),
+                                    }),
+                                }),
+                            }),
+                        }),
+                        update: vi.fn().mockReturnValue({
+                            set: vi.fn().mockReturnValue({
+                                where: vi.fn().mockResolvedValue(undefined),
+                            }),
+                        }),
+                    };
+                    return cb(tx);
+                },
+            );
 
             const result = await syncRecordingsForUser(mockUserId);
 

--- a/src/tests/transcription.test.ts
+++ b/src/tests/transcription.test.ts
@@ -5,11 +5,13 @@ vi.mock("@/db", () => ({
         select: vi.fn(),
         insert: vi.fn(),
         update: vi.fn(),
+        transaction: vi.fn(),
     },
 }));
 
 vi.mock("@/lib/encryption", () => ({
     decrypt: vi.fn().mockReturnValue("fake-api-key"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
 }));
 
 vi.mock("@/lib/storage/factory", () => ({
@@ -29,9 +31,26 @@ vi.mock("openai", () => {
     return { OpenAI: MockOpenAI };
 });
 
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/ai/generate-title", () => ({
+    generateTitleFromTranscription: vi
+        .fn()
+        .mockResolvedValue("Generated Title"),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
 import { OpenAI } from "openai";
 import { db } from "@/db";
+import { recordings } from "@/db/schema";
+import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+import { emitEvent } from "@/lib/webhooks/emit";
 
 describe("Transcription", () => {
     const mockUserId = "user-123";
@@ -39,6 +58,16 @@ describe("Transcription", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+        (OpenAI as unknown as Mock).mockImplementation(function () {
+            return {
+                audio: {
+                    transcriptions: {
+                        create: vi.fn(),
+                    },
+                },
+            };
+        });
     });
 
     describe("transcribeRecording", () => {
@@ -189,6 +218,151 @@ describe("Transcription", () => {
 
             expect(result.success).toBe(false);
             expect(result.error).toBe("API Error");
+        });
+
+        it("bumps recording updatedAt and emits completion after generated title is stored", async () => {
+            const mockCreate = vi.fn().mockResolvedValue({
+                text: "Fresh transcript",
+                language: "en",
+            });
+            // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+            (OpenAI as unknown as Mock).mockImplementation(function () {
+                return {
+                    audio: { transcriptions: { create: mockCreate } },
+                };
+            });
+            (generateTitleFromTranscription as Mock).mockResolvedValue(
+                "Generated Title",
+            );
+
+            (db.select as Mock)
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([
+                                {
+                                    id: mockRecordingId,
+                                    userId: mockUserId,
+                                    plaudFileId: "plaud-1",
+                                    filename: "Original Title",
+                                    storagePath: "test.mp3",
+                                    deletedAt: null,
+                                },
+                            ]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([
+                                {
+                                    id: "creds-1",
+                                    provider: "openai",
+                                    apiKey: "encrypted-key",
+                                    defaultModel: "whisper-1",
+                                    baseUrl: null,
+                                },
+                            ]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([
+                                {
+                                    autoGenerateTitle: true,
+                                    syncTitleToPlaud: false,
+                                },
+                            ]),
+                        }),
+                    }),
+                });
+
+            const txInsertValues = vi.fn().mockResolvedValue(undefined);
+            const txInsert = vi.fn().mockReturnValue({
+                values: txInsertValues,
+            });
+            const recordingBumpWhere = vi.fn().mockResolvedValue(undefined);
+            const recordingBumpSet = vi.fn().mockReturnValue({
+                where: recordingBumpWhere,
+            });
+            const txUpdate = vi.fn().mockReturnValue({
+                set: recordingBumpSet,
+            });
+            const tx = {
+                select: vi
+                    .fn()
+                    .mockReturnValueOnce({
+                        from: vi.fn().mockReturnValue({
+                            where: vi.fn().mockReturnValue({
+                                for: vi.fn().mockReturnValue({
+                                    limit: vi
+                                        .fn()
+                                        .mockResolvedValue([
+                                            { deletedAt: null },
+                                        ]),
+                                }),
+                            }),
+                        }),
+                    })
+                    .mockReturnValueOnce({
+                        from: vi.fn().mockReturnValue({
+                            where: vi.fn().mockReturnValue({
+                                limit: vi.fn().mockResolvedValue([]),
+                            }),
+                        }),
+                    }),
+                insert: txInsert,
+                update: txUpdate,
+            };
+            (db.transaction as Mock).mockImplementation(
+                async (
+                    callback: (
+                        transaction: typeof tx,
+                    ) => Promise<unknown> | unknown,
+                ) => callback(tx),
+            );
+
+            const titleUpdateWhere = vi.fn().mockResolvedValue(undefined);
+            const titleUpdateSet = vi.fn().mockReturnValue({
+                where: titleUpdateWhere,
+            });
+            (db.update as Mock).mockReturnValue({
+                set: titleUpdateSet,
+            });
+
+            const result = await transcribeRecording(
+                mockUserId,
+                mockRecordingId,
+            );
+
+            expect(result.success).toBe(true);
+            expect(txInsert).toHaveBeenCalled();
+            expect(txUpdate).toHaveBeenCalledWith(recordings);
+            expect(recordingBumpSet).toHaveBeenCalledWith({
+                updatedAt: expect.any(Date),
+            });
+            expect(titleUpdateSet).toHaveBeenCalledWith({
+                filename: "v1:encrypted:Generated Title",
+                updatedAt: expect.any(Date),
+            });
+            expect(emitEvent).toHaveBeenCalledWith(
+                "transcription.completed",
+                mockUserId,
+                mockRecordingId,
+            );
+            expect(
+                (emitEvent as Mock).mock.invocationCallOrder[0],
+            ).toBeGreaterThan(titleUpdateWhere.mock.invocationCallOrder[0]);
         });
     });
 });

--- a/src/tests/v1-rate-limit.test.ts
+++ b/src/tests/v1-rate-limit.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+    API_TOKEN_HASH_SECRET: undefined as string | undefined,
+    RATE_LIMIT_TRUST_PROXY_HEADERS: undefined as boolean | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+    },
+}));
+
+import { db } from "@/db";
+import { ErrorCode } from "@/lib/errors";
+import {
+    enforceV1AuthenticatedRateLimit,
+    getClientIp,
+} from "@/lib/v1/rate-limit";
+
+describe("v1 rate limiting", () => {
+    beforeEach(() => {
+        mockEnv.BETTER_AUTH_SECRET = "better-auth-secret-with-32-chars";
+        mockEnv.API_TOKEN_HASH_SECRET = undefined;
+        mockEnv.RATE_LIMIT_TRUST_PROXY_HEADERS = undefined;
+    });
+
+    it("ignores spoofable forwarding headers unless proxy trust is enabled", () => {
+        const request = new Request("http://localhost/api/v1/recordings", {
+            headers: {
+                "x-forwarded-for": "203.0.113.10",
+                "x-real-ip": "203.0.113.11",
+                "cf-connecting-ip": "203.0.113.12",
+            },
+        });
+
+        expect(getClientIp(request)).toBe("unknown");
+    });
+
+    it("uses trusted proxy headers when explicitly enabled", () => {
+        mockEnv.RATE_LIMIT_TRUST_PROXY_HEADERS = true;
+
+        expect(
+            getClientIp(
+                new Request("http://localhost/api/v1/recordings", {
+                    headers: { "cf-connecting-ip": "203.0.113.12" },
+                }),
+            ),
+        ).toBe("203.0.113.12");
+
+        expect(
+            getClientIp(
+                new Request("http://localhost/api/v1/recordings", {
+                    headers: { "x-real-ip": "203.0.113.11" },
+                }),
+            ),
+        ).toBe("203.0.113.11");
+
+        expect(
+            getClientIp(
+                new Request("http://localhost/api/v1/recordings", {
+                    headers: {
+                        "x-forwarded-for":
+                            "198.51.100.1, 198.51.100.2, 203.0.113.10",
+                    },
+                }),
+            ),
+        ).toBe("198.51.100.1");
+    });
+
+    it("returns the unified error envelope and headers when auth buckets are exhausted", async () => {
+        const resetAt = new Date(Date.now() + 30_000);
+        (db.insert as unknown as Mock).mockReturnValue({
+            values: vi.fn().mockReturnValue({
+                onConflictDoUpdate: vi.fn().mockReturnValue({
+                    returning: vi.fn().mockResolvedValue([
+                        {
+                            count: 601,
+                            resetAt,
+                        },
+                    ]),
+                }),
+            }),
+        });
+
+        const response = await enforceV1AuthenticatedRateLimit({
+            user: { id: "user-1" },
+            via: "api-key",
+            apiKeyId: "api-key-1",
+        });
+
+        expect(response).not.toBeNull();
+        if (!response) return;
+        expect(response.status).toBe(429);
+        expect(response.headers.get("Retry-After")).toBeTruthy();
+        expect(response.headers.get("X-RateLimit-Limit")).toBe("600");
+        expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+        expect(response.headers.get("X-RateLimit-Reset")).toBe(
+            Math.ceil(resetAt.getTime() / 1000).toString(),
+        );
+        await expect(response.json()).resolves.toEqual({
+            error: "Rate limit exceeded",
+            code: ErrorCode.RATE_LIMITED,
+            details: {
+                retryAfter: expect.any(Number) as number,
+                limit: 600,
+                remaining: 0,
+                resetAt: Math.ceil(resetAt.getTime() / 1000),
+            },
+        });
+    });
+});

--- a/src/tests/v1-recordings.test.ts
+++ b/src/tests/v1-recordings.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: vi.fn((value: string | null | undefined) =>
+        typeof value === "string" ? value.replace(/^encrypted:/, "") : value,
+    ),
+    decryptJsonField: vi.fn((value: unknown) => value ?? null),
+}));
+
+import {
+    decodeRecordingCursor,
+    encodeRecordingCursor,
+    serializeRecording,
+    serializeRecordingDetail,
+} from "@/lib/v1/serialize";
+
+const now = new Date("2026-05-06T12:00:00.000Z");
+
+const recording = {
+    id: "rec-1",
+    userId: "user-1",
+    deviceSn: "SN-1",
+    plaudFileId: "plaud-1",
+    filename: "encrypted:Planning Call",
+    duration: 120000,
+    startTime: new Date("2026-05-06T11:00:00.000Z"),
+    endTime: new Date("2026-05-06T11:02:00.000Z"),
+    filesize: 12345,
+    fileMd5: "abc",
+    storageType: "local",
+    storagePath: "user-1/rec.mp3",
+    downloadedAt: now,
+    plaudVersion: "1",
+    timezone: null,
+    zonemins: null,
+    scene: null,
+    isTrash: false,
+    deletedAt: null,
+    createdAt: now,
+    updatedAt: now,
+};
+
+const device = {
+    id: "device-1",
+    userId: "user-1",
+    serialNumber: "SN-1",
+    name: "Plaud Note",
+    model: "Note",
+    versionNumber: null,
+    createdAt: now,
+    updatedAt: now,
+};
+
+const transcription = {
+    id: "tr-1",
+    recordingId: "rec-1",
+    userId: "user-1",
+    text: "encrypted:Hello world",
+    detectedLanguage: "en",
+    transcriptionType: "server",
+    provider: "openai",
+    model: "whisper-1",
+    createdAt: now,
+};
+
+const enhancement = {
+    id: "sum-1",
+    recordingId: "rec-1",
+    userId: "user-1",
+    summary: "encrypted:A short summary",
+    actionItems: ["Follow up"],
+    keyPoints: ["Planning"],
+    provider: "openai",
+    model: "gpt-4o-mini",
+    createdAt: now,
+};
+
+describe("v1 recordings", () => {
+    it("round-trips recording cursors", () => {
+        const cursor = encodeRecordingCursor({ updatedAt: now, id: "rec-1" });
+        expect(decodeRecordingCursor(cursor)).toEqual({
+            updatedAt: now,
+            id: "rec-1",
+        });
+        expect(decodeRecordingCursor("not-base64-json")).toBeNull();
+    });
+
+    it("serializes stable list payloads", () => {
+        expect(
+            serializeRecording(recording, device, transcription, enhancement),
+        ).toEqual({
+            id: "rec-1",
+            title: "Planning Call",
+            created_at: now.toISOString(),
+            updated_at: now.toISOString(),
+            recorded_at: "2026-05-06T11:00:00.000Z",
+            duration_ms: 120000,
+            filesize_bytes: 12345,
+            device: {
+                serial_number: "SN-1",
+                name: "Plaud Note",
+                model: "Note",
+            },
+            has_transcription: true,
+            has_summary: true,
+            links: {
+                self: "/api/v1/recordings/rec-1",
+                transcript: "/api/v1/recordings/rec-1/transcript",
+                audio: "/api/v1/recordings/rec-1/audio",
+            },
+        });
+    });
+
+    it("inlines transcript and summary for detail payloads", () => {
+        const detail = serializeRecordingDetail(
+            recording,
+            device,
+            transcription,
+            enhancement,
+        );
+
+        expect(detail.transcript?.text).toBe("Hello world");
+        expect(detail.summary?.text).toBe("A short summary");
+        expect(detail.summary?.action_items).toEqual(["Follow up"]);
+        expect(detail.summary?.key_points).toEqual(["Planning"]);
+    });
+
+    it("keeps legacy plaintext rows readable through the same serializers", () => {
+        const detail = serializeRecordingDetail(
+            { ...recording, filename: "Legacy Recording" },
+            null,
+            { ...transcription, text: "Legacy transcript" },
+            null,
+        );
+
+        expect(detail.title).toBe("Legacy Recording");
+        expect(detail.transcript?.text).toBe("Legacy transcript");
+    });
+});

--- a/src/tests/webhook-settings-routes.test.ts
+++ b/src/tests/webhook-settings-routes.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        IS_HOSTED: false,
+        WEBHOOKS_REQUIRE_PUBLIC_TARGETS: undefined,
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+    decrypt: vi.fn((ciphertext: string) =>
+        ciphertext.replace(/^encrypted:/, ""),
+    ),
+}));
+
+vi.mock("@/lib/auth", () => ({
+    auth: {
+        api: {
+            getSession: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-1" },
+    }),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+        select: vi.fn(),
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/webhooks/worker", () => ({
+    signalWebhookWorker: vi.fn(),
+}));
+
+import { POST as redeliverWebhook } from "@/app/api/settings/webhooks/[id]/deliveries/[deliveryId]/redeliver/route";
+import { PATCH as updateWebhook } from "@/app/api/settings/webhooks/[id]/route";
+import { POST as createWebhook } from "@/app/api/settings/webhooks/route";
+import { db } from "@/db";
+import { requireApiSession } from "@/lib/auth-server";
+import { ErrorCode } from "@/lib/errors";
+import { signalWebhookWorker } from "@/lib/webhooks/worker";
+
+const now = new Date("2026-05-06T12:00:00.000Z");
+
+function routeRequest(path: string, init?: RequestInit) {
+    return new Request(`http://localhost${path}`, init);
+}
+
+function routeParams(id = "wh-1") {
+    return { params: Promise.resolve({ id }) };
+}
+
+function redeliveryParams(id = "wh-1", deliveryId = "delivery-1") {
+    return { params: Promise.resolve({ id, deliveryId }) };
+}
+
+function webhookEndpoint(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "wh-1",
+        userId: "user-1",
+        url: "encrypted:https://example.com/webhook",
+        secret: "encrypted:whsec_abcdefghijkl",
+        events: ["recording.synced"],
+        description: null,
+        enabled: true,
+        lastDeliveryAt: null,
+        lastDeliveryStatus: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+describe("webhook settings routes", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (requireApiSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-1" },
+        });
+    });
+
+    it("encrypts webhook URLs at rest when creating endpoints", async () => {
+        let inserted: Record<string, unknown> = {};
+        (db.insert as Mock).mockReturnValue({
+            values: vi.fn((values: Record<string, unknown>) => {
+                inserted = values;
+                return {
+                    returning: vi
+                        .fn()
+                        .mockResolvedValue([webhookEndpoint(values)]),
+                };
+            }),
+        });
+
+        const response = await createWebhook(
+            routeRequest("/api/settings/webhooks", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    url: "https://example.com/hook?token=secret",
+                    events: ["recording.synced"],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(201);
+        expect(inserted?.url).toBe(
+            "encrypted:https://example.com/hook?token=secret",
+        );
+        const body = (await response.json()) as {
+            webhook: { url: string };
+        };
+        expect(body.webhook.url).toBe("https://example.com/hook?token=secret");
+    });
+
+    it("encrypts webhook URLs at rest when updating endpoints", async () => {
+        let updates: Record<string, unknown> = {};
+        (db.update as Mock).mockReturnValue({
+            set: vi.fn((values: Record<string, unknown>) => {
+                updates = values;
+                return {
+                    where: vi.fn().mockReturnValue({
+                        returning: vi
+                            .fn()
+                            .mockResolvedValue([webhookEndpoint(values)]),
+                    }),
+                };
+            }),
+        });
+
+        const response = await updateWebhook(
+            routeRequest("/api/settings/webhooks/wh-1", {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    url: "https://example.com/new?token=secret",
+                }),
+            }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(updates?.url).toBe(
+            "encrypted:https://example.com/new?token=secret",
+        );
+        const body = (await response.json()) as {
+            webhook: { url: string };
+        };
+        expect(body.webhook.url).toBe("https://example.com/new?token=secret");
+    });
+
+    it("rejects manual redelivery for disabled webhooks", async () => {
+        (db.select as Mock).mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi
+                        .fn()
+                        .mockResolvedValue([{ id: "wh-1", enabled: false }]),
+                }),
+            }),
+        });
+
+        const response = await redeliverWebhook(
+            routeRequest(
+                "/api/settings/webhooks/wh-1/deliveries/delivery-1/redeliver",
+                { method: "POST" },
+            ),
+            redeliveryParams(),
+        );
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toEqual({
+            error: "Webhook is disabled",
+            code: ErrorCode.CONFLICT,
+            details: { id: "wh-1" },
+        });
+        expect(db.update).not.toHaveBeenCalled();
+        expect(signalWebhookWorker).not.toHaveBeenCalled();
+    });
+
+    it("rejects manual redelivery while a delivery is processing", async () => {
+        (db.select as Mock)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi
+                            .fn()
+                            .mockResolvedValue([{ id: "wh-1", enabled: true }]),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi
+                            .fn()
+                            .mockResolvedValue([{ status: "processing" }]),
+                    }),
+                }),
+            });
+        (db.update as Mock).mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    returning: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        });
+
+        const response = await redeliverWebhook(
+            routeRequest(
+                "/api/settings/webhooks/wh-1/deliveries/delivery-1/redeliver",
+                { method: "POST" },
+            ),
+            redeliveryParams(),
+        );
+
+        expect(response.status).toBe(409);
+        await expect(response.json()).resolves.toEqual({
+            error: "Delivery is already processing",
+            code: ErrorCode.CONFLICT,
+            details: { id: "delivery-1" },
+        });
+        expect(signalWebhookWorker).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/webhook-settings-routes.test.ts
+++ b/src/tests/webhook-settings-routes.test.ts
@@ -186,6 +186,28 @@ describe("webhook settings routes", () => {
         expect(signalWebhookWorker).not.toHaveBeenCalled();
     });
 
+    it("rejects unknown webhook event names instead of silently dropping them", async () => {
+        const response = await createWebhook(
+            routeRequest("/api/settings/webhooks", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    url: "https://example.com/hook",
+                    // 'transcription.complete' missing trailing 'd' —
+                    // previously this silently became an empty filter,
+                    // so the user thought they subscribed but never got
+                    // any deliveries. Now it 400s.
+                    events: ["transcription.complete"],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        const body = (await response.json()) as { error: string };
+        expect(body.error).toMatch(/unknown events/i);
+        expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it("rejects manual redelivery while a delivery is processing", async () => {
         (db.select as Mock)
             .mockReturnValueOnce({

--- a/src/tests/webhooks.test.ts
+++ b/src/tests/webhooks.test.ts
@@ -1,0 +1,866 @@
+import { lookup } from "node:dns/promises";
+import { EventEmitter } from "node:events";
+import type { RequestOptions } from "node:http";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import type { LookupFunction } from "node:net";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    APP_URL: "https://openplaud.example",
+    IS_HOSTED: false,
+    WEBHOOKS_REQUIRE_PUBLIC_TARGETS: undefined as boolean | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+vi.mock("node:dns/promises", () => ({
+    lookup: vi.fn(),
+}));
+
+vi.mock("node:http", () => ({
+    request: vi.fn(),
+}));
+
+vi.mock("node:https", () => ({
+    request: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        execute: vi.fn(),
+        select: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+    decrypt: vi.fn((ciphertext: string) => {
+        if (!ciphertext.startsWith("encrypted:")) {
+            throw new Error("Expected encrypted webhook value");
+        }
+        return ciphertext.replace(/^encrypted:/, "");
+    }),
+}));
+
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: vi.fn((value: string | null | undefined) =>
+        typeof value === "string" ? value.replace(/^encrypted:/, "") : value,
+    ),
+}));
+
+vi.mock("@/lib/v1/serialize", () => ({
+    getV1RecordingDetailForUser: vi.fn().mockResolvedValue({
+        id: "rec-1",
+        title: "Current Recording",
+        created_at: "2026-05-06T11:59:00.000Z",
+        updated_at: "2026-05-06T12:00:00.000Z",
+        recorded_at: "2026-05-06T11:00:00.000Z",
+        duration_ms: 120000,
+        filesize_bytes: 12345,
+        device: {
+            serial_number: "SN-1",
+            name: "Plaud Note",
+            model: "Note",
+        },
+        has_transcription: true,
+        has_summary: true,
+        links: {
+            self: "/api/v1/recordings/rec-1",
+            transcript: "/api/v1/recordings/rec-1/transcript",
+            audio: "/api/v1/recordings/rec-1/audio",
+        },
+        transcript: {
+            language: "en",
+            text: "x".repeat(600),
+            provider: "openai",
+            model: "whisper-1",
+            created_at: "2026-05-06T12:00:00.000Z",
+        },
+        summary: { text: "Current summary" },
+    }),
+    serializeRecordingDetail: vi.fn((recording, device) => {
+        const self = `/api/v1/recordings/${recording.id}`;
+        return {
+            id: recording.id,
+            title: recording.filename,
+            created_at: recording.createdAt.toISOString(),
+            updated_at: recording.updatedAt.toISOString(),
+            recorded_at: recording.startTime.toISOString(),
+            duration_ms: recording.duration,
+            filesize_bytes: recording.filesize,
+            device: device
+                ? {
+                      serial_number: device.serialNumber,
+                      name: device.name,
+                      model: device.model,
+                  }
+                : null,
+            has_transcription: false,
+            has_summary: false,
+            links: {
+                self,
+                transcript: `${self}/transcript`,
+                audio: `${self}/audio`,
+            },
+            transcript: null,
+            summary: null,
+        };
+    }),
+}));
+
+import { db } from "@/db";
+import { recordings, webhookDeliveries, webhookEndpoints } from "@/db/schema";
+import { getV1RecordingDetailForUser } from "@/lib/v1/serialize";
+import {
+    decryptWebhookSecret,
+    decryptWebhookUrl,
+    encryptWebhookSecret,
+    maskStoredWebhookSecret,
+} from "@/lib/webhooks/secrets";
+import {
+    createWebhookSignature,
+    formatWebhookSignatureHeader,
+    verifyWebhookSignature,
+} from "@/lib/webhooks/signature";
+import { parseWebhookUrl, resolveWebhookUrl } from "@/lib/webhooks/url";
+import { deliverDueWebhooks, getWebhookBackoffMs } from "@/lib/webhooks/worker";
+
+type MockClientRequest = EventEmitter & {
+    write: Mock;
+    end: Mock;
+    destroy: Mock;
+};
+
+let lastMockRequest: MockClientRequest | null = null;
+
+function mockNodeResponse(requestMock: Mock, statusCode: number, body: string) {
+    requestMock.mockImplementation(
+        (
+            _options: RequestOptions,
+            callback: (
+                response: EventEmitter & {
+                    statusCode: number;
+                    setEncoding: Mock;
+                },
+            ) => void,
+        ) => {
+            const response = new EventEmitter() as EventEmitter & {
+                statusCode: number;
+                setEncoding: Mock;
+            };
+            response.statusCode = statusCode;
+            response.setEncoding = vi.fn();
+
+            const request = new EventEmitter() as MockClientRequest;
+            request.write = vi.fn();
+            request.end = vi.fn(() => {
+                callback(response);
+                response.emit("data", body);
+                response.emit("end");
+            });
+            request.destroy = vi.fn((error?: Error) => {
+                request.emit("error", error ?? new Error("Request destroyed"));
+            });
+            lastMockRequest = request;
+
+            return request;
+        },
+    );
+}
+
+function deliveryRow(overrides: Record<string, unknown> = {}) {
+    const now = new Date("2026-05-06T12:00:00.000Z");
+    return {
+        id: "delivery-1",
+        endpointId: "endpoint-1",
+        userId: "user-1",
+        recordingId: "rec-1",
+        event: "recording.synced",
+        payload: {
+            event: "recording.synced",
+            recording_id: "rec-1",
+            delivered_at: now.toISOString(),
+        },
+        status: "pending",
+        attempts: 0,
+        lastAttemptAt: null,
+        nextAttemptAt: now,
+        lastResponseStatus: null,
+        lastResponseBody: null,
+        lastError: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+function endpointRow(overrides: Record<string, unknown> = {}) {
+    const now = new Date("2026-05-06T12:00:00.000Z");
+    return {
+        id: "endpoint-1",
+        userId: "user-1",
+        url: "encrypted:https://example.com/webhook",
+        secret: "encrypted:whsec_abcdefghijkl",
+        events: ["recording.synced"],
+        description: null,
+        enabled: true,
+        lastDeliveryAt: null,
+        lastDeliveryStatus: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+function mockLoadedDeliveries(rows: unknown[]) {
+    const selectChain = {
+        innerJoin: vi.fn(),
+        where: vi.fn(),
+    };
+    selectChain.innerJoin.mockReturnValue(selectChain);
+    selectChain.where.mockResolvedValue(rows);
+    (db.select as Mock).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue(selectChain),
+    });
+}
+
+function mockReloadedDelivery(row: unknown | null) {
+    const selectChain = {
+        innerJoin: vi.fn(),
+        where: vi.fn(),
+        limit: vi.fn().mockResolvedValue(row ? [row] : []),
+    };
+    selectChain.innerJoin.mockReturnValue(selectChain);
+    selectChain.where.mockReturnValue(selectChain);
+    (db.select as Mock).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue(selectChain),
+    });
+    return selectChain;
+}
+
+function mockDueDeliveries(
+    rows: unknown[],
+    options: { reloadRows?: Array<unknown | null> } = {},
+) {
+    (db.execute as Mock).mockResolvedValue(
+        rows.map((row) => ({
+            id: (row as { delivery: { id: string } }).delivery.id,
+        })),
+    );
+
+    mockLoadedDeliveries(rows);
+
+    const claimedRows = rows.map((row) => ({
+        id: (row as { delivery: { id: string } }).delivery.id,
+    }));
+    (db.update as Mock).mockReturnValueOnce({
+        set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue(claimedRows),
+            }),
+        }),
+    });
+
+    const reloadRows = options.reloadRows ?? rows;
+    for (const reloadRow of reloadRows) {
+        mockReloadedDelivery(reloadRow);
+    }
+}
+
+function mockTombstonedRecording() {
+    const now = new Date("2026-05-06T12:00:00.000Z");
+    const selectChain = {
+        leftJoin: vi.fn(),
+        where: vi.fn(),
+        limit: vi.fn().mockResolvedValue([
+            {
+                recording: {
+                    id: "rec-1",
+                    filename: "Deleted Recording",
+                    startTime: new Date("2026-05-06T11:00:00.000Z"),
+                    duration: 120000,
+                    filesize: 12345,
+                    createdAt: new Date("2026-05-06T11:59:00.000Z"),
+                    updatedAt: now,
+                    deletedAt: now,
+                },
+                device: {
+                    serialNumber: "SN-1",
+                    name: "Plaud Note",
+                    model: "Note",
+                },
+            },
+        ]),
+    };
+    selectChain.leftJoin.mockReturnValue(selectChain);
+    selectChain.where.mockReturnValue(selectChain);
+    (db.select as Mock).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue(selectChain),
+    });
+    return selectChain;
+}
+
+function mockSuccessfulUpdates() {
+    const updateChain = {
+        set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: "delivery-1" }]),
+            }),
+        }),
+    };
+    (db.transaction as Mock).mockImplementation(async (callback) => {
+        await callback({
+            update: vi.fn().mockReturnValue(updateChain),
+        });
+    });
+    return updateChain;
+}
+
+function exprReferencesColumn(
+    expr: unknown,
+    col: unknown,
+    seen = new Set<unknown>(),
+): boolean {
+    if (expr == null || typeof expr !== "object") return false;
+    if (expr === col) return true;
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+
+    for (const key of [
+        "queryChunks",
+        "sql",
+        "left",
+        "right",
+        "value",
+        "args",
+        "chunks",
+        "expr",
+    ]) {
+        const value = (expr as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+            if (value.some((item) => exprReferencesColumn(item, col, seen))) {
+                return true;
+            }
+        } else if (exprReferencesColumn(value, col, seen)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function countExprColumnRefs(
+    expr: unknown,
+    col: unknown,
+    seen = new Set<unknown>(),
+): number {
+    if (expr == null || typeof expr !== "object") return 0;
+    if (expr === col) return 1;
+    if (seen.has(expr)) return 0;
+    seen.add(expr);
+
+    let count = 0;
+    for (const value of Object.values(expr as Record<string, unknown>)) {
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                count += countExprColumnRefs(item, col, seen);
+            }
+        } else {
+            count += countExprColumnRefs(value, col, seen);
+        }
+    }
+    return count;
+}
+
+function collectStringChunks(
+    value: unknown,
+    seen = new Set<unknown>(),
+): string {
+    if (typeof value === "string") return value;
+    if (value == null || typeof value !== "object") return "";
+    if (seen.has(value)) return "";
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+        return value.map((item) => collectStringChunks(item, seen)).join(" ");
+    }
+
+    return Object.values(value as Record<string, unknown>)
+        .map((item) => collectStringChunks(item, seen))
+        .join(" ");
+}
+
+function normalizedSqlText(value: unknown): string {
+    return collectStringChunks(value).replace(/\s+/g, " ").toLowerCase();
+}
+
+describe("webhooks", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockEnv.APP_URL = "https://openplaud.example";
+        mockEnv.IS_HOSTED = false;
+        mockEnv.WEBHOOKS_REQUIRE_PUBLIC_TARGETS = undefined;
+        lastMockRequest = null;
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("formats and verifies HMAC signatures", () => {
+        const body = JSON.stringify({ event: "recording.synced" });
+        const secret = "whsec_test";
+        const timestamp = 1778078610;
+        const signature = createWebhookSignature(secret, timestamp, body);
+        const header = formatWebhookSignatureHeader(secret, timestamp, body);
+
+        expect(signature).toHaveLength(64);
+        expect(header).toBe(`t=${timestamp},v1=${signature}`);
+        expect(
+            verifyWebhookSignature(secret, header, body, 300, timestamp + 60),
+        ).toBe(true);
+        expect(
+            verifyWebhookSignature(
+                secret,
+                header,
+                JSON.stringify({ event: "recording.updated" }),
+                300,
+                timestamp + 60,
+            ),
+        ).toBe(false);
+    });
+
+    it("uses the documented retry backoff schedule", () => {
+        expect(getWebhookBackoffMs(1)).toBe(30_000);
+        expect(getWebhookBackoffMs(2)).toBe(120_000);
+        expect(getWebhookBackoffMs(3)).toBe(600_000);
+        expect(getWebhookBackoffMs(4)).toBe(3_600_000);
+        expect(getWebhookBackoffMs(5)).toBe(21_600_000);
+        expect(getWebhookBackoffMs(99)).toBe(21_600_000);
+    });
+
+    it("claims candidates with per-user fair-share ranking", async () => {
+        let query: unknown;
+        (db.execute as Mock).mockImplementation((sqlQuery: unknown) => {
+            query = sqlQuery;
+            return Promise.resolve([]);
+        });
+
+        await deliverDueWebhooks();
+
+        const text = normalizedSqlText(query);
+        expect(text).toContain("row_number() over");
+        expect(text).toContain("partition by");
+        expect(text).toContain("user_rank <=");
+    });
+
+    it("rechecks due time when claiming selected deliveries", async () => {
+        let whereExpr: unknown;
+        (db.execute as Mock).mockResolvedValue([{ id: "delivery-1" }]);
+        (db.update as Mock).mockReturnValueOnce({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn((expr: unknown) => {
+                    whereExpr = expr;
+                    return {
+                        returning: vi.fn().mockResolvedValue([]),
+                    };
+                }),
+            }),
+        });
+
+        await deliverDueWebhooks();
+
+        expect(
+            countExprColumnRefs(whereExpr, webhookDeliveries.nextAttemptAt),
+        ).toBeGreaterThanOrEqual(2);
+    });
+
+    it("rechecks endpoint enablement when claiming and loading selected deliveries", async () => {
+        let claimWhereExpr: unknown;
+        let loadWhereExpr: unknown;
+        (db.execute as Mock).mockResolvedValue([{ id: "delivery-1" }]);
+        (db.update as Mock).mockReturnValueOnce({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn((expr: unknown) => {
+                    claimWhereExpr = expr;
+                    return {
+                        returning: vi
+                            .fn()
+                            .mockResolvedValue([{ id: "delivery-1" }]),
+                    };
+                }),
+            }),
+        });
+
+        const selectChain = {
+            innerJoin: vi.fn(),
+            where: vi.fn((expr: unknown) => {
+                loadWhereExpr = expr;
+                return Promise.resolve([]);
+            }),
+        };
+        selectChain.innerJoin.mockReturnValue(selectChain);
+        (db.select as Mock).mockReturnValueOnce({
+            from: vi.fn().mockReturnValue(selectChain),
+        });
+
+        await deliverDueWebhooks();
+
+        expect(normalizedSqlText(claimWhereExpr)).toContain("enabled");
+        expect(
+            exprReferencesColumn(loadWhereExpr, webhookEndpoints.enabled),
+        ).toBe(true);
+    });
+
+    it("allows self-host HTTP and local targets without DNS pinning by default", () => {
+        expect(() => parseWebhookUrl("http://n8n:5678/webhook")).not.toThrow();
+        expect(() => parseWebhookUrl("http://127.0.0.1/hook")).not.toThrow();
+        expect(() =>
+            parseWebhookUrl("https://listener.local/hook"),
+        ).not.toThrow();
+        expect(() =>
+            parseWebhookUrl("http://user:pass@n8n:5678/webhook"),
+        ).toThrow("Webhook URL must not include credentials");
+        expect(() => parseWebhookUrl("ftp://example.com/webhook")).toThrow(
+            "Webhook URL must use HTTP or HTTPS",
+        );
+    });
+
+    it("enforces HTTPS and public targets when hosted defaults strict", async () => {
+        mockEnv.IS_HOSTED = true;
+        expect(() =>
+            parseWebhookUrl("https://example.com/webhook"),
+        ).not.toThrow();
+        expect(() => parseWebhookUrl("http://example.com/webhook")).toThrow(
+            "Webhook URL must use HTTPS",
+        );
+        expect(() => parseWebhookUrl("https://localhost:3000/hook")).toThrow(
+            "Webhook URL must use a public hostname or IP address",
+        );
+
+        (lookup as unknown as Mock).mockResolvedValue([
+            { address: "93.184.216.34", family: 4 },
+        ]);
+        await expect(
+            resolveWebhookUrl("https://example.com/hook"),
+        ).resolves.toMatchObject({
+            addresses: [{ address: "93.184.216.34", family: 4 }],
+        });
+    });
+
+    it("rejects expanded IPv6 loopback targets in strict mode", async () => {
+        mockEnv.IS_HOSTED = true;
+        const message = "Webhook URL must use a public hostname or IP address";
+
+        for (const url of [
+            "https://[::]/hook",
+            "https://[::1]/hook",
+            "https://[0:0:0:0:0:0:0:0]/hook",
+            "https://[0:0:0:0:0:0:0:1]/hook",
+        ]) {
+            expect(() => parseWebhookUrl(url)).toThrow(message);
+        }
+
+        (lookup as unknown as Mock).mockResolvedValue([
+            { address: "0:0:0:0:0:0:0:1", family: 6 },
+        ]);
+        await expect(
+            resolveWebhookUrl("https://example.com/hook"),
+        ).rejects.toThrow("Webhook URL must resolve to public IP addresses");
+    });
+
+    it("lets WEBHOOKS_REQUIRE_PUBLIC_TARGETS override IS_HOSTED", () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.WEBHOOKS_REQUIRE_PUBLIC_TARGETS = false;
+        expect(() => parseWebhookUrl("http://127.0.0.1/hook")).not.toThrow();
+
+        mockEnv.IS_HOSTED = false;
+        mockEnv.WEBHOOKS_REQUIRE_PUBLIC_TARGETS = true;
+        expect(() => parseWebhookUrl("http://127.0.0.1/hook")).toThrow(
+            "Webhook URL must use HTTPS",
+        );
+    });
+
+    it("encrypts webhook secrets before storage and masks decrypted values", () => {
+        const secret = "whsec_abcdefghijkl";
+        const encrypted = encryptWebhookSecret(secret);
+
+        expect(encrypted).toBe(`encrypted:${secret}`);
+        expect(decryptWebhookSecret(encrypted)).toBe(secret);
+        expect(() => decryptWebhookSecret(secret)).toThrow(
+            "Expected encrypted webhook value",
+        );
+        expect(() => decryptWebhookUrl("https://example.com/webhook")).toThrow(
+            "Expected encrypted webhook value",
+        );
+        expect(maskStoredWebhookSecret(encrypted)).toBe("whsec_****ijkl");
+    });
+
+    it("uses http.request and no pinned lookup in permissive mode", async () => {
+        mockDueDeliveries([
+            {
+                delivery: deliveryRow(),
+                endpoint: endpointRow({
+                    url: "encrypted:http://n8n:5678/webhook",
+                }),
+            },
+        ]);
+        mockSuccessfulUpdates();
+        mockNodeResponse(httpRequest as unknown as Mock, 204, "");
+
+        await deliverDueWebhooks();
+
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(httpsRequest).not.toHaveBeenCalled();
+        expect(lookup).not.toHaveBeenCalled();
+        const requestOptions = (httpRequest as unknown as Mock).mock
+            .calls[0][0] as RequestOptions;
+        expect(requestOptions.lookup).toBeUndefined();
+        expect(requestOptions.hostname).toBe("n8n");
+
+        const requestBody = JSON.parse(
+            String(lastMockRequest?.write.mock.calls[0]?.[0] ?? "{}"),
+        ) as {
+            data?: {
+                api_url?: string;
+                links?: { transcript?: string };
+                transcript?: {
+                    text?: string;
+                    preview?: string;
+                    length?: number;
+                };
+            };
+        };
+        expect(requestBody.data?.api_url).toBe(
+            "https://openplaud.example/api/v1/recordings/rec-1",
+        );
+        expect(requestBody.data?.links?.transcript).toBe(
+            "https://openplaud.example/api/v1/recordings/rec-1/transcript",
+        );
+        expect(requestBody.data?.transcript).toMatchObject({
+            preview: "x".repeat(500),
+            truncated: true,
+            length: 600,
+        });
+        expect(requestBody.data?.transcript).not.toHaveProperty("text");
+    });
+
+    it("re-checks endpoint state immediately before posting", async () => {
+        mockDueDeliveries(
+            [
+                {
+                    delivery: deliveryRow(),
+                    endpoint: endpointRow({
+                        url: "encrypted:http://n8n:5678/webhook",
+                    }),
+                },
+            ],
+            { reloadRows: [null] },
+        );
+
+        const releaseSetSpy = vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
+        });
+        (db.update as Mock).mockReturnValueOnce({
+            set: releaseSetSpy,
+        });
+
+        await deliverDueWebhooks();
+
+        expect(httpRequest).not.toHaveBeenCalled();
+        expect(httpsRequest).not.toHaveBeenCalled();
+        expect(getV1RecordingDetailForUser).not.toHaveBeenCalled();
+        expect(releaseSetSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: "pending",
+            }),
+        );
+    });
+
+    it("uses https.request and pinned lookup in strict mode", async () => {
+        mockEnv.WEBHOOKS_REQUIRE_PUBLIC_TARGETS = true;
+        (lookup as unknown as Mock).mockResolvedValue([
+            { address: "93.184.216.34", family: 4 },
+        ]);
+        mockDueDeliveries([
+            {
+                delivery: deliveryRow(),
+                endpoint: endpointRow({
+                    url: "encrypted:https://example.com/webhook",
+                }),
+            },
+        ]);
+        mockSuccessfulUpdates();
+        mockNodeResponse(httpsRequest as unknown as Mock, 204, "");
+
+        await deliverDueWebhooks();
+
+        expect(httpsRequest).toHaveBeenCalledTimes(1);
+        expect(httpRequest).not.toHaveBeenCalled();
+        expect(getV1RecordingDetailForUser).toHaveBeenCalledWith(
+            "user-1",
+            "rec-1",
+        );
+        const requestOptions = (httpsRequest as unknown as Mock).mock
+            .calls[0][0] as RequestOptions & { lookup: LookupFunction };
+        expect(requestOptions.hostname).toBe("example.com");
+        expect(requestOptions.lookup).toBeTypeOf("function");
+
+        let resolvedAddress = "";
+        let resolvedFamily = 0;
+        requestOptions.lookup(
+            "example.com",
+            { family: 4 },
+            (error, address, family) => {
+                expect(error).toBeNull();
+                resolvedAddress =
+                    typeof address === "string"
+                        ? address
+                        : address[0]?.address || "";
+                resolvedFamily =
+                    family ??
+                    (typeof address === "string" ? 0 : address[0]?.family || 0);
+            },
+        );
+
+        expect(resolvedAddress).toBe("93.184.216.34");
+        expect(resolvedFamily).toBe(4);
+    });
+
+    it("does not auto-follow webhook delivery redirects", async () => {
+        mockDueDeliveries([
+            {
+                delivery: deliveryRow(),
+                endpoint: endpointRow({
+                    url: "encrypted:https://93.184.216.34/webhook",
+                }),
+            },
+        ]);
+        mockSuccessfulUpdates();
+        mockNodeResponse(httpsRequest as unknown as Mock, 302, "redirect");
+
+        await deliverDueWebhooks();
+
+        expect(httpsRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-checks stored endpoints against current strict policy before sending", async () => {
+        mockEnv.WEBHOOKS_REQUIRE_PUBLIC_TARGETS = true;
+        mockDueDeliveries([
+            {
+                delivery: deliveryRow(),
+                endpoint: endpointRow({
+                    url: "encrypted:http://example.com/webhook",
+                }),
+            },
+        ]);
+
+        const setSpy = vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: "delivery-1" }]),
+            }),
+        });
+        (db.transaction as Mock).mockImplementation(async (callback) => {
+            await callback({
+                update: vi.fn().mockReturnValue({
+                    set: setSpy,
+                }),
+            });
+        });
+
+        await deliverDueWebhooks();
+
+        expect(httpRequest).not.toHaveBeenCalled();
+        expect(httpsRequest).not.toHaveBeenCalled();
+        expect(getV1RecordingDetailForUser).not.toHaveBeenCalled();
+        expect(setSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: "dead",
+                lastError: "Webhook URL must use HTTPS",
+            }),
+        );
+    });
+
+    it("hydrates deleted recording webhooks from user-scoped tombstone metadata", async () => {
+        const deletedAt = new Date("2026-05-06T12:00:00.000Z");
+        mockDueDeliveries([
+            {
+                delivery: deliveryRow({
+                    event: "recording.deleted",
+                    payload: {
+                        event: "recording.deleted",
+                        recording_id: "rec-1",
+                        delivered_at: deletedAt.toISOString(),
+                    },
+                }),
+                endpoint: endpointRow({
+                    url: "encrypted:http://n8n:5678/webhook",
+                    events: ["recording.deleted"],
+                }),
+            },
+        ]);
+        const tombstoneSelect = mockTombstonedRecording();
+        const updateChain = mockSuccessfulUpdates();
+        mockNodeResponse(httpRequest as unknown as Mock, 204, "");
+
+        await deliverDueWebhooks();
+
+        expect(httpRequest).toHaveBeenCalledTimes(1);
+        expect(getV1RecordingDetailForUser).not.toHaveBeenCalled();
+        expect(tombstoneSelect.where).toHaveBeenCalled();
+        const whereExpr = tombstoneSelect.where.mock.calls[0][0];
+        expect(exprReferencesColumn(whereExpr, recordings.id)).toBe(true);
+        expect(exprReferencesColumn(whereExpr, recordings.userId)).toBe(true);
+        expect(exprReferencesColumn(whereExpr, recordings.deletedAt)).toBe(
+            true,
+        );
+        const requestBody = JSON.parse(
+            String(lastMockRequest?.write.mock.calls[0]?.[0] ?? "{}"),
+        ) as {
+            event?: string;
+            data?: {
+                id?: string;
+                title?: string;
+                deleted_at?: string;
+                transcript?: unknown;
+                summary?: unknown;
+                api_url?: string;
+                links?: { self?: string };
+            };
+        };
+
+        expect(requestBody.event).toBe("recording.deleted");
+        expect(requestBody.data).toMatchObject({
+            id: "rec-1",
+            title: "Deleted Recording",
+            deleted_at: deletedAt.toISOString(),
+            transcript: null,
+            summary: null,
+            api_url: "https://openplaud.example/api/v1/recordings/rec-1",
+        });
+        expect(requestBody.data?.links?.self).toBe(
+            "https://openplaud.example/api/v1/recordings/rec-1",
+        );
+        expect(updateChain.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: "success",
+                attempts: 1,
+                lastResponseStatus: 204,
+                lastError: null,
+            }),
+        );
+    });
+});

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -4,6 +4,8 @@
 
 export type SettingsSection =
     | "providers"
+    | "api-keys"
+    | "webhooks"
     | "transcription"
     | "summary"
     | "storage"


### PR DESCRIPTION
## Description

Merge of #80 (luisalrp:feat/automation-api-webhooks) rebased on current `main`, with #108 folded in and the migration set renumbered to land cleanly on top of the v0.4.0 admin schema.

Adds the automation surface from #79: revocable personal API keys, a versioned `/api/v1/recordings` surface for external agents, signed webhooks with delivery tracking and retries, and settings UI for managing both.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Closes #79
Closes #108

## Changes Made

- New `/api/v1/*` namespace: `GET /v1/recordings` with cursor pagination + `created_since` / `updated_since` / `has_transcription` filters, `GET /v1/recordings/[id]`, `/transcript`, `/audio` (S3 redirect or local range stream).
- Personal API keys (`op_...`), HMAC-SHA256 hashed at rest keyed by `API_TOKEN_HASH_SECRET ?? BETTER_AUTH_SECRET`, with `source` / `name` / `lastUsedAt` metadata, prefix display, and revocation. Settings UI under `/api/settings/api-keys`.
- Signed webhooks (HMAC-SHA256, `t=...,v1=...` header) for `recording.synced`, `recording.updated`, `recording.deleted`, `transcription.completed`, `transcription.failed`. URL + secret encrypted at rest via `src/lib/encryption.ts`. Per-user fairness in the worker, DB-leased claim, exponential backoff (30s -> 6h, then dead), manual redelivery via settings UI.
- Webhook target policy switches on `WEBHOOKS_REQUIRE_PUBLIC_TARGETS ?? IS_HOSTED`: hosted requires HTTPS + public hostnames + DNS pinning; self-host stays permissive so docker-bridge URLs like `http://n8n:5678/webhook` keep working.
- Per-IP and per-identity rate limiting on `/api/v1/*` (1200/min IP, 600/min identity) with `Retry-After` and `X-RateLimit-*` headers. Hosted mode hard-requires `RATE_LIMIT_TRUST_PROXY_HEADERS=true` at boot.
- User-scoping pass on routes the v1 surface shares: `recordings/[id]`, `summary`, `transcribe`, sync hot path (`processRecording`, `uniqueStorageKey`). Recordings unique constraint changed from `plaud_file_id` global to `(user_id, plaud_file_id)` composite.
- v1 transcript paths integrate with encrypted-at-rest content (#96): serializers decrypt before returning to API consumers; webhook transcript previews ship plaintext bounded to 500 chars with `truncated`/`length`/`apiUrl`.
- New routes use the unified `{ error, code, details }` envelope from #97.
- Adds `instrumentation.ts` to start the in-process webhook worker on Node.js runtime.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): not run locally

### Test Steps
1. `pnpm format-and-lint:fix` - clean.
2. `pnpm type-check` - clean.
3. `pnpm test` - 270 passed / 3 skipped (Plaud integration tests skip without `PLAUD_BEARER_TOKEN`).
4. `pnpm db:generate` - confirms `0019_massive_spectrum.sql` matches `schema.ts` with no drift.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [x] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

Renumbered the PR's migration to `0019_massive_spectrum.sql` so it lands cleanly on top of `0018_quick_joshua_kane.sql` (v0.4.0 admin schema). The new migration only contains the automation-API delta: `api_key_source` enum, `api_keys`, `api_rate_limit_buckets`, `webhook_endpoints`, `webhook_deliveries`, and the `recordings` unique-constraint swap from `plaud_file_id` to `(user_id, plaud_file_id)`.

## Breaking Changes

None for self-host. New env vars are optional:

- `API_TOKEN_HASH_SECRET` (optional; falls back to `BETTER_AUTH_SECRET`)
- `WEBHOOKS_REQUIRE_PUBLIC_TARGETS` (optional; defaults to `IS_HOSTED`)
- `RATE_LIMIT_TRUST_PROXY_HEADERS` (optional; defaults to `false`)

Hosted-mode operators must set `RATE_LIMIT_TRUST_PROXY_HEADERS=true` or the app refuses to start at boot. Documented in `.env.example` and `docs/API.md`.

## Additional Notes

- Squash commit authored by @luisalrp with co-author trailer for the merge / rebase / migration-renumber work. PR #80 will be closed with a thank-you on merge.
- Real-Plaud sync smoke test still pending maintainer-side because `PLAUD_BEARER_TOKEN` is not in CI; the `processRecording` / `uniqueStorageKey` user-scoping is exactly the hot path AGENTS.md flags.
- CHANGELOG entry at release: `Added` for v1 API + webhooks + API keys, with sub-notes under `Changed` for the recordings unique-constraint swap and the new hosted-mode `RATE_LIMIT_TRUST_PROXY_HEADERS` requirement.

## For Reviewers

- User-scoping correctness on the v1 routes and the now-tightened existing routes (`recordings/[id]`, `summary`, `transcribe`, sync).
- Webhook worker: DB-leased claim, per-user fairness, backoff/dead semantics, and the `recording.deleted` tombstone hydration path.
- Encryption-at-rest integration on v1 transcript reads + bounded webhook previews.
- Hosted-mode `RATE_LIMIT_TRUST_PROXY_HEADERS=true` boot-time requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds personal API keys, a versioned `/api/v1/recordings` API, and signed webhooks for safe automation and integrations. Also hardens deletes and sync, fixes audio range handling, tightens scoping and rate limits, and improves webhook validation and UI.

- **New Features**
  - Personal API keys (`op_...`), HMAC-SHA256 hashed at rest via `API_TOKEN_HASH_SECRET ?? BETTER_AUTH_SECRET`, with `name`, `source`, `lastUsedAt`, prefix display, and revocation at `/api/settings/api-keys`.
  - Versioned API under `/api/v1/recordings`: list (cursor pagination; `created_since`/`updated_since`/`has_transcription`), detail, transcript, and audio redirect; unified `{ error, code, details }` responses.
  - Rate limits for `/api/v1/*`: 1200/min per IP and 600/min per identity with `Retry-After` and `X-RateLimit-*` headers.
  - Signed webhooks for `recording.synced|updated|deleted` and `transcription.completed|failed` using `t=...,v1=...` HMAC-SHA256 headers; URL/secret encrypted at rest; delivery tracking with backoff and manual redelivery at `/api/settings/webhooks`.
  - Target policy: `WEBHOOKS_REQUIRE_PUBLIC_TARGETS ?? IS_HOSTED` requires HTTPS public targets on hosted; self-host allows local URLs (e.g., `http://n8n:5678/webhook`).
  - Hardening: lock the parent row at the start of DELETE transactions; re-check tombstones in a transaction before update+emit; prevent duplicate `recording.deleted` events; clean up orphaned storage when a concurrent tombstone is detected during sync; correct RFC 7233 audio range clamping; reject unknown webhook events with 400; clear stale deliveries when switching endpoints; user scoping tightened and transcript previews are plaintext capped at 500 chars.

- **Migration**
  - DB: adds `api_keys`, `api_rate_limit_buckets`, `webhook_endpoints`, `webhook_deliveries`; changes recordings uniqueness to `(user_id, plaud_file_id)`; drops redundant `api_keys.key_hash` index. Migration: `0019_lucky_swordsman.sql`.
  - Env (optional): `API_TOKEN_HASH_SECRET`, `WEBHOOKS_REQUIRE_PUBLIC_TARGETS`, `RATE_LIMIT_TRUST_PROXY_HEADERS`. Hosted must set `RATE_LIMIT_TRUST_PROXY_HEADERS=true` or boot fails.
  - Worker: in-process webhook worker starts via `instrumentation.ts` on the Node.js runtime.
  - Docs: `docs/API.md` updated with auth, endpoints, rate limits, and webhook signing.

<sup>Written for commit af6e5a3ced485fcc5df765ca7ec70752ed7fbf4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

