### PR TITLE
docs(agents): require db:generate for rebases and renumbering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,8 @@ Decrypt only at the moment of HTTP request construction. Never log decrypted val
 
 Always edit `src/db/schema.ts` first, then run `pnpm db:generate` to produce the migration. **NEVER hand-write migration SQL files.** Drizzle tracks migrations via snapshot files in `src/db/migrations/meta/` — hand-written files don't generate snapshots, which causes future `db:generate` runs to re-emit already-applied columns. That's silent history corruption.
 
+Same applies to rebases, conflict resolution, and renumbering: rerun `pnpm db:generate` against the rebased schema. Never hand-edit `meta/_journal.json` or `meta/*_snapshot.json`.
+
 If drizzle-kit generates SQL that re-adds columns that already exist, meta snapshots are out of sync with reality. **Fix the drift, don't hand-edit around it.** Migrations `0010-0012` are historical examples of this drift; `0013+` are clean.
 
 ## Architecture Notes


### PR DESCRIPTION
## Summary
- Adds one sentence to the Database Migrations CRITICAL block in `AGENTS.md` clarifying that the existing "edit `schema.ts` then `pnpm db:generate`" rule also applies to rebases, conflict resolution, and migration renumbering.
- Motivated by #118: when resolving the `0018` migration-number collision against `main`'s admin migration, the right move was to drop the PR's snapshot/journal entries and rerun `pnpm db:generate`, not hand-edit the journal.

## Testing
- Not run (docs-only change).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified migration docs in `AGENTS.md`: on rebases, conflict resolution, or renumbering, update `src/db/schema.ts` and rerun `pnpm db:generate`.

Explicitly disallows hand-editing Drizzle meta files (`src/db/migrations/meta/_journal.json` and `*_snapshot.json`) to prevent snapshot drift and duplicate column SQL.

<sup>Written for commit 72a2fbc6ca68f6ce99006766a75c2faba46a3f5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

