### PR TITLE
feat(ui): show running version and self-host update badge; fix release drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ APP_URL=http://localhost:3000
 # closed self-host instances. Defaults to `false` (registration open).
 # DISABLE_REGISTRATION=false
 
+# Disable the self-host "update available" check. When unset/`false`,
+# the footer fetches the latest release tag from api.github.com (cached
+# 5 minutes) and shows a small "update available" link when a newer
+# version exists. Set to `true` if your instance blocks outbound HTTPS
+# or you don't want any phone-home behavior. Has no effect when
+# IS_HOSTED=true (the hosted instance hides the badge anyway).
+# DISABLE_UPDATE_CHECK=false
+
 # ----------------------------------------------------------------------
 # Admin dashboard (HOSTED-ONLY -- self-hosters: leave all of these blank)
 # ----------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,17 @@ jobs:
       contents: write
 
     steps:
+      # Check out the tag the workflow is publishing for, not the
+      # branch the dispatch came from. On `push: tags: v*` this is the
+      # tag commit by default; on `workflow_dispatch` `actions/checkout`
+      # otherwise defaults to the dispatch branch (typically `main`),
+      # which would make the tag/package.json gate below read main's
+      # package.json instead of the tag's. Either way, pin to the input
+      # tag when present.
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: Determine tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,25 @@ jobs:
           fi
           echo "tag=$PREV" >> "$GITHUB_OUTPUT"
 
+      # Hard gate: refuse to publish if package.json doesn't match the tag.
+      # This is the structural fix for the drift that produced issue #123
+      # (tag v0.4.1 published while main still said 0.2.0). The normal
+      # release path can't trip this -- scripts/release.ts bumps before
+      # tagging -- but a manual tag, a bad rebase, or a hand-edited
+      # package.json all can. Fail loud rather than ship a mislabeled
+      # GitHub Release.
+      - name: Verify package.json matches tag
+        env:
+          TAG: ${{ steps.tag.outputs.current }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="${TAG#v}"
+          if [ "$PKG_VERSION" != "$EXPECTED" ]; then
+            echo "::error file=package.json::package.json version ($PKG_VERSION) does not match tag ($TAG). Push the release bump commit to main before tagging."
+            exit 1
+          fi
+
       # Pull release notes straight from CHANGELOG.md. The maintainer-curated
       # `## [X.Y.Z]` section is the single source of truth -- the workflow
       # just extracts it. Fail loud if the section is missing so we never

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.2.0",
+    "version": "0.4.2",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -133,10 +133,31 @@ stage();
 run(`git commit -m "chore: add [Unreleased] section for next cycle"`);
 
 console.log("\nPushing main + tag atomically...");
-// Single push: both commits and the tag go up together, or none do.
-// If main has diverged on the remote, the push fails before the tag
-// is published — rebase locally and rerun.
-run(`git push origin main v${version}`);
+// `--atomic` makes the push a single transaction: either every ref
+// update lands or none of them do. Without it, git pushes refs
+// sequentially and the tag could be published while `main` is
+// rejected (or vice versa) -- the exact half-state we're trying to
+// prevent.
+//
+// If the push fails (diverged remote, server-side hook reject), the
+// local tag and the two new commits stay on the local main. We catch
+// the failure explicitly here so we can print recovery commands
+// rather than dying through run()'s generic handler -- otherwise the
+// maintainer's next attempt trips on `git tag` (already exists) and
+// `assertCleanOnMain` (the two commits are ahead of origin/main).
+try {
+	execSync(`git push --atomic origin main v${version}`, { stdio: "inherit" });
+} catch {
+	console.error("\nError: push failed. Local state still has:");
+	console.error(`  - tag v${version}`);
+	console.error("  - 2 commits ahead of origin/main (release + [Unreleased] cycle)");
+	console.error("\nTo retry after rebasing:");
+	console.error(`  git tag -d v${version}`);
+	console.error("  git reset --hard origin/main");
+	console.error("  git pull --rebase origin main");
+	console.error("  bun scripts/release.ts <target>");
+	process.exit(1);
+}
 
 console.log(`\n=== Released v${version} ===`);
 console.log("Next steps:");

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -11,12 +11,17 @@
  *   2. Bump version in package.json
  *   3. Rewrite CHANGELOG.md: [Unreleased] -> [X.Y.Z] - <date>
  *   4. Commit (release commit), tag vX.Y.Z
- *   5. Push tag (NOT main — release commit goes through normal review/push)
- *   6. Re-add empty [Unreleased] section, commit
+ *   5. Re-add empty [Unreleased] section, commit
+ *   6. Push main + tag in one atomic push
  *
- * The script stops after pushing the tag. GitHub workflows (docker.yml,
- * release.yml) take over from there. Per AGENTS.md, agents do not invoke
- * this — it's a maintainer action.
+ * The push is atomic on purpose: if `main` has diverged on the remote,
+ * the whole push fails and the tag isn't published, so we never end up
+ * in a state where the tag exists but `main` doesn't include the
+ * version bump (that's how `package.json` drifted to `0.2.0` behind
+ * `v0.4.1` before — see issue #123). Rebase locally and rerun.
+ *
+ * After push, GitHub workflows (docker.yml, release.yml) take over.
+ * Per AGENTS.md, agents do not invoke this — it's a maintainer action.
  *
  * Files staged are explicitly listed (package.json, CHANGELOG.md). No
  * `git add -A` / `git add .` — see AGENTS.md.
@@ -122,16 +127,18 @@ stage();
 run(`git commit -m "chore(release): v${version}"`);
 run(`git tag v${version}`);
 
-console.log("\nPushing tag (not main — push the release commit yourself after review)...");
-run(`git push origin v${version}`);
-
-console.log("\nAdding [Unreleased] section for next cycle...");
+console.log("Adding [Unreleased] section for next cycle...");
 addUnreleasedSection();
 stage();
 run(`git commit -m "chore: add [Unreleased] section for next cycle"`);
 
-console.log(`\n=== Tagged v${version} ===`);
+console.log("\nPushing main + tag atomically...");
+// Single push: both commits and the tag go up together, or none do.
+// If main has diverged on the remote, the push fails before the tag
+// is published — rebase locally and rerun.
+run(`git push origin main v${version}`);
+
+console.log(`\n=== Released v${version} ===`);
 console.log("Next steps:");
-console.log("  1. git push origin main   # pushes release commit + [Unreleased] commit");
-console.log("  2. Wait for docker.yml + release.yml workflows");
-console.log("  3. Review and publish the draft GitHub Release");
+console.log("  1. Wait for docker.yml + release.yml workflows");
+console.log("  2. Review and publish the draft GitHub Release");

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
+import { APP_VERSION } from "@/lib/version";
 
 export async function GET() {
-    return NextResponse.json({ status: "ok" });
+    return NextResponse.json({ status: "ok", version: APP_VERSION });
 }

--- a/src/app/install.sh/route.ts
+++ b/src/app/install.sh/route.ts
@@ -3,7 +3,7 @@ import {
     INSTALL_SCRIPT_HEADERS,
     renderInstallScript,
 } from "@/lib/install-script";
-import packageJson from "../../../package.json" with { type: "json" };
+import { APP_VERSION_TAG } from "@/lib/version";
 
 // Always-latest installer entry point. Shape:
 //   curl -fsSL https://openplaud.com/install.sh | sh
@@ -16,10 +16,8 @@ import packageJson from "../../../package.json" with { type: "json" };
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const FALLBACK_VERSION = `v${packageJson.version}`;
-
 export async function GET() {
-    const tag = (await fetchLatestReleaseTag()) ?? FALLBACK_VERSION;
+    const tag = (await fetchLatestReleaseTag()) ?? APP_VERSION_TAG;
     const script = await renderInstallScript(tag);
     return new Response(script, { headers: INSTALL_SCRIPT_HEADERS });
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,9 +1,10 @@
-"use client";
-
 import { Heart } from "lucide-react";
 import Link from "next/link";
+import { Suspense } from "react";
 import { Github } from "@/components/icons/icons";
 import { Logo } from "@/components/icons/logo";
+import { UpdateBadge } from "@/components/update-badge";
+import { APP_RELEASE_URL, APP_VERSION_TAG } from "@/lib/version";
 
 export function Footer() {
     const currentYear = new Date().getFullYear();
@@ -74,6 +75,21 @@ export function Footer() {
                         >
                             <Github className="size-4 text-muted-foreground/50 hover:text-muted-foreground transition-colors" />
                         </Link>
+                        <Link
+                            href={APP_RELEASE_URL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors font-mono uppercase tracking-wider"
+                            aria-label={`Release notes for OpenPlaud ${APP_VERSION_TAG}`}
+                        >
+                            {APP_VERSION_TAG}
+                        </Link>
+                        {/* Self-host-only update notice. Suspended with a null
+                            fallback so a cold GitHub-API cache doesn't block
+                            the rest of the footer from streaming. */}
+                        <Suspense fallback={null}>
+                            <UpdateBadge />
+                        </Suspense>
                         <div className="flex gap-1">
                             {[...Array(3)].map((_, i) => (
                                 <div

--- a/src/components/update-badge.tsx
+++ b/src/components/update-badge.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { env } from "@/lib/env";
+import { fetchLatestReleaseTag } from "@/lib/install-script";
+
+import { APP_VERSION, compareSemver, releaseUrlFor } from "@/lib/version";
+
+/**
+ * Self-host-only "update available" indicator. Renders nothing on the
+ * hosted instance (operators control deploys there -- a badge would be
+ * noise + leak of internal state) and nothing when the operator opts
+ * out via `DISABLE_UPDATE_CHECK=true`.
+ *
+ * Failure modes degrade silently to "no badge":
+ *   - GitHub API down / rate-limited      -> fetchLatestReleaseTag() returns null
+ *   - Egress blocked at network layer     -> fetchLatestReleaseTag() returns null
+ *   - Tag doesn't match `vX.Y.Z` shape    -> fetchLatestReleaseTag() returns null
+ *   - Current version >= latest            -> returns null here
+ *
+ * The fetch is cached 5 minutes (Next `revalidate: 300`) so this runs
+ * at most ~12 times/hour per server, regardless of traffic.
+ *
+ * Server component on purpose: `env.IS_HOSTED` and `env.DISABLE_UPDATE_CHECK`
+ * are server-only, and we don't want the badge to hydrate / flash on
+ * the client.
+ */
+export async function UpdateBadge() {
+    if (env.IS_HOSTED) return null;
+    if (env.DISABLE_UPDATE_CHECK) return null;
+
+    const latestTag = await fetchLatestReleaseTag();
+    if (!latestTag) return null;
+    if (compareSemver(APP_VERSION, latestTag) >= 0) return null;
+
+    return (
+        <Link
+            href={releaseUrlFor(latestTag)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[10px] text-primary/70 hover:text-primary transition-colors font-mono uppercase tracking-wider underline decoration-dotted underline-offset-2"
+            aria-label={`Update available: ${latestTag}`}
+            title={`Update available: ${latestTag} (running ${APP_VERSION})`}
+        >
+            {latestTag} available
+        </Link>
+    );
+}

--- a/src/components/update-badge.tsx
+++ b/src/components/update-badge.tsx
@@ -29,7 +29,14 @@ export async function UpdateBadge() {
 
     const latestTag = await fetchLatestReleaseTag();
     if (!latestTag) return null;
-    if (compareSemver(APP_VERSION, latestTag) >= 0) return null;
+    // `compareSemver` returns null when either input fails to parse as
+    // X.Y.Z -- treat that as "can't determine, hide the badge" rather
+    // than surface a misleading or crashing UI. APP_VERSION is sourced
+    // from package.json and not pre-validated against the tag regex,
+    // so a malformed local version (e.g. "0.4.2-dirty") lands here.
+    const cmp = compareSemver(APP_VERSION, latestTag);
+    if (cmp === null) return null;
+    if (cmp >= 0) return null;
 
     return (
         <Link

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,6 +36,18 @@ export const envSchema = z.object({
         .optional()
         .transform((val) => val === "true"),
 
+    // Disable the self-host update-available check (GitHub releases API).
+    // When `true`, the footer never reaches out to api.github.com to look
+    // for a newer release tag. Useful for instances with strict egress
+    // controls or operators who don't want any phone-home behavior.
+    // Defaults to `false` (check enabled). Inert when IS_HOSTED=true --
+    // the hosted instance hides the badge unconditionally because the
+    // operator (us) controls deploys.
+    DISABLE_UPDATE_CHECK: z
+        .string()
+        .optional()
+        .transform((val) => val === "true"),
+
     // Server-required values are optional at schema level so that `next build`
     // (phase-production-build) doesn't depend on server-only secrets.
     DATABASE_URL: z.string().optional(),
@@ -176,6 +188,7 @@ function validateEnv(): Env {
         const parsed = envSchema.parse({
             IS_HOSTED: process.env.IS_HOSTED,
             DISABLE_REGISTRATION: process.env.DISABLE_REGISTRATION,
+            DISABLE_UPDATE_CHECK: process.env.DISABLE_UPDATE_CHECK,
             DATABASE_URL: process.env.DATABASE_URL,
             BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
             API_TOKEN_HASH_SECRET: process.env.API_TOKEN_HASH_SECRET,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,45 @@
+import packageJson from "../../package.json" with { type: "json" };
+
+/**
+ * Single source of truth for the running OpenPlaud version.
+ *
+ * Sourced from `package.json` at build time so there's no runtime fs
+ * read and no extra bundle weight (Next inlines the import as a string
+ * constant). Anything user-visible — footer, /api/health, install
+ * script — reads from here so we don't grow a second "what version
+ * are we?" code path.
+ *
+ * Drift between this value and the latest published GitHub tag is
+ * caught by `.github/workflows/release.yml` (tag/version equality
+ * gate). If those disagree, the release fails loud rather than
+ * publishing a mislabeled artifact.
+ */
+export const APP_VERSION = packageJson.version;
+export const APP_VERSION_TAG = `v${packageJson.version}`;
+export const APP_RELEASE_URL = `https://github.com/openplaud/openplaud/releases/tag/${APP_VERSION_TAG}`;
+
+/**
+ * Compare two 3-part dotted version strings ("0.4.2", "0.5.0"). Returns
+ * -1 / 0 / 1 with the usual semantics. Tolerates a leading `v`.
+ *
+ * Not a full semver implementation -- OpenPlaud tags are all bare
+ * `vX.Y.Z` (enforced by `isValidVersionTag` in install-script.ts), so
+ * three integers is all we need. No prerelease, no build metadata.
+ * Adding the `semver` dep for three integer compares would be silly.
+ */
+export function compareSemver(a: string, b: string): -1 | 0 | 1 {
+    const ap = a.replace(/^v/, "").split(".").map(Number);
+    const bp = b.replace(/^v/, "").split(".").map(Number);
+    for (let i = 0; i < 3; i++) {
+        const av = ap[i] ?? 0;
+        const bv = bp[i] ?? 0;
+        if (Number.isNaN(av) || Number.isNaN(bv)) return 0;
+        if (av < bv) return -1;
+        if (av > bv) return 1;
+    }
+    return 0;
+}
+
+export function releaseUrlFor(tag: string): string {
+    return `https://github.com/openplaud/openplaud/releases/tag/${tag}`;
+}

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -20,22 +20,38 @@ export const APP_RELEASE_URL = `https://github.com/openplaud/openplaud/releases/
 
 /**
  * Compare two 3-part dotted version strings ("0.4.2", "0.5.0"). Returns
- * -1 / 0 / 1 with the usual semantics. Tolerates a leading `v`.
+ * -1 / 0 / 1 with the usual semantics, or `null` if either input is
+ * not a parseable bare `X.Y.Z` (optionally `v`-prefixed).
  *
  * Not a full semver implementation -- OpenPlaud tags are all bare
  * `vX.Y.Z` (enforced by `isValidVersionTag` in install-script.ts), so
  * three integers is all we need. No prerelease, no build metadata.
  * Adding the `semver` dep for three integer compares would be silly.
+ *
+ * Returning `null` (rather than throwing or returning 0) on bad input
+ * is deliberate: callers like UpdateBadge surface updates via
+ * `cmp < 0`, and silently coercing a malformed input to "equal" would
+ * hide legitimate updates. Forcing callers to handle the null branch
+ * keeps the failure mode explicit. Tag inputs from the GitHub API are
+ * already pre-validated by `isValidVersionTag`; APP_VERSION comes
+ * from package.json and is not pre-validated -- this is where the
+ * null branch matters.
  */
-export function compareSemver(a: string, b: string): -1 | 0 | 1 {
-    const ap = a.replace(/^v/, "").split(".").map(Number);
-    const bp = b.replace(/^v/, "").split(".").map(Number);
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+    const parts = (s: string): [number, number, number] | null => {
+        const p = s.replace(/^v/, "").split(".");
+        if (p.length !== 3) return null;
+        const nums = p.map(Number);
+        if (nums.some((n) => Number.isNaN(n) || !Number.isFinite(n) || n < 0))
+            return null;
+        return [nums[0], nums[1], nums[2]];
+    };
+    const ap = parts(a);
+    const bp = parts(b);
+    if (!ap || !bp) return null;
     for (let i = 0; i < 3; i++) {
-        const av = ap[i] ?? 0;
-        const bv = bp[i] ?? 0;
-        if (Number.isNaN(av) || Number.isNaN(bv)) return 0;
-        if (av < bv) return -1;
-        if (av > bv) return 1;
+        if (ap[i] < bp[i]) return -1;
+        if (ap[i] > bp[i]) return 1;
     }
     return 0;
 }


### PR DESCRIPTION
## Description

Closes #123. Surfaces the running OpenPlaud version in the UI, adds a self-host-only "update available" badge, and structurally fixes the release-script drift that produced the issue (package.json on main was `0.2.0` behind tagged `v0.4.1`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — version drift
- [x] New feature (non-breaking change which adds functionality) — version footer + update badge
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #123

## Changes Made

Three focused commits:

1. **`chore(release): bump package.json to 0.4.2`** — resets the baseline so the new CI gate doesn't trip on existing skew.
2. **`ci(release): prevent package.json/tag drift`**
   - `scripts/release.ts` now creates both commits before pushing, then pushes `main` and the tag atomically (`git push origin main vX.Y.Z`). If `main` has diverged on the remote the whole push fails and the tag is not published — no more half-states. Removes the two-step ritual where the maintainer had to remember to push `main` separately after the script.
   - `.github/workflows/release.yml` gains a tag/version equality gate before CHANGELOG extraction. Fails loud if `package.json` ≠ tag (catches manual tags, rebases, hand-edits the script can't catch).
3. **`feat(ui): show running version and self-host update badge`**
   - New `src/lib/version.ts` — single source of truth (`APP_VERSION`, `APP_VERSION_TAG`, `APP_RELEASE_URL`, three-int `compareSemver`). Sourced from `package.json` at build time, no runtime fs read.
   - Footer renders the version as a link to its release notes. Dropped the gratuitous `"use client"` on `Footer` (no client behavior; the boundary was making it impossible to mount an async server component inline).
   - New `src/components/update-badge.tsx` — async RSC, Suspense-wrapped with `fallback={null}`. Renders only when `!IS_HOSTED && !DISABLE_UPDATE_CHECK && latestTag > APP_VERSION`. Reuses `fetchLatestReleaseTag()` (5-min Next-fetch cache, so ~12 calls/hr/server max). Silent degrade on any failure.
   - `/api/health` response gains a `version` field (additive).
   - `src/app/install.sh/route.ts` refactored to consume `APP_VERSION_TAG` from the helper (no more parallel `package.json` imports).
   - New env var `DISABLE_UPDATE_CHECK` (optional bool, default `false`) — opt-out for operators who block outbound or don't want phone-home. Documented in `.env.example`.

## Screenshots (if applicable)

Footer bottom row, self-host with an upgrade available:

```
••• Open Source • Built for the Community  [GitHub]  v0.4.2  v0.5.0 available  •••
```

Hosted (`IS_HOSTED=true`) and self-host on the latest tag: badge is absent; everything else identical.

## Testing

### Test Environment
- OS: macOS (local dev)
- Node version: 20 (per CI), pnpm 10.18.1
- Browser: not required for these changes

### Test Steps
1. `pnpm install --frozen-lockfile` — clean
2. `pnpm type-check` — clean
3. `pnpm format-and-lint` — only 2 pre-existing infos in `src/tests/admin/elevated-cookie.test.ts` (untouched by this PR)

Visibility matrix walked manually against the code paths:

| Condition | Badge |
|---|---|
| `IS_HOSTED=true` | hidden |
| `DISABLE_UPDATE_CHECK=true` | hidden |
| GitHub API down / rate-limited / malformed | hidden (silent) |
| `APP_VERSION >= latest tag` | hidden |
| Self-host, check enabled, newer tag exists | shown |

`pnpm test` not run — no test files added or modified by this PR, and the changes are server-render + config gates without testable branching logic beyond `compareSemver` (three-int, trivially correct). Happy to add a focused unit test for `compareSemver` and `UpdateBadge` visibility if you want it.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (release script, env var rationale, suspense fallback reasoning)
- [x] I have made corresponding changes to the documentation (`.env.example`)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — see Testing note above
- [x] New and existing unit tests pass locally with my changes — not run (no test changes); `pnpm test` left for CI
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published — n/a

## Database Changes

None.

## Breaking Changes

None. Deploy surface impact:

- **New env var `DISABLE_UPDATE_CHECK`** — optional, defaults `false`. Additive. Existing self-host deploys get the badge by default; operators who don't want it can opt out.
- **`/api/health`** — response gains a `version` field. Existing consumers reading `status` are unaffected.
- **`docker-compose.yml`** — untouched.
- **Schema** — untouched.

## Additional Notes

- `CHANGELOG.md` deliberately not touched — per `AGENTS.md` it's maintainer-curated at release time. Suggested `[Unreleased]` entries: under **Added** "Running version link in footer + self-host update-available badge", "`DISABLE_UPDATE_CHECK` env var"; under **Fixed** "Release script no longer leaves `main` behind tag — `git push origin main` is no longer a manual second step".
- `ci.yml` has `continue-on-error: true` on the type-check job (line 65). Out of scope for this PR but a louder smell than the version drift — type errors silently pass CI today. Worth a separate cleanup.
- The 2 lint infos in `src/tests/admin/elevated-cookie.test.ts` are pre-existing and unrelated; left for a separate sweep.

## For Reviewers

Focus areas, in order of risk:

- **`scripts/release.ts`** atomic push — verify the new ordering (release commit → tag → `[Unreleased]` commit → single push of `main`+tag) matches your mental model of what should happen if the remote `main` has diverged. The intent is that a diverged remote causes the whole push to fail *before* anything is published, so the recovery is just `git pull --rebase main` and rerun. Tag is created locally before push; if push fails the local tag will need deleting before retry — should that be wrapped in a recovery hint?
- **`UpdateBadge` gating** — confirm the `!IS_HOSTED && !DISABLE_UPDATE_CHECK` posture is what you want. Alternative framings: opt-in (default off), or `IS_HOSTED` not gating it at all. Current default chosen because (a) self-hosters benefit from drift visibility most, (b) hosted users seeing "update available" when we control the version is just confusing.
- **Phone-home framing** — the badge does hit `api.github.com` by default on self-host. Documented prominently in `.env.example`. Worth mirroring in `README.md` self-host section so it isn't a surprise? Not done here to keep the PR scoped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the running version in the footer and adds a self-host “update available” badge. Fixes #123 by making release pushes atomic and tightening CI so tags and `package.json` stay in sync.

- **New Features**
  - Added `src/lib/version.ts` as the single source of truth; footer shows the current version linking to its release notes.
  - Self-host-only update badge when a newer tag exists; gated by `IS_HOSTED` and `DISABLE_UPDATE_CHECK` (5‑min cache, silent on failures).
  - `/api/health` now includes `version`.

- **Bug Fixes**
  - Atomic release: `scripts/release.ts` pushes `main`+tag with `--atomic` and prints recovery steps if the push fails.
  - CI guard: `.github/workflows/release.yml` checks out the tagged ref on publish and fails when `package.json` version ≠ tag.
  - Hardened `compareSemver` to return `null` on invalid input so a malformed local version doesn’t hide the update badge.
  - Bumped `package.json` to `0.4.2` to realign.

<sup>Written for commit 2572f9633ac38d373badbd024b41bcec7ddc3953. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

