### PR TITLE
feat(footer): mature footer for hosted product; add /install, /privacy, /terms

### DIFF
--- a/src/app/(legal)/layout.tsx
+++ b/src/app/(legal)/layout.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Logo } from "@/components/icons/logo";
+import { LandingFooter } from "@/components/landing-footer";
+import { env } from "@/lib/env";
+
+/**
+ * Layout for the legal route group (`/privacy`, `/terms`). Deliberately
+ * separate from `(app)` -- legal pages are linked from the public
+ * landing footer, so they must render for signed-out visitors without
+ * any in-app chrome (no sidebar, no auth-required wrappers).
+ *
+ * Hosted-only by design. These pages describe the terms of the hosted
+ * service we operate; on a self-host instance there is no "we" running
+ * a service, so the docs simply don't apply -- 404 rather than serve
+ * misleading legal text. Centralizing the `notFound()` check at the
+ * layout means every route in the group inherits the guard with one
+ * line.
+ */
+export default function LegalLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    if (!env.IS_HOSTED) {
+        notFound();
+    }
+
+    return (
+        <div className="flex flex-col min-h-[100vh]">
+            <header className="border-b border-border/40">
+                <div className="container mx-auto px-4 max-w-3xl flex h-16 items-center">
+                    <Link
+                        href="/"
+                        className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+                    >
+                        <Logo className="size-7" />
+                        <span className="text-lg font-bold tracking-tight font-mono">
+                            OpenPlaud
+                        </span>
+                    </Link>
+                </div>
+            </header>
+            <main className="flex-1">
+                <article className="container mx-auto px-4 max-w-3xl py-16 md:py-24 [&_h1]:text-3xl [&_h1]:md:text-4xl [&_h1]:font-bold [&_h1]:font-mono [&_h1]:tracking-tight [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:font-mono [&_h2]:tracking-tight [&_h2]:mt-10 [&_h2]:mb-3 [&_p]:text-muted-foreground [&_p]:leading-relaxed [&_p]:mb-4 [&_a]:text-foreground [&_a]:underline [&_a]:decoration-dotted [&_a]:underline-offset-2 [&_a]:hover:text-foreground/80 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-muted-foreground [&_ul]:mb-4 [&_li]:mb-1">
+                    {children}
+                </article>
+            </main>
+            <LandingFooter />
+        </div>
+    );
+}

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+/*
+ * TODO(legal): Replace this placeholder with the real privacy policy
+ * before hosted GA. This is a structural stub so the footer's Privacy
+ * link is not a dead link -- the content here is NOT a legal document
+ * and must not be treated as one. Coordinate with counsel on:
+ *   - Data controller / processor framing
+ *   - Sub-processors (AI providers, S3 host, email, analytics)
+ *   - International transfer mechanism (SCCs)
+ *   - User rights (access, deletion, export -- export is already
+ *     implemented via the full-backup endpoint)
+ *   - Retention defaults and overrides
+ *   - Cookie / tracking disclosure (Rybbit only, no third-party ads)
+ *   - Contact for data requests (privacy@openplaud.com -- needs
+ *     mailbox if we want to use it)
+ */
+
+export const metadata: Metadata = {
+    title: "Privacy Policy — OpenPlaud",
+    description: "How OpenPlaud handles your data on the hosted service.",
+};
+
+export default function PrivacyPage() {
+    return (
+        <>
+            <h1>Privacy Policy</h1>
+            <p>
+                <em>Last updated: TBD — this page is a placeholder.</em>
+            </p>
+            <p>
+                OpenPlaud is open-source software you can run yourself (under
+                AGPL-3.0) or use through the hosted service at openplaud.com.
+                This page describes how the hosted service handles your data. If
+                you self-host, your data never touches our infrastructure and
+                this policy does not apply to you — see the{" "}
+                <Link href="https://github.com/openplaud/openplaud#readme">
+                    project README
+                </Link>{" "}
+                for self-host guidance.
+            </p>
+
+            <h2>What we collect</h2>
+            <p>
+                Account information you provide (email, name), the Plaud account
+                credentials you connect (encrypted at rest with AES-256-GCM),
+                and the recordings, transcripts, and summaries the service
+                generates on your behalf.
+            </p>
+
+            <h2>What we do not do</h2>
+            <ul>
+                <li>We do not train AI models on your recordings.</li>
+                <li>We do not sell your data.</li>
+                <li>
+                    We do not share recordings with anyone other than the AI
+                    provider you configure to transcribe and summarize them.
+                </li>
+            </ul>
+
+            <h2>AI providers</h2>
+            <p>
+                When you configure an AI provider (OpenAI, Anthropic, Groq,
+                OpenRouter, a local Ollama instance, etc.) the hosted service
+                forwards the relevant audio or text to that provider on your
+                behalf. Their privacy terms apply to that processing. We do not
+                retain a separate copy of what we send to them beyond what is
+                already stored in your account.
+            </p>
+
+            <h2>Export and deletion</h2>
+            <p>
+                You can export every recording, transcript, and summary from
+                your account at any time via the full-backup endpoint. You can
+                delete your account, which removes all associated data from
+                active storage.
+            </p>
+
+            <h2>Compliance posture</h2>
+            <p>
+                OpenPlaud is not HIPAA or SOC 2 certified. For regulated work,
+                self-host the project and plug in an AI provider that signs a
+                BAA you have reviewed, or run a local model.
+            </p>
+
+            <h2>Contact</h2>
+            <p>
+                Questions about this policy:{" "}
+                <Link href="mailto:support@openplaud.com">
+                    support@openplaud.com
+                </Link>
+                . Security disclosures:{" "}
+                <Link href="mailto:security@openplaud.com">
+                    security@openplaud.com
+                </Link>
+                .
+            </p>
+        </>
+    );
+}

--- a/src/app/(legal)/terms/page.tsx
+++ b/src/app/(legal)/terms/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+/*
+ * TODO(legal): Replace this placeholder with the real terms of service
+ * before hosted GA. This is a structural stub so the footer's Terms
+ * link is not a dead link -- the content here is NOT a legal document
+ * and must not be treated as one. Coordinate with counsel on:
+ *   - Acceptable use (no automated abuse, no illegal content,
+ *     recording-consent requirements vary by jurisdiction)
+ *   - Account termination / suspension grounds
+ *   - Subscription, billing, refund terms (once billing lands)
+ *   - Disclaimer of warranties / limitation of liability
+ *   - Governing law and dispute resolution
+ *   - DMCA / takedown contact
+ *   - Relationship to the AGPL-3.0 license that governs the software
+ *     itself (the software is AGPL; the hosted service is a service
+ *     under these terms -- these are independent contracts)
+ */
+
+export const metadata: Metadata = {
+    title: "Terms of Service — OpenPlaud",
+    description:
+        "Terms governing your use of the hosted OpenPlaud service at openplaud.com.",
+};
+
+export default function TermsPage() {
+    return (
+        <>
+            <h1>Terms of Service</h1>
+            <p>
+                <em>Last updated: TBD — this page is a placeholder.</em>
+            </p>
+            <p>
+                These terms govern your use of the hosted OpenPlaud service at
+                openplaud.com. If you self-host the project, your relationship
+                is with the AGPL-3.0 license that governs the source code, not
+                with these terms.
+            </p>
+
+            <h2>The software vs. the service</h2>
+            <p>
+                The OpenPlaud source code is licensed under AGPL-3.0 and lives
+                at{" "}
+                <Link
+                    href="https://github.com/openplaud/openplaud"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    github.com/openplaud/openplaud
+                </Link>
+                . You are free to run, modify, and redistribute it under the
+                terms of that license. These Terms of Service apply only to the
+                hosted instance we operate.
+            </p>
+
+            <h2>Acceptable use</h2>
+            <p>
+                You may not use the service to process content you do not have
+                the right to record or process. Recording-consent laws vary by
+                jurisdiction; you are responsible for complying with the laws
+                that apply to you and to the people in your recordings.
+            </p>
+
+            <h2>Your data</h2>
+            <p>
+                You own the recordings, transcripts, and summaries you bring to
+                or generate through the service. You can export everything at
+                any time via the full-backup endpoint.
+            </p>
+
+            <h2>No warranty</h2>
+            <p>
+                The service is provided as-is. Sync depends on Plaud&apos;s
+                upstream API; AI features depend on the provider you configure.
+                We do our best to keep the service running and will communicate
+                outages, but we make no uptime guarantees on the hosted service
+                at this stage.
+            </p>
+
+            <h2>Changes</h2>
+            <p>
+                We may update these terms. Material changes will be announced
+                before they take effect.
+            </p>
+
+            <h2>Contact</h2>
+            <p>
+                <Link href="mailto:support@openplaud.com">
+                    support@openplaud.com
+                </Link>
+            </p>
+        </>
+    );
+}

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -1,0 +1,213 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { CopyableCommand } from "@/components/copyable-command";
+import { Footer } from "@/components/footer";
+import { Logo } from "@/components/icons/logo";
+import { LandingFooter } from "@/components/landing-footer";
+import { env } from "@/lib/env";
+import { APP_VERSION_TAG } from "@/lib/version";
+
+/**
+ * Public "how do I self-host this?" page. Linked from the landing
+ * footer (Resources → Install script) and intended as a friendlier
+ * landing than dumping `/install.sh` straight into the browser.
+ *
+ * Reachable in both deployment modes -- the page content is just
+ * project docs that are useful to anyone considering self-host,
+ * whether they found it via the hosted marketing site or via a
+ * self-host operator sharing their own instance. Only the surrounding
+ * footer chrome differs: hosted gets the rich `LandingFooter`
+ * (matches the rest of the marketing surface); self-host gets the
+ * minimal `Footer` (no marketing sitemap on a self-host instance).
+ *
+ * Deliberately a server component -- the only interactive bit is the
+ * Copy button inside `<CopyableCommand>` (a small client island).
+ * Reads `APP_VERSION_TAG` at build time so the version-pinned form
+ * below always matches the running build.
+ */
+
+export const metadata: Metadata = {
+    title: "Install OpenPlaud — Self-host in one command",
+    description:
+        "Self-host OpenPlaud with a single curl command. Docker + Compose v2 required. AGPL-3.0, no telemetry, no license server.",
+};
+
+const ONE_LINER = "curl -fsSL https://openplaud.com/install.sh | sh";
+const PINNED_LINER = `curl -fsSL https://openplaud.com/${APP_VERSION_TAG}/install.sh | sh`;
+
+export default function InstallPage() {
+    return (
+        <div className="flex flex-col min-h-[100vh] bg-background text-foreground">
+            <header className="border-b border-border/40">
+                <div className="container mx-auto px-4 max-w-4xl flex h-16 items-center justify-between">
+                    <Link
+                        href="/"
+                        className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+                    >
+                        <Logo className="size-7" />
+                        <span className="text-lg font-bold tracking-tight font-mono">
+                            OpenPlaud
+                        </span>
+                    </Link>
+                    <Link
+                        href="/#deploy"
+                        className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                        ← Back to landing
+                    </Link>
+                </div>
+            </header>
+
+            <main className="flex-1">
+                <section className="container mx-auto px-4 max-w-4xl py-16 md:py-24">
+                    <div className="max-w-2xl">
+                        <div className="inline-flex items-center rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground mb-6 font-mono">
+                            Self-host
+                        </div>
+                        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-6">
+                            Install OpenPlaud
+                        </h1>
+                        <p className="text-lg text-muted-foreground leading-relaxed">
+                            One command on a machine with Docker and Compose v2.
+                            The installer pulls the latest release&apos;s{" "}
+                            <code className="font-mono text-foreground/80">
+                                docker-compose.yml
+                            </code>{" "}
+                            and{" "}
+                            <code className="font-mono text-foreground/80">
+                                env.example
+                            </code>
+                            , generates secrets, starts the stack, and waits on{" "}
+                            <code className="font-mono text-foreground/80">
+                                /api/health
+                            </code>
+                            .
+                        </p>
+                    </div>
+
+                    <div className="mt-10 space-y-3">
+                        <div className="flex items-baseline justify-between gap-4">
+                            <h2 className="text-xs font-semibold font-mono uppercase tracking-wider text-foreground/80">
+                                Latest release
+                            </h2>
+                            <Link
+                                href="/install.sh"
+                                target="_blank"
+                                className="text-xs text-muted-foreground hover:text-foreground transition-colors font-mono"
+                            >
+                                View raw script →
+                            </Link>
+                        </div>
+                        <CopyableCommand
+                            command={ONE_LINER}
+                            ariaLabel="Copy install command"
+                        />
+                    </div>
+
+                    <div className="mt-8 space-y-3">
+                        <h2 className="text-xs font-semibold font-mono uppercase tracking-wider text-foreground/80">
+                            Pin to a specific version
+                        </h2>
+                        <CopyableCommand
+                            command={PINNED_LINER}
+                            ariaLabel="Copy version-pinned install command"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            Replace{" "}
+                            <code className="font-mono">{APP_VERSION_TAG}</code>{" "}
+                            with any released tag from{" "}
+                            <Link
+                                href="https://github.com/openplaud/openplaud/releases"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline decoration-dotted underline-offset-2 hover:text-foreground transition-colors"
+                            >
+                                the releases page
+                            </Link>
+                            .
+                        </p>
+                    </div>
+
+                    <div className="mt-16 grid gap-8 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <h2 className="text-sm font-semibold font-mono uppercase tracking-wider text-foreground/80">
+                                Requirements
+                            </h2>
+                            <ul className="text-sm text-muted-foreground space-y-1.5 list-disc pl-5">
+                                <li>Linux or macOS</li>
+                                <li>Docker (any modern version)</li>
+                                <li>Docker Compose v2</li>
+                                <li>Outbound HTTPS to GitHub</li>
+                            </ul>
+                        </div>
+                        <div className="space-y-2">
+                            <h2 className="text-sm font-semibold font-mono uppercase tracking-wider text-foreground/80">
+                                What the script does
+                            </h2>
+                            <ul className="text-sm text-muted-foreground space-y-1.5 list-disc pl-5">
+                                <li>Verifies Docker + Compose v2</li>
+                                <li>
+                                    Downloads{" "}
+                                    <code className="font-mono text-foreground/80">
+                                        docker-compose.yml
+                                    </code>{" "}
+                                    + env template
+                                </li>
+                                <li>
+                                    Generates{" "}
+                                    <code className="font-mono text-foreground/80">
+                                        BETTER_AUTH_SECRET
+                                    </code>
+                                    ,{" "}
+                                    <code className="font-mono text-foreground/80">
+                                        ENCRYPTION_KEY
+                                    </code>
+                                    ,{" "}
+                                    <code className="font-mono text-foreground/80">
+                                        POSTGRES_PASSWORD
+                                    </code>
+                                </li>
+                                <li>
+                                    Starts the stack, waits on{" "}
+                                    <code className="font-mono text-foreground/80">
+                                        /api/health
+                                    </code>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div className="mt-12 rounded-lg border border-border bg-muted/30 p-5">
+                        <h2 className="text-sm font-semibold mb-2">
+                            Don&apos;t want to pipe to shell?
+                        </h2>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                            Fair. Read the source at{" "}
+                            <Link
+                                href="https://github.com/openplaud/openplaud/blob/main/scripts/install.sh"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-foreground underline decoration-dotted underline-offset-2 hover:text-foreground/80 transition-colors"
+                            >
+                                scripts/install.sh
+                            </Link>{" "}
+                            on GitHub, or follow the manual{" "}
+                            <Link
+                                href="https://github.com/openplaud/openplaud#self-host"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-foreground underline decoration-dotted underline-offset-2 hover:text-foreground/80 transition-colors"
+                            >
+                                self-host instructions
+                            </Link>{" "}
+                            in the README. The whole project is AGPL-3.0 —
+                            inspect everything before you run it.
+                        </p>
+                    </div>
+                </section>
+            </main>
+
+            {env.IS_HOSTED ? <LandingFooter /> : <Footer />}
+        </div>
+    );
+}

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -49,12 +49,20 @@ export default function InstallPage() {
                             OpenPlaud
                         </span>
                     </Link>
-                    <Link
-                        href="/#deploy"
-                        className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                        ← Back to landing
-                    </Link>
+                    {/* The marketing landing only exists on hosted
+                        (`/` redirects to `/login` on self-host), so
+                        "Back to landing" is hosted-only chrome. Hiding
+                        rather than rewriting the href -- on a
+                        self-host instance there is no landing to go
+                        back to. */}
+                    {env.IS_HOSTED ? (
+                        <Link
+                            href="/#deploy"
+                            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                            ← Back to landing
+                        </Link>
+                    ) : null}
                 </div>
             </header>
 
@@ -93,6 +101,7 @@ export default function InstallPage() {
                             <Link
                                 href="/install.sh"
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 className="text-xs text-muted-foreground hover:text-foreground transition-colors font-mono"
                             >
                                 View raw script →

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from "next/navigation";
-import { Footer } from "@/components/footer";
 import { Deploy } from "@/components/landing/deploy";
 import { FAQ } from "@/components/landing/faq";
 import { Features } from "@/components/landing/features";
@@ -10,6 +9,7 @@ import { LandingNav } from "@/components/landing/landing-nav";
 import { Pricing } from "@/components/landing/pricing";
 import { RedditQuotes } from "@/components/landing/reddit-quotes";
 import { TheMath } from "@/components/landing/the-math";
+import { LandingFooter } from "@/components/landing-footer";
 import { getSession } from "@/lib/auth-server";
 import { env } from "@/lib/env";
 
@@ -41,7 +41,7 @@ export default async function HomePage() {
                 <FAQ />
                 <FinalCTA />
             </main>
-            <Footer />
+            <LandingFooter />
         </div>
     );
 }

--- a/src/components/copyable-command.tsx
+++ b/src/components/copyable-command.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Single-line shell command with a copy-to-clipboard button. Styled to
+ * match the dark code blocks already used in the `Deploy` landing
+ * section so it reads as "a thing you paste into a terminal," not as
+ * generic site chrome.
+ *
+ * Kept deliberately small and prop-driven so it can be reused later
+ * (docs pages, settings hints) without dragging page-specific styling
+ * along. Client component because clipboard access requires it.
+ */
+export function CopyableCommand({
+    command,
+    ariaLabel,
+}: {
+    command: string;
+    ariaLabel?: string;
+}) {
+    const [copied, setCopied] = useState(false);
+
+    async function handleCopy() {
+        try {
+            await navigator.clipboard.writeText(command);
+            setCopied(true);
+            // 1.6s is long enough to read "Copied" without lingering
+            // past the user's next interaction.
+            setTimeout(() => setCopied(false), 1600);
+        } catch {
+            // Clipboard write can reject in iframes, insecure contexts,
+            // or when the user denies permission. Swallow rather than
+            // throw -- the command text is still selectable manually.
+        }
+    }
+
+    return (
+        <div className="rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-50 overflow-hidden">
+            <div className="flex items-center gap-2 px-4 py-2.5 border-b border-zinc-800 bg-zinc-900">
+                <div className="text-xs font-mono text-zinc-500">
+                    ~/openplaud
+                </div>
+            </div>
+            <div className="flex items-center gap-3 p-4 font-mono text-sm">
+                <div className="flex-1 overflow-x-auto">
+                    <span className="text-zinc-500">$ </span>
+                    <span className="text-zinc-100 whitespace-nowrap">
+                        {command}
+                    </span>
+                </div>
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    aria-label={ariaLabel ?? "Copy command"}
+                    className="shrink-0 inline-flex items-center gap-1.5 rounded-md border border-zinc-800 bg-zinc-900 px-2.5 py-1.5 text-xs text-zinc-400 hover:text-zinc-100 hover:border-zinc-700 transition-colors"
+                >
+                    {copied ? (
+                        <>
+                            <Check className="size-3.5 text-green-400" />
+                            <span>Copied</span>
+                        </>
+                    ) : (
+                        <>
+                            <Copy className="size-3.5" />
+                            <span>Copy</span>
+                        </>
+                    )}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/copyable-command.tsx
+++ b/src/components/copyable-command.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Single-line shell command with a copy-to-clipboard button. Styled to
@@ -21,14 +21,33 @@ export function CopyableCommand({
     ariaLabel?: string;
 }) {
     const [copied, setCopied] = useState(false);
+    // Tracked so we can cancel a pending "flip back to Copy" timer if
+    // the component unmounts (route change, parent re-render) before
+    // it fires. Modern React no-ops setState-after-unmount silently,
+    // but cancelling the timer is the cheap correct thing.
+    const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (resetTimerRef.current !== null) {
+                clearTimeout(resetTimerRef.current);
+            }
+        };
+    }, []);
 
     async function handleCopy() {
         try {
             await navigator.clipboard.writeText(command);
             setCopied(true);
+            if (resetTimerRef.current !== null) {
+                clearTimeout(resetTimerRef.current);
+            }
             // 1.6s is long enough to read "Copied" without lingering
             // past the user's next interaction.
-            setTimeout(() => setCopied(false), 1600);
+            resetTimerRef.current = setTimeout(() => {
+                setCopied(false);
+                resetTimerRef.current = null;
+            }, 1600);
         } catch {
             // Clipboard write can reject in iframes, insecure contexts,
             // or when the user denies permission. Swallow rather than

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,104 +1,83 @@
-import { Heart } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
 import { Github } from "@/components/icons/icons";
 import { Logo } from "@/components/icons/logo";
 import { UpdateBadge } from "@/components/update-badge";
+import { env } from "@/lib/env";
 import { APP_RELEASE_URL, APP_VERSION_TAG } from "@/lib/version";
 
+/**
+ * In-app footer rendered on every signed-in screen via
+ * `src/app/(app)/layout.tsx`. Kept deliberately minimal -- this is
+ * chrome that ships under every workstation, dashboard, and settings
+ * pane, so weight here is paid for on every view.
+ *
+ * The richer marketing footer lives in `landing-footer.tsx` and is
+ * only mounted from `src/app/page.tsx` (hosted-only by virtue of the
+ * `IS_HOSTED` redirect at the top of that file).
+ *
+ * Server component so it can read `env.IS_HOSTED` directly -- hosted
+ * gets a support link, self-host gets the update badge. Neither side
+ * sees both. PR #124 already dropped the original `"use client"`.
+ */
 export function Footer() {
     const currentYear = new Date().getFullYear();
 
     return (
         <footer className="border-t border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-            <div className="container mx-auto px-4 py-6 max-w-7xl">
-                <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-                    <div className="flex flex-col items-center md:items-start gap-2">
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                            <span className="font-mono">Made with</span>
-                            <Heart className="w-4 h-4 text-destructive fill-destructive animate-pulse" />
-                            <span className="font-mono">for meetings</span>
-                        </div>
-                        <div className="flex flex-col items-center md:items-start gap-1">
-                            <div className="flex items-center gap-2 text-xs text-muted-foreground/80 font-mono">
-                                <Logo className="size-4" />
-                                <span>
-                                    © {currentYear}{" "}
-                                    <Link
-                                        href="https://openplaud.com"
-                                        className="text-primary hover:text-primary/80 transition-colors"
-                                    >
-                                        OpenPlaud
-                                    </Link>
-                                    . Licensed under{" "}
-                                    <Link
-                                        href="https://www.gnu.org/licenses/agpl-3.0.html"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="text-primary hover:text-primary/80 transition-colors underline decoration-dotted underline-offset-2"
-                                    >
-                                        AGPL-3.0
-                                    </Link>
-                                    .
-                                </span>
-                            </div>
+            <div className="container mx-auto px-4 py-3 max-w-7xl">
+                <div className="flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-muted-foreground font-mono">
+                    <div className="flex items-center gap-2">
+                        <Logo className="size-4" />
+                        <span>
+                            © {currentYear} OpenPlaud · Licensed under{" "}
                             <Link
-                                href="https://openplaud.com"
-                                className="text-xs text-muted-foreground/60 hover:text-muted-foreground transition-colors font-mono"
+                                href="https://www.gnu.org/licenses/agpl-3.0.html"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-2"
                             >
-                                openplaud.com
+                                AGPL-3.0
                             </Link>
-                        </div>
+                        </span>
                     </div>
-                </div>
 
-                <div className="mt-6 pt-6 border-t border-border/20">
-                    <div className="flex items-center justify-center gap-3">
-                        <div className="flex gap-1">
-                            {[...Array(3)].map((_, i) => (
-                                <div
-                                    // biome-ignore lint/suspicious/noArrayIndexKey: screw key
-                                    key={i}
-                                    className="w-1 h-1 rounded-full bg-muted-foreground/30"
-                                />
-                            ))}
-                        </div>
-                        <div className="text-[10px] text-muted-foreground/50 font-mono uppercase tracking-wider">
-                            Open Source • Built for the Community
-                        </div>
-                        <Link
-                            href="https://github.com/openplaud/openplaud"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-                            aria-label="View source code on GitHub"
-                        >
-                            <Github className="size-4 text-muted-foreground/50 hover:text-muted-foreground transition-colors" />
-                        </Link>
+                    <div className="flex items-center gap-3">
+                        {/* Self-host-only update notice. Suspended with a
+                            null fallback so a cold GitHub-API cache
+                            doesn't block the rest of the footer from
+                            streaming. UpdateBadge already no-ops on
+                            hosted -- the Suspense is for the network
+                            fetch, not the gate. */}
+                        <Suspense fallback={null}>
+                            <UpdateBadge />
+                        </Suspense>
                         <Link
                             href={APP_RELEASE_URL}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-[10px] text-muted-foreground/50 hover:text-muted-foreground transition-colors font-mono uppercase tracking-wider"
+                            className="hover:text-foreground transition-colors"
                             aria-label={`Release notes for OpenPlaud ${APP_VERSION_TAG}`}
                         >
                             {APP_VERSION_TAG}
                         </Link>
-                        {/* Self-host-only update notice. Suspended with a null
-                            fallback so a cold GitHub-API cache doesn't block
-                            the rest of the footer from streaming. */}
-                        <Suspense fallback={null}>
-                            <UpdateBadge />
-                        </Suspense>
-                        <div className="flex gap-1">
-                            {[...Array(3)].map((_, i) => (
-                                <div
-                                    // biome-ignore lint/suspicious/noArrayIndexKey: screw key
-                                    key={i}
-                                    className="w-1 h-1 rounded-full bg-muted-foreground/30"
-                                />
-                            ))}
-                        </div>
+                        {env.IS_HOSTED ? (
+                            <Link
+                                href="mailto:support@openplaud.com"
+                                className="hover:text-foreground transition-colors"
+                            >
+                                Support
+                            </Link>
+                        ) : null}
+                        <Link
+                            href="https://github.com/openplaud/openplaud"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-foreground transition-colors"
+                            aria-label="View source code on GitHub"
+                        >
+                            <Github className="size-4" />
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -12,9 +12,14 @@ import { APP_RELEASE_URL, APP_VERSION_TAG } from "@/lib/version";
  * chrome that ships under every workstation, dashboard, and settings
  * pane, so weight here is paid for on every view.
  *
+ * Also mounted on `/install` when `!env.IS_HOSTED` -- on a self-host
+ * instance the install page is reachable but the marketing-sitemap
+ * `LandingFooter` would be dishonest chrome (no "Pricing" or "For
+ * Professionals" surface exists), so the page falls back to this
+ * minimal footer.
+ *
  * The richer marketing footer lives in `landing-footer.tsx` and is
- * only mounted from `src/app/page.tsx` (hosted-only by virtue of the
- * `IS_HOSTED` redirect at the top of that file).
+ * mounted on `/`, `/install` (hosted branch), and the `(legal)` layout.
  *
  * Server component so it can read `env.IS_HOSTED` directly -- hosted
  * gets a support link, self-host gets the update badge. Neither side

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -1,5 +1,23 @@
 type IconProps = React.HTMLAttributes<SVGElement>;
 
+export const X = ({ className, ...props }: IconProps) => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="24"
+            height="24"
+            {...props}
+            className={className}
+            aria-label="X"
+            aria-hidden="true"
+            fill="currentColor"
+        >
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+    );
+};
+
 export const Github = ({ className, ...props }: IconProps) => {
     return (
         <svg

--- a/src/components/landing-footer.tsx
+++ b/src/components/landing-footer.tsx
@@ -3,16 +3,24 @@ import { Github, X } from "@/components/icons/icons";
 import { Logo } from "@/components/icons/logo";
 
 /**
- * Marketing footer for the hosted landing page (`/`). This file is
- * intentionally not used by `src/app/(app)/layout.tsx` -- signed-in
+ * Marketing footer for hosted public surfaces. Currently mounted on:
+ *   - `/`                           (`src/app/page.tsx`)
+ *   - `/install` (hosted branch)    (`src/app/install/page.tsx`)
+ *   - `/privacy`, `/terms`          (`src/app/(legal)/layout.tsx`)
+ *
+ * Intentionally not used by `src/app/(app)/layout.tsx` -- signed-in
  * users get the minimal `Footer` (AppFooter) from `./footer.tsx`
  * instead. Splitting them keeps app chrome from inheriting marketing-
  * sitemap weight, and keeps marketing free to grow columns without
  * bloating every workstation screen.
  *
- * Reached only when `IS_HOSTED=true` (enforced by `src/app/page.tsx`
- * redirecting to `/login` when the flag is unset), so this component
- * never needs to internally branch on hosted/self-host.
+ * Every call site that mounts this component is hosted-only -- either
+ * by virtue of `src/app/page.tsx` redirecting to `/login` when
+ * `IS_HOSTED` is unset, the `(legal)` layout calling `notFound()` on
+ * self-host, or `/install` branching on `env.IS_HOSTED` to render
+ * `Footer` instead. The component itself therefore never needs to
+ * internally branch on hosted/self-host; new call sites must keep
+ * this invariant.
  */
 
 type FooterLink = {

--- a/src/components/landing-footer.tsx
+++ b/src/components/landing-footer.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import { Github, X } from "@/components/icons/icons";
+import { Logo } from "@/components/icons/logo";
+
+/**
+ * Marketing footer for the hosted landing page (`/`). This file is
+ * intentionally not used by `src/app/(app)/layout.tsx` -- signed-in
+ * users get the minimal `Footer` (AppFooter) from `./footer.tsx`
+ * instead. Splitting them keeps app chrome from inheriting marketing-
+ * sitemap weight, and keeps marketing free to grow columns without
+ * bloating every workstation screen.
+ *
+ * Reached only when `IS_HOSTED=true` (enforced by `src/app/page.tsx`
+ * redirecting to `/login` when the flag is unset), so this component
+ * never needs to internally branch on hosted/self-host.
+ */
+
+type FooterLink = {
+    label: string;
+    href: string;
+    external?: boolean;
+};
+
+type FooterColumn = {
+    title: string;
+    links: FooterLink[];
+};
+
+// Docs link points at the README for now; swap to `/docs` once that
+// route lands (issue/PR pending). Never ship a known-broken link on
+// a marketing surface.
+const COLUMNS: FooterColumn[] = [
+    {
+        title: "Product",
+        links: [
+            { label: "Features", href: "/#features" },
+            { label: "Pricing", href: "/#pricing" },
+            { label: "Self-host", href: "/#deploy" },
+            {
+                label: "Changelog",
+                href: "https://github.com/openplaud/openplaud/blob/main/CHANGELOG.md",
+                external: true,
+            },
+            {
+                label: "Roadmap",
+                href: "https://github.com/openplaud/openplaud/issues",
+                external: true,
+            },
+        ],
+    },
+    {
+        title: "Resources",
+        links: [
+            {
+                label: "Documentation",
+                href: "https://github.com/openplaud/openplaud#readme",
+                external: true,
+            },
+            { label: "Install script", href: "/install" },
+            {
+                label: "Discussions",
+                href: "https://github.com/openplaud/openplaud/discussions",
+                external: true,
+            },
+            {
+                label: "Security",
+                href: "https://github.com/openplaud/openplaud/blob/main/SECURITY.md",
+                external: true,
+            },
+        ],
+    },
+    {
+        title: "Company",
+        links: [
+            { label: "For Professionals", href: "/#for-professionals" },
+            {
+                label: "Open Source",
+                href: "https://github.com/openplaud/openplaud",
+                external: true,
+            },
+            {
+                label: "Code of Conduct",
+                href: "https://github.com/openplaud/openplaud/blob/main/CODE_OF_CONDUCT.md",
+                external: true,
+            },
+            { label: "Contact", href: "mailto:support@openplaud.com" },
+        ],
+    },
+    {
+        title: "Legal",
+        links: [
+            { label: "Privacy", href: "/privacy" },
+            { label: "Terms", href: "/terms" },
+            {
+                label: "Security disclosure",
+                href: "mailto:security@openplaud.com",
+            },
+            {
+                label: "License (AGPL-3.0)",
+                href: "https://www.gnu.org/licenses/agpl-3.0.html",
+                external: true,
+            },
+        ],
+    },
+];
+
+function FooterLinkItem({ label, href, external }: FooterLink) {
+    const externalProps = external
+        ? { target: "_blank", rel: "noopener noreferrer" as const }
+        : {};
+    return (
+        <li>
+            <Link
+                href={href}
+                {...externalProps}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+                {label}
+            </Link>
+        </li>
+    );
+}
+
+export function LandingFooter() {
+    const currentYear = new Date().getFullYear();
+
+    return (
+        <footer className="border-t border-border/40 bg-background">
+            <div className="container mx-auto px-4 py-16 md:py-20 max-w-7xl">
+                <div className="grid grid-cols-2 md:grid-cols-6 gap-8 md:gap-12">
+                    {/* Brand block spans 2 cols on desktop so the sitemap
+                        sits cleanly to the right. */}
+                    <div className="col-span-2 flex flex-col gap-4">
+                        <Link
+                            href="/"
+                            className="flex items-center gap-2 hover:opacity-80 transition-opacity w-fit"
+                        >
+                            <Logo className="size-7" />
+                            <span className="text-lg font-bold tracking-tight font-mono">
+                                OpenPlaud
+                            </span>
+                        </Link>
+                        <p className="text-sm text-muted-foreground leading-relaxed max-w-xs">
+                            Open-source companion for your Plaud device.
+                            Self-host it or let us run it for you.
+                        </p>
+                        <div className="flex items-center gap-3 mt-1">
+                            <Link
+                                href="https://github.com/openplaud/openplaud"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-muted-foreground hover:text-foreground transition-colors"
+                                aria-label="OpenPlaud on GitHub"
+                            >
+                                <Github className="size-5" />
+                            </Link>
+                            <Link
+                                href="https://x.com/openplaud"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-muted-foreground hover:text-foreground transition-colors"
+                                aria-label="OpenPlaud on X"
+                            >
+                                <X className="size-[18px]" />
+                            </Link>
+                        </div>
+                    </div>
+
+                    {COLUMNS.map((col) => (
+                        <div key={col.title} className="flex flex-col gap-3">
+                            <h3 className="text-xs font-semibold font-mono uppercase tracking-wider text-foreground/80">
+                                {col.title}
+                            </h3>
+                            <ul className="flex flex-col gap-2">
+                                {col.links.map((link) => (
+                                    <FooterLinkItem
+                                        key={link.label}
+                                        {...link}
+                                    />
+                                ))}
+                            </ul>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Honesty rail. OpenPlaud's Slice 2 audience
+                    (lawyers/journalists/regulated work) responds to
+                    explicit disclaimers more than to vague trust
+                    badges -- mirrors the FAQ's HIPAA answer. */}
+                <div className="mt-16 pt-6 border-t border-border/40">
+                    <p className="text-xs text-muted-foreground/80 leading-relaxed max-w-2xl">
+                        OpenPlaud is not HIPAA or SOC 2 certified. For regulated
+                        work, self-host and plug in an AI provider that signs a
+                        BAA you&apos;ve reviewed, or run a local model that
+                        never leaves your machine.
+                    </p>
+                </div>
+
+                <div className="mt-6 pt-6 border-t border-border/40 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <p className="text-xs text-muted-foreground font-mono">
+                        © {currentYear} OpenPlaud. Licensed under{" "}
+                        <Link
+                            href="https://www.gnu.org/licenses/agpl-3.0.html"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-foreground/80 hover:text-foreground transition-colors underline decoration-dotted underline-offset-2"
+                        >
+                            AGPL-3.0
+                        </Link>
+                        .
+                    </p>
+                    <p className="text-xs text-muted-foreground/70 font-mono">
+                        Built in the open on{" "}
+                        <Link
+                            href="https://github.com/openplaud/openplaud"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-2"
+                        >
+                            GitHub
+                        </Link>
+                    </p>
+                </div>
+            </div>
+        </footer>
+    );
+}


### PR DESCRIPTION
## Description

Matures the footer for the hosted product. Splits the single decorative footer into two purpose-built components, adds public-facing install/privacy/terms surfaces, and keeps self-host clean of marketing chrome.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

n/a — proactive maturity pass on the hosted marketing surface.

## Changes Made

**Footer split (`feat(footer)`)**

- New `src/components/landing-footer.tsx` — four-column marketing footer (Product / Resources / Company / Legal) with brand block, GitHub + X socials, and an honesty rail explicitly disclaiming HIPAA / SOC 2 certification (mirrors the FAQ tone). Used only on `/` and other hosted-public surfaces.
- `src/components/footer.tsx` rewritten as a minimal one-row in-app footer (logo + AGPL + version link + hosted-only Support + GitHub). Keeps the `Footer` export name so `(app)/layout.tsx` is untouched. Server component; reads `env.IS_HOSTED` directly to gate the Support link. Preserves `UpdateBadge` + version-link behavior introduced in #124.
- `src/components/icons/icons.tsx` — added `X` icon.
- `src/app/page.tsx` — landing now renders `LandingFooter`.

**Legal stubs (`feat(legal)`)**

- New route group `src/app/(legal)/` with a shared layout. `notFound()` at the top of the layout makes `/privacy` and `/terms` 404 on self-host (hosted-service legal docs don't apply to operators).
- `/privacy` and `/terms` are clearly marked placeholders with `TODO(legal)` blocks for counsel review before hosted GA. They exist so the LandingFooter's Privacy/Terms links aren't dead links — the content is not legal advice and is annotated as such in code.

**Install page (`feat(install)`)**

- New `src/app/install/page.tsx` replaces the footer's direct `/install.sh` link with a real page: hero, copy-to-clipboard one-liner, copy-to-clipboard version-pinned form, requirements grid, what-the-script-does grid, and an "audit the source before piping to shell" escape hatch linking to `scripts/install.sh` + README self-host section.
- New `src/components/copyable-command.tsx` — small client island (clipboard write + 1.6s "Copied" state) styled to match the dark terminal blocks already used in the `Deploy` landing section. Reusable later.
- Reachable in both modes: hosted gets `LandingFooter`, self-host gets the minimal `Footer` (no marketing chrome on a self-host instance). Version-pinned example uses build-time `APP_VERSION_TAG`; not wiring this to a runtime GitHub fetch on purpose — the pinned block demonstrates URL shape, and the releases-page link covers the rare "give me an exact older version" case. Redeploy lag after a release is minutes.

## Screenshots (if applicable)

Footer matrix the PR establishes:

| URL | Hosted | Self-host |
|---|---|---|
| `/` | `LandingFooter` | redirects to `/login` |
| `/install` | `LandingFooter` | `Footer` (minimal) |
| `/privacy` | `LandingFooter` | **404** |
| `/terms` | `LandingFooter` | **404** |
| `/dashboard`, `/recordings/*`, `/settings/*` | `Footer` | `Footer` |

## Testing

### Test Environment
- OS: macOS (local dev)
- Node version: 20 / pnpm 10.18.1
- Browser: Chrome (visual pass on `/install`)

### Test Steps
1. `pnpm install --frozen-lockfile` — clean.
2. `pnpm format-and-lint:fix` — 1 file auto-fixed; 2 pre-existing infos in `src/tests/admin/elevated-cookie.test.ts` (untouched by this PR, also flagged in #124).
3. `pnpm type-check` — clean.
4. `pnpm dev` — manually visited `/`, `/install`, `/dashboard` on local hosted-mode build. Confirmed: landing footer columns render, X + GitHub socials, honesty rail. `/install` copy buttons write to clipboard and flip to "Copied" for 1.6s. AppFooter on `/dashboard` is one row, no heart/dots.

`pnpm test` not run — no test files added or modified; changes are server-rendered marketing/legal/install surfaces with no testable branching beyond the `env.IS_HOSTED` gate (already exercised by existing IS_HOSTED-gated routes).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (footer split rationale, legal `TODO(legal)` blocks, `/install` dual-mode footer choice)
- [ ] I have made corresponding changes to the documentation — n/a, no doc surfaces changed
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective — see Testing note above
- [x] New and existing unit tests pass locally with my changes — `pnpm test` not run (no test changes); type-check + lint clean
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published — depends on #124 (merged before this work started)

## Database Changes

None.

## Breaking Changes

None. Deploy surface impact:

- **No schema changes**, no migrations, no env vars added or renamed.
- **`docker-compose.yml`** untouched.
- **`/api/*`** untouched.
- **Self-host visible changes**:
  - In-app footer is now a thin one-row strip instead of the decorative two-row block. Same information density (AGPL + version + GitHub) plus the `UpdateBadge` from #124. No functional regression.
  - `/privacy` and `/terms` 404 on self-host (they didn't exist before either — net new pages gated to hosted).
  - `/install` is reachable on self-host with the minimal footer. New surface; doesn't displace anything.

## Additional Notes

- `CHANGELOG.md` deliberately not touched — per `AGENTS.md`, maintainer-curated at release time. Suggested `[Unreleased]` entries: under **Added** "Public `/install` page with copy-to-clipboard install commands", "Hosted-only `/privacy` and `/terms` placeholder pages (404 on self-host)"; under **Changed** "Split footer into rich `LandingFooter` (hosted public surfaces) and minimal `Footer` (signed-in app screens)".
- The legal pages are **placeholders, not legal advice**. They must be reviewed by counsel before hosted GA. The `TODO(legal)` blocks at the top of each file enumerate the open questions (sub-processors, retention, jurisdiction, acceptable use, billing terms).
- Not wiring `/install`'s version-pinned example to a runtime GitHub fetch: the pinned block demonstrates URL shape, and the redeploy lag after a release is minutes. Adding a `fetchLatestReleaseTag()` call to every page render to close a minutes-long cosmetic gap is the wrong trade.

## For Reviewers

Focus areas, in order of risk:

- **Footer split decision** — `LandingFooter` on hosted public surfaces, `Footer` (minimal) on signed-in app + self-host everywhere. Confirm the hybrid model is right: marketing-only chrome should not appear on self-host instances; in-app screens shouldn't carry a marketing sitemap on either mode.
- **Legal page placeholders** — the content is clearly marked as TODO and not legal advice. Confirm you're OK shipping the placeholder structure now and replacing the copy before hosted GA, rather than leaving the footer links broken in the meantime.
- **`/install` dual-mode footer** — `{env.IS_HOSTED ? <LandingFooter /> : <Footer />}` at the bottom of the page. Alternative is making `/install` hosted-only (404 on self-host). Chose dual-mode because the content is project docs useful in both audiences.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the footer into a minimal in‑app `Footer` and a hosted-only `LandingFooter`, and added public `/install`, `/privacy`, and `/terms` pages. Keeps self‑host instances free of marketing chrome, fixes dead links, and addresses small UX/security nits.

- **New Features**
  - Added `LandingFooter`: 4-column marketing footer with brand, GitHub + X, and HIPAA/SOC 2 disclaimer. Landing page now renders `LandingFooter`.
  - Rewrote in‑app `Footer`: one-row (logo, AGPL, version link, hosted-only Support). Server component reads `env.IS_HOSTED`; preserves `UpdateBadge` and `APP_VERSION_TAG` link.
  - Introduced `(legal)` route group with layout that calls `notFound()` on self‑host; hosted-only `/privacy` and `/terms` placeholder pages.
  - Added `/install` page with `CopyableCommand` buttons for latest and version‑pinned commands (uses build‑time `APP_VERSION_TAG`), plus requirements and “audit the source” links. Renders `LandingFooter` on hosted, `Footer` on self‑host.
  - Added `X` icon.

- **Bug Fixes**
  - `CopyableCommand`: clear the “Copied” timeout on unmount to avoid setState-after-unmount.
  - `/install`: hide “Back to landing” on self‑host; add `rel="noopener noreferrer"` to “View raw script” link.

<sup>Written for commit 2ed0b864531f8c42fc8b15a0f88ff9eb9a132f03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

