### PR TITLE
fix(ai): OpenRouter transcription via chat-completions + curated model lists

### DIFF
--- a/src/app/api/settings/ai/providers/models/route.ts
+++ b/src/app/api/settings/ai/providers/models/route.ts
@@ -1,0 +1,154 @@
+/**
+ * POST /api/settings/ai/providers/models
+ *
+ * Fetches the list of audio-input-capable models from a provider, so the
+ * Add/Edit dialogs can offer a dropdown instead of forcing the user to
+ * paste a model id they may not have on hand. Powering the OpenRouter
+ * happy path for issue #122.
+ *
+ * Request body: `{ provider, apiKey, baseUrl? }`. The apiKey is taken from
+ * the in-progress form (the credential may not be saved yet), validated
+ * via a single upstream call, and never persisted from this route.
+ *
+ * Currently only OpenRouter exposes per-model `input_modalities`. Other
+ * presets return an empty list and the UI falls back to the freeform
+ * text input. The route is intentionally generic so other providers can
+ * be added (Together AI, Groq) without a new endpoint shape.
+ */
+
+import { NextResponse } from "next/server";
+import { findPreset } from "@/lib/ai/provider-presets";
+import { validateAiBaseUrl } from "@/lib/ai/validate-base-url";
+import { requireApiSession } from "@/lib/auth-server";
+import { env } from "@/lib/env";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+
+interface ModelOption {
+    id: string;
+    name: string;
+}
+
+interface OpenRouterModel {
+    id: string;
+    name?: string;
+    architecture?: {
+        input_modalities?: string[];
+    };
+}
+
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
+export const POST = apiHandler(async (request: Request) => {
+    // Auth-only: we never read or write user-scoped DB rows here, but the
+    // route proxies an outbound HTTP call using a user-supplied key. Gate
+    // it behind a session so anonymous traffic can't burn our egress.
+    await requireApiSession(request);
+
+    const body = (await request.json().catch(() => null)) as {
+        provider?: unknown;
+        apiKey?: unknown;
+        baseUrl?: unknown;
+    } | null;
+
+    const provider = typeof body?.provider === "string" ? body.provider : "";
+    const apiKey = typeof body?.apiKey === "string" ? body.apiKey : "";
+    const baseUrl = typeof body?.baseUrl === "string" ? body.baseUrl : "";
+
+    if (!provider || !apiKey) {
+        throw new AppError(
+            ErrorCode.MISSING_REQUIRED_FIELD,
+            "provider and apiKey are required",
+            400,
+        );
+    }
+
+    // Same hosted-mode loopback guard the credential routes apply, so the
+    // hosted app process can't be tricked into probing internal endpoints
+    // via a crafted baseUrl.
+    const urlCheck = validateAiBaseUrl(baseUrl, { isHosted: env.IS_HOSTED });
+    if (!urlCheck.ok) {
+        throw new AppError(ErrorCode.INVALID_INPUT, urlCheck.message, 400, {
+            field: "baseUrl",
+        });
+    }
+
+    const preset = findPreset(provider);
+    const effectiveBaseUrl =
+        baseUrl || preset?.baseUrl || "https://api.openai.com/v1";
+
+    if (provider === "OpenRouter") {
+        const models = await fetchOpenRouterAudioModels(
+            effectiveBaseUrl,
+            apiKey,
+        );
+        return NextResponse.json({ models });
+    }
+
+    // For every other preset we don't have a reliable capability tag.
+    // Return empty and let the UI fall back to the freeform input.
+    return NextResponse.json({ models: [] satisfies ModelOption[] });
+});
+
+async function fetchOpenRouterAudioModels(
+    baseUrl: string,
+    apiKey: string,
+): Promise<ModelOption[]> {
+    const url = `${baseUrl.replace(/\/$/, "")}/models`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: controller.signal,
+        });
+    } catch (err) {
+        if ((err as Error).name === "AbortError") {
+            throw new AppError(
+                ErrorCode.AI_PROVIDER_API_ERROR,
+                "Timed out fetching models from OpenRouter.",
+                504,
+            );
+        }
+        throw new AppError(
+            ErrorCode.AI_PROVIDER_API_ERROR,
+            "Failed to reach OpenRouter.",
+            502,
+        );
+    } finally {
+        clearTimeout(timer);
+    }
+
+    if (response.status === 401 || response.status === 403) {
+        throw new AppError(
+            ErrorCode.AI_PROVIDER_API_ERROR,
+            "OpenRouter rejected the API key.",
+            401,
+        );
+    }
+    if (!response.ok) {
+        throw new AppError(
+            ErrorCode.AI_PROVIDER_API_ERROR,
+            `OpenRouter returned ${response.status} while listing models.`,
+            502,
+        );
+    }
+
+    const payload = (await response.json().catch(() => null)) as {
+        data?: OpenRouterModel[];
+    } | null;
+    const list = Array.isArray(payload?.data) ? payload.data : [];
+
+    const models: ModelOption[] = list
+        .filter((m) =>
+            (m.architecture?.input_modalities ?? []).includes("audio"),
+        )
+        .map((m) => ({ id: m.id, name: m.name || m.id }))
+        // Stable alphabetical order so the dropdown doesn't reshuffle on
+        // every refresh as OpenRouter's catalog re-orders.
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    return models;
+}

--- a/src/components/settings/add-provider-dialog.tsx
+++ b/src/components/settings/add-provider-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { MetalButton } from "@/components/metal-button";
 import { Panel } from "@/components/panel";
+import { TranscriptionModelPicker } from "@/components/settings/transcription-model-picker";
 import {
     Dialog,
     DialogContent,
@@ -178,20 +179,14 @@ export function AddProviderDialog({
                         )}
                     </div>
 
-                    <div className="space-y-2">
-                        <Label htmlFor="defaultModel">
-                            Default Model (Optional)
-                        </Label>
-                        <Input
-                            id="defaultModel"
-                            type="text"
-                            placeholder="whisper-1, gpt-4o, etc."
-                            value={defaultModel}
-                            onChange={(e) => setDefaultModel(e.target.value)}
-                            disabled={isLoading}
-                            className="font-mono text-sm"
-                        />
-                    </div>
+                    <TranscriptionModelPicker
+                        preset={selectedPreset}
+                        apiKey={apiKey}
+                        baseUrl={baseUrl}
+                        value={defaultModel}
+                        onChange={setDefaultModel}
+                        disabled={isLoading}
+                    />
 
                     <Panel variant="inset" className="space-y-2 text-sm">
                         <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/settings/edit-provider-dialog.tsx
+++ b/src/components/settings/edit-provider-dialog.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { MetalButton } from "@/components/metal-button";
 import { Panel } from "@/components/panel";
+import { TranscriptionModelPicker } from "@/components/settings/transcription-model-picker";
 import {
     Dialog,
     DialogContent,
@@ -278,20 +279,14 @@ export function EditProviderDialog({
                         )}
                     </div>
 
-                    <div className="space-y-2">
-                        <Label htmlFor="defaultModel">
-                            Default Model (Optional)
-                        </Label>
-                        <Input
-                            id="defaultModel"
-                            type="text"
-                            placeholder="whisper-1, gpt-4o, etc."
-                            value={defaultModel}
-                            onChange={(e) => setDefaultModel(e.target.value)}
-                            disabled={isLoading}
-                            className="font-mono text-sm"
-                        />
-                    </div>
+                    <TranscriptionModelPicker
+                        preset={selectedPreset}
+                        apiKey={apiKey}
+                        baseUrl={baseUrl}
+                        value={defaultModel}
+                        onChange={setDefaultModel}
+                        disabled={isLoading}
+                    />
 
                     <Panel variant="inset" className="space-y-2 text-sm">
                         <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/settings/transcription-model-picker.tsx
+++ b/src/components/settings/transcription-model-picker.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * Transcription model picker shared by the Add/Edit provider dialogs.
+ *
+ * Three modes:
+ *   - Preset has `fetchAudioModels: true` (OpenRouter): live-fetch the
+ *     audio-input model list from the provider's /v1/models endpoint via
+ *     `POST /api/settings/ai/providers/models`. Debounced on apiKey change.
+ *   - Preset has `knownTranscriptionModels`: render a dropdown from the
+ *     hand-curated list shipped in `provider-presets.ts`.
+ *   - Otherwise: plain freeform text input (LM Studio / Ollama / Custom).
+ *
+ * Both list modes include a final "Custom (type model name)…" option as
+ * an escape hatch so users on a stale OpenPlaud release can still type a
+ * model id we haven't seeded yet.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type { ProviderPreset } from "@/lib/ai/provider-presets";
+
+interface ModelOption {
+    id: string;
+    name: string;
+}
+
+const CUSTOM_SENTINEL = "__custom__";
+
+interface Props {
+    preset: ProviderPreset | undefined;
+    apiKey: string;
+    baseUrl: string;
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+}
+
+export function TranscriptionModelPicker({
+    preset,
+    apiKey,
+    baseUrl,
+    value,
+    onChange,
+    disabled,
+}: Props) {
+    // Live fetch for `fetchAudioModels: true` presets.
+    const [audioModels, setAudioModels] = useState<ModelOption[]>([]);
+    const [audioModelsLoading, setAudioModelsLoading] = useState(false);
+    const [audioModelsError, setAudioModelsError] = useState<string | null>(
+        null,
+    );
+    // Used to discard out-of-order audio-model fetches when the user
+    // toggles providers / edits the key faster than the network responds.
+    const requestId = useRef(0);
+
+    const shouldFetch =
+        preset?.fetchAudioModels === true && apiKey.trim().length > 0;
+    const providerName = preset?.name ?? "";
+
+    useEffect(() => {
+        if (!shouldFetch) {
+            setAudioModels([]);
+            setAudioModelsError(null);
+            setAudioModelsLoading(false);
+            return;
+        }
+        // Debounce so we don't fire a request on every keystroke of the
+        // API key paste. 400ms feels responsive without being chatty.
+        const reqId = ++requestId.current;
+        setAudioModelsLoading(true);
+        setAudioModelsError(null);
+        const timer = setTimeout(async () => {
+            try {
+                const res = await fetch("/api/settings/ai/providers/models", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        provider: providerName,
+                        apiKey,
+                        baseUrl: baseUrl || null,
+                    }),
+                });
+                const data = (await res.json().catch(() => null)) as {
+                    models?: ModelOption[];
+                    error?: string;
+                } | null;
+                if (reqId !== requestId.current) return;
+                if (!res.ok) {
+                    setAudioModels([]);
+                    setAudioModelsError(
+                        data?.error || "Couldn't load audio models.",
+                    );
+                    return;
+                }
+                setAudioModels(data?.models ?? []);
+            } catch {
+                if (reqId !== requestId.current) return;
+                setAudioModelsError("Couldn't load audio models.");
+            } finally {
+                if (reqId === requestId.current) {
+                    setAudioModelsLoading(false);
+                }
+            }
+        }, 400);
+        return () => clearTimeout(timer);
+    }, [shouldFetch, providerName, apiKey, baseUrl]);
+
+    // Resolve which option list (if any) we should render.
+    const options: ModelOption[] = preset?.fetchAudioModels
+        ? audioModels
+        : (preset?.knownTranscriptionModels ?? []).map((id) => ({
+              id,
+              name: id,
+          }));
+
+    const hasOptions = options.length > 0;
+
+    // Custom-mode toggle: true when the user explicitly picked "Custom…"
+    // OR when the stored `value` isn't one of the curated options (legacy
+    // values or hand-typed ids from a stale release).
+    const [useCustom, setUseCustom] = useState(false);
+
+    // Reset whenever the selected preset changes. Without this, clicking
+    // "Custom…" on one provider and then switching providers leaves the
+    // picker stuck in freeform mode for the new provider (where the
+    // current value is a perfectly valid item in its curated list).
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on preset change only.
+    useEffect(() => {
+        setUseCustom(false);
+    }, [providerName]);
+
+    useEffect(() => {
+        if (!hasOptions) {
+            setUseCustom(false);
+            return;
+        }
+        if (value && !options.some((o) => o.id === value)) {
+            setUseCustom(true);
+        }
+        // We deliberately don't flip useCustom back to false when value
+        // matches an option — the user might be in the middle of typing.
+    }, [hasOptions, options, value]);
+
+    const handleSelectChange = (selected: string) => {
+        if (selected === CUSTOM_SENTINEL) {
+            setUseCustom(true);
+            onChange("");
+            return;
+        }
+        setUseCustom(false);
+        onChange(selected);
+    };
+
+    // Helper text below the picker.
+    let helper: string | null = null;
+    if (preset?.fetchAudioModels) {
+        if (audioModelsLoading) {
+            helper = "Loading audio-capable models…";
+        } else if (audioModelsError) {
+            helper = audioModelsError;
+        } else if (hasOptions) {
+            helper =
+                "Only audio-input models are shown. Transcription uses chat-completions; mp3/wav recordings only.";
+        } else {
+            helper = "Enter your API key to load audio-capable models.";
+        }
+    } else if (preset?.knownTranscriptionModels?.length) {
+        helper =
+            "Pick a transcription model. Choose Custom… to type a model id we haven't shipped yet.";
+    }
+
+    return (
+        <div className="space-y-2">
+            <Label htmlFor="defaultModel">Default Model</Label>
+            {hasOptions && !useCustom ? (
+                <Select
+                    value={value || undefined}
+                    onValueChange={handleSelectChange}
+                    disabled={disabled}
+                >
+                    <SelectTrigger>
+                        <SelectValue placeholder="Pick a transcription model" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {options.map((m) => (
+                            <SelectItem key={m.id} value={m.id}>
+                                {m.name}
+                            </SelectItem>
+                        ))}
+                        <SelectItem value={CUSTOM_SENTINEL}>
+                            Custom (type model name)…
+                        </SelectItem>
+                    </SelectContent>
+                </Select>
+            ) : (
+                <Input
+                    id="defaultModel"
+                    type="text"
+                    placeholder="whisper-1, gpt-4o, etc."
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    disabled={disabled}
+                    className="font-mono text-sm"
+                />
+            )}
+            {hasOptions && useCustom && (
+                <button
+                    type="button"
+                    className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+                    onClick={() => {
+                        setUseCustom(false);
+                        onChange(options[0]?.id ?? "");
+                    }}
+                >
+                    Back to suggested models
+                </button>
+            )}
+            {helper && (
+                <p className="text-xs text-muted-foreground">{helper}</p>
+            )}
+        </div>
+    );
+}

--- a/src/lib/ai/provider-presets.ts
+++ b/src/lib/ai/provider-presets.ts
@@ -6,13 +6,61 @@
  * the user's machine; on hosted (`IS_HOSTED=true`) we hide them from the
  * dropdown because the hosted app process can't reach loopback. The API
  * layer enforces the same rule via `validateAiBaseUrl`.
+ *
+ * `transcriptionStyle` controls which API surface the transcription worker
+ * uses for a given preset:
+ *   - "whisper" → OpenAI-compatible `/v1/audio/transcriptions` (multipart).
+ *     Whisper, Groq Whisper, Together Whisper, LM Studio / Ollama Whisper.
+ *   - "chat"    → `/v1/chat/completions` with an `input_audio` content part
+ *     (OpenAI chat-audio spec). Used for providers that expose audio-input
+ *     LLMs instead of a dedicated transcription endpoint, like OpenRouter
+ *     (Gemini / GPT-audio / Voxtral routed under one API). See issue #122.
+ *
+ * The default for the freeform "Custom" preset is "whisper" so existing
+ * OpenAI-compatible self-host setups keep working unchanged.
+ *
+ * ── Maintaining `knownTranscriptionModels` ─────────────────────────────
+ *
+ * For providers that don't expose a structured `input_modalities` field
+ * (everyone except OpenRouter today), we hand-curate the list of
+ * transcription models so the Add/Edit dialog can render a dropdown
+ * instead of forcing users to paste model ids. When a provider ships a
+ * new transcription model:
+ *
+ *   1. Add the model id (exact string the API expects) to the relevant
+ *      preset's `knownTranscriptionModels` array.
+ *   2. Note it under `### Added` in `CHANGELOG.md` under `[Unreleased]`.
+ *
+ * No DB migration is needed — `defaultModel` is a free-form `varchar`,
+ * and the dialogs render a "Custom…" escape hatch so users on a stale
+ * release can still type a new model id by hand.
  */
+
+export type TranscriptionStyle = "whisper" | "chat";
 
 export interface ProviderPreset {
     name: string;
     baseUrl: string;
     placeholder: string;
     defaultModel: string;
+    /**
+     * Which transcription API surface this preset uses. Defaults to
+     * "whisper" if absent (treated as Whisper-compatible).
+     */
+    transcriptionStyle: TranscriptionStyle;
+    /**
+     * If true, the UI offers to fetch the live list of audio-capable models
+     * from the provider's `/v1/models` endpoint when the user enters an
+     * API key. Only OpenRouter exposes per-model `input_modalities` today.
+     */
+    fetchAudioModels?: boolean;
+    /**
+     * Hand-curated list of transcription model ids for providers without a
+     * structured capability tag. Drives the dropdown in the dialog; users
+     * can still pick "Custom…" to type an arbitrary id (escape hatch for
+     * new releases that ship before our next OpenPlaud version).
+     */
+    knownTranscriptionModels?: readonly string[];
 }
 
 export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
@@ -21,42 +69,71 @@ export const PROVIDER_PRESETS: readonly ProviderPreset[] = [
         baseUrl: "",
         placeholder: "sk-...",
         defaultModel: "whisper-1",
+        transcriptionStyle: "whisper",
+        knownTranscriptionModels: [
+            "whisper-1",
+            "gpt-4o-transcribe",
+            "gpt-4o-mini-transcribe",
+            "gpt-4o-transcribe-diarize",
+        ],
     },
     {
         name: "Groq",
         baseUrl: "https://api.groq.com/openai/v1",
         placeholder: "gsk_...",
         defaultModel: "whisper-large-v3-turbo",
+        transcriptionStyle: "whisper",
+        knownTranscriptionModels: [
+            "whisper-large-v3-turbo",
+            "whisper-large-v3",
+        ],
     },
     {
+        // FIX: Together AI's actual model id is prefixed `openai/`. The
+        // previous default `whisper-large-v3` (no prefix) silently 404'd
+        // on Together accounts. Their docs:
+        // https://docs.together.ai/docs/serverless-models#audio-models
         name: "Together AI",
         baseUrl: "https://api.together.xyz/v1",
         placeholder: "...",
-        defaultModel: "whisper-large-v3",
+        defaultModel: "openai/whisper-large-v3",
+        transcriptionStyle: "whisper",
+        knownTranscriptionModels: [
+            "openai/whisper-large-v3",
+            "nvidia/parakeet-tdt-0.6b-v3",
+        ],
     },
     {
+        // OpenRouter does NOT expose `/v1/audio/transcriptions`. Audio runs
+        // through chat-completions with audio-input models (Gemini 2.x/3.x,
+        // openai/gpt-audio, mistralai/voxtral, etc.). See issue #122.
         name: "OpenRouter",
         baseUrl: "https://openrouter.ai/api/v1",
         placeholder: "sk-or-...",
-        defaultModel: "whisper-1",
+        defaultModel: "google/gemini-2.5-flash-lite",
+        transcriptionStyle: "chat",
+        fetchAudioModels: true,
     },
     {
         name: "LM Studio",
         baseUrl: "http://localhost:1234/v1",
         placeholder: "lm-studio",
         defaultModel: "",
+        transcriptionStyle: "whisper",
     },
     {
         name: "Ollama",
         baseUrl: "http://localhost:11434/v1",
         placeholder: "ollama",
         defaultModel: "",
+        transcriptionStyle: "whisper",
     },
     {
         name: "Custom",
         baseUrl: "",
         placeholder: "Your API key",
         defaultModel: "",
+        transcriptionStyle: "whisper",
     },
 ] as const;
 
@@ -84,4 +161,15 @@ export function findPreset(name: string): ProviderPreset | undefined {
 
 export function isLocalPreset(name: string): boolean {
     return LOCAL_PRESET_NAMES.has(name);
+}
+
+/**
+ * Resolve the transcription style for a stored credential's provider name.
+ * Unknown providers (free-form "Custom" name, legacy values) default to
+ * "whisper" — every Whisper-compatible OpenAI-like endpoint keeps working.
+ */
+export function getTranscriptionStyle(
+    providerName: string,
+): TranscriptionStyle {
+    return findPreset(providerName)?.transcriptionStyle ?? "whisper";
 }

--- a/src/lib/transcription/chat-transcribe.ts
+++ b/src/lib/transcription/chat-transcribe.ts
@@ -1,0 +1,118 @@
+/**
+ * Chat-completions-based transcription path.
+ *
+ * Used for providers that expose audio-input LLMs via `/v1/chat/completions`
+ * instead of a dedicated `/v1/audio/transcriptions` endpoint — OpenRouter
+ * being the motivating case (issue #122).
+ *
+ * Wire format follows OpenAI's chat-audio spec: an `input_audio` content
+ * part with `{ data: <base64>, format: "mp3" | "wav" }`. We pass a short
+ * system-style instruction telling the model to output the transcript
+ * verbatim with no commentary.
+ *
+ * Limitations (documented in the dialog and in the README):
+ *   - Format support is mp3 / wav only. Opus / OGG / m4a uploads are
+ *     rejected with an actionable error pointing the user at a Whisper
+ *     provider. Plaud-synced recordings are always mp3 (sync hardcodes
+ *     the extension) so this only bites direct uploads of non-mp3 files.
+ *   - No segment timestamps / verbose-JSON metadata — chat-style models
+ *     don't surface those. We return `detectedLanguage: language ?? null`
+ *     so an explicit language hint still propagates to the DB.
+ */
+
+import type { OpenAI } from "openai";
+
+export interface ChatTranscribeArgs {
+    client: OpenAI;
+    model: string;
+    audioBuffer: Buffer;
+    /** MIME content type from the stored audio (e.g. "audio/mpeg"). */
+    contentType: string;
+    /** ISO language hint forwarded to the model in the prompt. */
+    language?: string;
+}
+
+export interface ChatTranscribeResult {
+    text: string;
+    detectedLanguage: string | null;
+}
+
+/**
+ * Map our internal MIME types to the `format` strings OpenAI chat-audio
+ * accepts. Anything not in this map throws — see file header.
+ */
+function contentTypeToAudioFormat(contentType: string): "mp3" | "wav" {
+    const ct = contentType.toLowerCase();
+    if (ct === "audio/mpeg" || ct === "audio/mp3") return "mp3";
+    if (ct === "audio/wav" || ct === "audio/x-wav" || ct === "audio/wave") {
+        return "wav";
+    }
+    throw new ChatTranscribeFormatError(contentType);
+}
+
+export class ChatTranscribeFormatError extends Error {
+    constructor(public contentType: string) {
+        super(
+            `This transcription provider only accepts mp3 or wav audio (got ${contentType}). ` +
+                `Re-upload as mp3/wav, or set a Whisper-compatible provider (OpenAI, Groq, Together AI, ` +
+                `or a local Whisper server) as your default for transcription.`,
+        );
+        this.name = "ChatTranscribeFormatError";
+    }
+}
+
+const TRANSCRIBE_INSTRUCTION =
+    "Transcribe the attached audio verbatim. Output only the transcript text — no preamble, no summary, no timestamps, no speaker labels, no markdown.";
+
+export async function chatTranscribe({
+    client,
+    model,
+    audioBuffer,
+    contentType,
+    language,
+}: ChatTranscribeArgs): Promise<ChatTranscribeResult> {
+    const format = contentTypeToAudioFormat(contentType);
+    const data = audioBuffer.toString("base64");
+
+    const prompt = language
+        ? `${TRANSCRIBE_INSTRUCTION} The audio language is ${language}.`
+        : TRANSCRIBE_INSTRUCTION;
+
+    // The OpenAI SDK's typed `content` union doesn't include `input_audio`
+    // for `chat.completions.create` yet (it only types it on the Responses
+    // API). At wire-level the parameter is correct for any OpenAI-compatible
+    // provider that supports chat-audio (OpenRouter, OpenAI gpt-audio). We
+    // pass through the typed object via a structural cast — no runtime
+    // transform — and assert the result shape we actually rely on.
+    const response = await client.chat.completions.create({
+        model,
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: prompt },
+                    {
+                        // Cast: see comment above.
+                        type: "input_audio",
+                        input_audio: { data, format },
+                    } as unknown as {
+                        type: "text";
+                        text: string;
+                    },
+                ],
+            },
+        ],
+    });
+
+    const text = response.choices?.[0]?.message?.content;
+    if (typeof text !== "string" || text.trim() === "") {
+        throw new Error(
+            "Transcription provider returned an empty response. The model may not support audio input — pick an audio-capable model.",
+        );
+    }
+
+    return {
+        text: text.trim(),
+        detectedLanguage: language ?? null,
+    };
+}

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -9,10 +9,12 @@ import {
     userSettings,
 } from "@/db/schema";
 import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
+import { getTranscriptionStyle } from "@/lib/ai/provider-presets";
 import { decrypt } from "@/lib/encryption";
 import { decryptText, encryptText } from "@/lib/encryption/fields";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
+import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
 import {
     getResponseFormat,
     parseTranscriptionResponse,
@@ -114,17 +116,41 @@ export async function transcribeRecording(
 
         const model = credentials.defaultModel || "whisper-1";
 
-        const responseFormat = getResponseFormat(model);
+        // Chat-style providers (OpenRouter today) don't implement
+        // `/v1/audio/transcriptions` — calling that path returns a 404
+        // with a non-JSON body that crashes the OpenAI SDK's response
+        // parser (issue #122). Route those through chat-completions
+        // with an `input_audio` content part instead.
+        const transcriptionStyle = getTranscriptionStyle(credentials.provider);
 
-        const transcription = await openai.audio.transcriptions.create({
-            file: audioFile,
-            model,
-            response_format: responseFormat,
-            ...(defaultLanguage ? { language: defaultLanguage } : {}),
-        });
+        let transcriptionText: string;
+        let detectedLanguage: string | null;
 
-        const { text: transcriptionText, detectedLanguage } =
-            parseTranscriptionResponse(transcription, responseFormat);
+        if (transcriptionStyle === "chat") {
+            const result = await chatTranscribe({
+                client: openai,
+                model,
+                audioBuffer,
+                contentType,
+                language: defaultLanguage,
+            });
+            transcriptionText = result.text;
+            detectedLanguage = result.detectedLanguage;
+        } else {
+            const responseFormat = getResponseFormat(model);
+            const transcription = await openai.audio.transcriptions.create({
+                file: audioFile,
+                model,
+                response_format: responseFormat,
+                ...(defaultLanguage ? { language: defaultLanguage } : {}),
+            });
+            const parsed = parseTranscriptionResponse(
+                transcription,
+                responseFormat,
+            );
+            transcriptionText = parsed.text;
+            detectedLanguage = parsed.detectedLanguage;
+        }
 
         const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
         try {

--- a/src/tests/provider-presets.test.ts
+++ b/src/tests/provider-presets.test.ts
@@ -55,4 +55,56 @@ describe("provider-presets", () => {
             expect(findPreset("Nope")).toBeUndefined();
         });
     });
+
+    describe("knownTranscriptionModels", () => {
+        it("OpenAI includes whisper-1 plus the gpt-4o-transcribe family", () => {
+            const models = findPreset("OpenAI")?.knownTranscriptionModels;
+            expect(models).toEqual([
+                "whisper-1",
+                "gpt-4o-transcribe",
+                "gpt-4o-mini-transcribe",
+                "gpt-4o-transcribe-diarize",
+            ]);
+        });
+
+        it("Groq lists current Whisper Large v3 models (no distil)", () => {
+            const models = findPreset("Groq")?.knownTranscriptionModels;
+            expect(models).toEqual([
+                "whisper-large-v3-turbo",
+                "whisper-large-v3",
+            ]);
+        });
+
+        it("Together AI uses the correct prefixed Whisper id", () => {
+            // Regression: the preset default used to be `whisper-large-v3`
+            // (no prefix), which 404s on Together AI. Their actual id is
+            // `openai/whisper-large-v3` per the audio section of
+            // docs.together.ai/docs/serverless-models.
+            const preset = findPreset("Together AI");
+            expect(preset?.defaultModel).toBe("openai/whisper-large-v3");
+            expect(preset?.knownTranscriptionModels).toEqual([
+                "openai/whisper-large-v3",
+                "nvidia/parakeet-tdt-0.6b-v3",
+            ]);
+        });
+
+        it("local + custom presets have no curated list (freeform input)", () => {
+            expect(
+                findPreset("LM Studio")?.knownTranscriptionModels,
+            ).toBeUndefined();
+            expect(
+                findPreset("Ollama")?.knownTranscriptionModels,
+            ).toBeUndefined();
+            expect(
+                findPreset("Custom")?.knownTranscriptionModels,
+            ).toBeUndefined();
+        });
+
+        it("every defaultModel appears in its preset's known list when one exists", () => {
+            for (const p of PROVIDER_PRESETS) {
+                if (!p.knownTranscriptionModels) continue;
+                expect(p.knownTranscriptionModels).toContain(p.defaultModel);
+            }
+        });
+    });
 });

--- a/src/tests/regressions/122-openrouter-transcription.test.ts
+++ b/src/tests/regressions/122-openrouter-transcription.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Regression: issue #122
+ *
+ * Background: OpenRouter doesn't implement `/v1/audio/transcriptions`.
+ * Before this fix, transcribing with an OpenRouter credential POSTed
+ * multipart audio to that 404 endpoint and crashed inside the OpenAI
+ * SDK's response parser ("No number after minus sign in JSON…").
+ *
+ * After the fix, providers with `transcriptionStyle: "chat"` route
+ * through `chat.completions.create` with an `input_audio` content part.
+ * The recording's transcription row is written from the chat response
+ * text exactly as for the Whisper path.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    decrypt: vi.fn().mockReturnValue("fake-api-key"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+}));
+
+vi.mock("@/lib/encryption/fields", async () => {
+    const actual = await vi.importActual<
+        typeof import("@/lib/encryption/fields")
+    >("@/lib/encryption/fields");
+    return {
+        ...actual,
+        decryptText: vi.fn((value: string) => value),
+        encryptText: vi.fn((value: string) => `enc:${value}`),
+    };
+});
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("fake-mp3-bytes")),
+    }),
+}));
+
+const audioCreate = vi.fn();
+const chatCreate = vi.fn();
+
+vi.mock("openai", () => {
+    const MockOpenAI = vi.fn(() => ({
+        audio: { transcriptions: { create: audioCreate } },
+        chat: { completions: { create: chatCreate } },
+    }));
+    return { OpenAI: MockOpenAI };
+});
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/ai/generate-title", () => ({
+    generateTitleFromTranscription: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+import { OpenAI } from "openai";
+import { db } from "@/db";
+import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+
+describe("issue #122 — OpenRouter transcription uses chat-completions", () => {
+    const userId = "user-122";
+    const recordingId = "rec-122";
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        audioCreate.mockReset();
+        chatCreate.mockReset();
+        // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+        (OpenAI as unknown as Mock).mockImplementation(function () {
+            return {
+                audio: { transcriptions: { create: audioCreate } },
+                chat: { completions: { create: chatCreate } },
+            };
+        });
+    });
+
+    it("routes OpenRouter credentials through chat.completions and never hits /audio/transcriptions", async () => {
+        chatCreate.mockResolvedValue({
+            choices: [
+                {
+                    message: {
+                        content: "this is the transcript from openrouter",
+                    },
+                },
+            ],
+        });
+
+        (db.select as Mock)
+            // recording lookup
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                id: recordingId,
+                                userId,
+                                plaudFileId: "plaud-1",
+                                filename: "Some Recording",
+                                storagePath: "rec-122.mp3",
+                                deletedAt: null,
+                            },
+                        ]),
+                    }),
+                }),
+            })
+            // existing transcription
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([]),
+                    }),
+                }),
+            })
+            // credentials
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                id: "creds-1",
+                                provider: "OpenRouter",
+                                apiKey: "encrypted-key",
+                                baseUrl: "https://openrouter.ai/api/v1",
+                                defaultModel: "google/gemini-2.5-flash-lite",
+                            },
+                        ]),
+                    }),
+                }),
+            })
+            // settings
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                autoGenerateTitle: false,
+                                syncTitleToPlaud: false,
+                                transcriptionQuality: "balanced",
+                            },
+                        ]),
+                    }),
+                }),
+            });
+
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            for: vi.fn().mockReturnValue({
+                                limit: vi
+                                    .fn()
+                                    .mockResolvedValue([{ deletedAt: null }]),
+                            }),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([]),
+                        }),
+                    }),
+                }),
+            insert: vi.fn().mockReturnValue({
+                values: vi.fn().mockResolvedValue(undefined),
+            }),
+            update: vi.fn().mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+        );
+
+        const result = await transcribeRecording(userId, recordingId);
+
+        expect(result.success).toBe(true);
+        expect(audioCreate).not.toHaveBeenCalled();
+        expect(chatCreate).toHaveBeenCalledTimes(1);
+
+        const chatArgs = chatCreate.mock.calls[0]?.[0];
+        expect(chatArgs?.model).toBe("google/gemini-2.5-flash-lite");
+        const contentParts = chatArgs?.messages?.[0]?.content as Array<{
+            type: string;
+            input_audio?: { format: string; data: string };
+        }>;
+        expect(Array.isArray(contentParts)).toBe(true);
+        const audioPart = contentParts.find((p) => p.type === "input_audio");
+        expect(audioPart?.input_audio?.format).toBe("mp3");
+        expect(typeof audioPart?.input_audio?.data).toBe("string");
+        expect(audioPart?.input_audio?.data.length).toBeGreaterThan(0);
+    });
+
+    it("returns an actionable error when the audio is opus (chat-style providers can't accept it)", async () => {
+        (db.select as Mock)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                id: recordingId,
+                                userId,
+                                plaudFileId: "plaud-1",
+                                filename: "Opus upload",
+                                storagePath: "rec-122.opus",
+                                deletedAt: null,
+                            },
+                        ]),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([]),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                id: "creds-1",
+                                provider: "OpenRouter",
+                                apiKey: "encrypted-key",
+                                baseUrl: "https://openrouter.ai/api/v1",
+                                defaultModel: "google/gemini-2.5-flash-lite",
+                            },
+                        ]),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                autoGenerateTitle: false,
+                                syncTitleToPlaud: false,
+                                transcriptionQuality: "balanced",
+                            },
+                        ]),
+                    }),
+                }),
+            });
+
+        const result = await transcribeRecording(userId, recordingId);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/mp3|wav/i);
+        expect(chatCreate).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Description

Fixes the OpenRouter transcription crash reported in #122 by routing chat-style providers through `chat.completions.create` instead of the (nonexistent) `/v1/audio/transcriptions` endpoint. Also ships curated transcription-model dropdowns for the well-known providers and corrects a latent bug in the Together AI default model id.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #122

## Changes Made

- **Chat-completions transcription path** (`src/lib/transcription/chat-transcribe.ts`). New `ProviderPreset.transcriptionStyle: "whisper" | "chat"` selects the API surface in `transcribe-recording.ts`. Unknown providers default to `"whisper"` so every existing Whisper-style endpoint keeps working unchanged. OpenRouter sends a base64 `input_audio` content part (mp3/wav); opus uploads fail fast with an actionable error pointing users at a Whisper provider. Plaud-synced recordings are always mp3 so this only bites direct uploads of non-mp3 files.
- **Live audio-model fetch** at `POST /api/settings/ai/providers/models`. Auth-gated, hosted-mode loopback guard, 10s timeout. For OpenRouter, calls `/v1/models` and filters by `architecture.input_modalities.includes("audio")`. Other presets return `[]` and fall back to the curated lists below.
- **Curated transcription model lists** for OpenAI (`whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`), Groq (`whisper-large-v3-turbo`, `whisper-large-v3`), and Together AI (`openai/whisper-large-v3`, `nvidia/parakeet-tdt-0.6b-v3`), sourced from each provider's current docs. Shared `<TranscriptionModelPicker>` component renders a dropdown with a `Custom…` escape hatch so self-host users on stale releases can still type ids we haven't seeded yet. Picker resets cleanly on preset change.
- **Together AI default-model fix.** The previous default `"whisper-large-v3"` (unprefixed) silently 404s on Together. Corrected to `"openai/whisper-large-v3"`. Regression-guarded in `provider-presets.test.ts`.
- **Maintenance docblock** at the top of `provider-presets.ts` describing how to add new transcription models in future releases.

## Screenshots (if applicable)

N/A — UI changes are localized to the existing Add/Edit AI Provider dialogs and replace the freeform "Default Model" input with a dropdown for the curated presets. The label was also updated from "Default Model (Optional)" to "Default Model".

## Testing

### Test Environment
- OS: macOS
- Node version: 22 (via pnpm)
- Browser (if UI changes): N/A in this run — UI behavior covered manually + via the picker's deterministic state.

### Test Steps

Commands run locally:

```
pnpm type-check                # clean
pnpm test                      # 292 passed, 3 skipped (Plaud integration, opt-in)
pnpm format-and-lint:fix       # clean (only 2 pre-existing unrelated infos)
```

Specific regression coverage:

- `src/tests/regressions/122-openrouter-transcription.test.ts`
  - OpenRouter credentials route through `chat.completions.create` and never hit `audio.transcriptions.create`; verifies the request ships a base64-encoded `input_audio` mp3 part.
  - Opus storagePath → response error contains "mp3"/"wav" and the chat call is not made.
- `src/tests/provider-presets.test.ts`
  - Curated lists per provider, the Together AI prefix fix (regression-guarded), and an invariant that every preset's `defaultModel` appears in its own `knownTranscriptionModels` array.

Also live-verified `https://openrouter.ai/api/v1/models` payload shape (`architecture.input_modalities`) and `https://openrouter.ai/api/v1/audio/transcriptions` 404 before writing the fix.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

No DB changes. `provider` and `defaultModel` are existing free-form `varchar` columns.

## Breaking Changes

None.

- No schema, env var, or docker-compose change.
- `transcriptionStyle` defaults to `"whisper"` for unknown providers, so any custom / legacy credential keeps working.
- Existing OpenRouter credentials that were stuck on `defaultModel: "whisper-1"` (broken before this PR) now hit the chat path. They will fail loudly with a clear message ("model does not support audio input — pick an audio-capable model") and the user can fix it via the edit dialog where the live model dropdown will appear.
- Existing Together AI credentials saved with the old broken `"whisper-large-v3"` default will continue to fail (unchanged behavior); the curated dropdown will offer the correct prefixed id on next edit.

## Additional Notes

Future maintenance of `knownTranscriptionModels` is a single-file change documented inline in `provider-presets.ts`. No migration burden.

Out of scope for this PR (separate concerns if/when prioritized):
- ffmpeg-based opus → wav transcoding so chat-style providers can accept opus uploads. Adds a Docker-image dep; deferred until there's demand.
- Live model fetch for OpenAI/Groq/Together AI. Their `/v1/models` endpoints don't tag transcription capability, so we'd be regex-matching model names — fragile. The curated-list approach was chosen as the better trade.
- README update mentioning OpenRouter transcription. Worth a follow-up docs commit.

## For Reviewers

- `src/lib/transcription/chat-transcribe.ts` — the input_audio content part requires a structural cast; the SDK's typed union doesn't yet include `input_audio` for chat.completions. Comment in the file explains.
- `src/components/settings/transcription-model-picker.tsx` — the `useCustom` state has two effects: a reset on preset change, and a value-driven flip for legacy/unknown stored values. Confirmed both edit-dialog (legacy value) and preset-switch flows.
- `src/app/api/settings/ai/providers/models/route.ts` — auth-only (no DB writes), but it does forward outbound traffic using the user-supplied key. Hosted-mode loopback guard mirrors the credential routes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenRouter transcription crashes by switching chat-style providers to chat completions with audio input and adds a simple model picker for easier setup. Also fixes Together AI’s default model and improves errors for unsupported audio formats. Fixes #122.

- **Bug Fixes**
  - Route OpenRouter through `chat.completions.create` with `input_audio` (no calls to `/v1/audio/transcriptions`).
  - Reject non-mp3/wav uploads on chat-style providers with a clear, actionable error.
  - Correct Together AI default model to `openai/whisper-large-v3`.

- **New Features**
  - Add `transcriptionStyle: "whisper" | "chat"` to presets; unknown providers default to `"whisper"`.
  - Live audio-model fetch for OpenRouter via `POST /api/settings/ai/providers/models` and a shared `<TranscriptionModelPicker>` with a “Custom…” option.
  - Curated transcription model lists:
    - OpenAI: `whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe-diarize`
    - Groq: `whisper-large-v3-turbo`, `whisper-large-v3`
    - Together AI: `openai/whisper-large-v3`, `nvidia/parakeet-tdt-0.6b-v3`

<sup>Written for commit 87c84aad4ff63ef6cfaae85a13f968927e5477ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

