### PR TITLE
fix(analytics): proxy Rybbit at runtime to fix /api/_int/s.js 404 in hosted mode

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,15 +1,12 @@
 import type { NextConfig } from "next";
 
-// Note: we read `process.env` directly here instead of importing the
-// validated `env` from `src/lib/env.ts`. `next.config.ts` is evaluated
-// before Next sets `NEXT_PHASE=phase-production-build`, so the build-phase
-// skip in env.ts doesn't trigger and CI builds (which set placeholder
-// ENCRYPTION_KEY etc.) would fail validation. Build configuration is the
-// documented exception to the "no process.env in feature code" rule.
-const IS_HOSTED = process.env.IS_HOSTED === "true";
-const RYBBIT_HOST = process.env.RYBBIT_HOST?.replace(/\/$/, "");
-const RYBBIT_SITE_ID = process.env.RYBBIT_SITE_ID;
-
+// The Rybbit analytics proxy used to live here as a `rewrites()` entry.
+// `next.config.ts` is evaluated at `next build`, and the published Docker
+// image is built generically without `IS_HOSTED`/`RYBBIT_*` set, so the
+// rewrite list was baked as `[]` and `/api/_int/*` 404'd at runtime even
+// when those vars were configured on the host. The proxy now lives as
+// runtime route handlers under `src/app/api/_int/*` which read `env` at
+// request time, in lockstep with `<RybbitAnalytics>`'s render gate.
 const nextConfig: NextConfig = {
     output: "standalone",
     // The `/install.sh` and `/[version]/install.sh` routes read
@@ -25,33 +22,6 @@ const nextConfig: NextConfig = {
         loader: "custom",
         loaderFile: "./loader.ts",
         remotePatterns: [],
-    },
-    async rewrites() {
-        // Hosted-only stealth proxy for Rybbit analytics. Same-origin paths
-        // bypass ad-blockers; the underscored `_int` prefix avoids analytics
-        // keyword filters. Self-host (no IS_HOSTED + RYBBIT_*) registers no
-        // rewrites and never proxies to Rybbit.
-        if (!IS_HOSTED || !RYBBIT_HOST || !RYBBIT_SITE_ID) {
-            return [];
-        }
-        // Explicit allowlist instead of a `:path*` catch-all so the upstream
-        // Rybbit instance's full /api surface (admin/dashboard endpoints) is
-        // never inadvertently exposed under our origin. Update this list if a
-        // new tracking endpoint is added (e.g. session replay).
-        return [
-            {
-                source: "/api/_int/s.js",
-                destination: `${RYBBIT_HOST}/api/script.js`,
-            },
-            {
-                source: "/api/_int/track",
-                destination: `${RYBBIT_HOST}/api/track`,
-            },
-            {
-                source: "/api/_int/identify",
-                destination: `${RYBBIT_HOST}/api/identify`,
-            },
-        ];
     },
 };
 

--- a/src/app/api/_int/identify/route.ts
+++ b/src/app/api/_int/identify/route.ts
@@ -1,0 +1,7 @@
+import { proxyRybbitEvent } from "@/lib/rybbit/proxy";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+    return proxyRybbitEvent(req, "identify");
+}

--- a/src/app/api/_int/s.js/route.ts
+++ b/src/app/api/_int/s.js/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
+
+// Runtime same-origin proxy for Rybbit's tracking script. Replaces the
+// build-time `rewrites()` entry that used to live in `next.config.ts` —
+// rewrites are baked into `routes-manifest.json` at `next build`, so a
+// generically-built Docker image (no `IS_HOSTED`/`RYBBIT_*` in the build
+// env) shipped an empty rewrite list and 404'd at runtime even when those
+// vars were set on the host. Reading `env` here at request time keeps the
+// proxy in lockstep with `<RybbitAnalytics>`'s render gate.
+//
+// Hosted-only. Self-host returns 404 even if an operator happens to set
+// `RYBBIT_HOST`/`RYBBIT_SITE_ID`, matching `<RybbitAnalytics>`'s render
+// gate exactly so the two never disagree. Self-hosters who want their
+// own Rybbit instance should point it at their app directly rather than
+// going through this proxy.
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+    if (!env.IS_HOSTED || !env.RYBBIT_HOST || !env.RYBBIT_SITE_ID) {
+        return new NextResponse("Not found", { status: 404 });
+    }
+
+    const upstream = `${env.RYBBIT_HOST.replace(/\/$/, "")}/api/script.js`;
+    const res = await fetch(upstream, { cache: "no-store" });
+    if (!res.ok || !res.body) {
+        return new NextResponse("Bad gateway", { status: 502 });
+    }
+
+    const headers = new Headers();
+    headers.set(
+        "Content-Type",
+        res.headers.get("content-type") ??
+            "application/javascript; charset=utf-8",
+    );
+    // Rybbit's script is effectively static per upstream deploy. Let
+    // browsers and our CDN cache it briefly so we don't proxy every page
+    // load; `stale-while-revalidate` keeps it snappy after expiry.
+    headers.set(
+        "Cache-Control",
+        "public, max-age=300, stale-while-revalidate=86400",
+    );
+
+    return new NextResponse(res.body, { status: 200, headers });
+}

--- a/src/app/api/_int/s.js/route.ts
+++ b/src/app/api/_int/s.js/route.ts
@@ -23,7 +23,15 @@ export async function GET() {
     }
 
     const upstream = `${env.RYBBIT_HOST.replace(/\/$/, "")}/api/script.js`;
-    const res = await fetch(upstream, { cache: "no-store" });
+    let res: Response;
+    try {
+        res = await fetch(upstream, { cache: "no-store" });
+    } catch {
+        // DNS failure, timeout, refused connection, etc. Mirror the
+        // event proxy and produce a controlled 502 instead of letting
+        // the route handler crash into a 500.
+        return new NextResponse("Bad gateway", { status: 502 });
+    }
     if (!res.ok || !res.body) {
         return new NextResponse("Bad gateway", { status: 502 });
     }

--- a/src/app/api/_int/track/route.ts
+++ b/src/app/api/_int/track/route.ts
@@ -1,0 +1,7 @@
+import { proxyRybbitEvent } from "@/lib/rybbit/proxy";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+    return proxyRybbitEvent(req, "track");
+}

--- a/src/components/rybbit-analytics.tsx
+++ b/src/components/rybbit-analytics.tsx
@@ -13,11 +13,12 @@ let warnedMisconfig = false;
  * `RYBBIT_HOST` are set. Self-hosters never load it and never make a
  * request to Rybbit.
  *
- * The script is loaded from same-origin (`/api/_int/s.js`) via Next.js
- * rewrites in `next.config.ts`. The Rybbit client derives its tracking
- * endpoint from its own `src`, so events POST back to `/api/_int/track`
- * (also same-origin), which the proxy forwards to `${RYBBIT_HOST}/api/track`.
- * This bypasses ad-blockers that filter third-party analytics.
+ * The script is loaded from same-origin (`/api/_int/s.js`) via runtime
+ * route handlers in `src/app/api/_int/*`. The Rybbit client derives its
+ * tracking endpoint from its own `src`, so events POST back to
+ * `/api/_int/track` (also same-origin), which the proxy forwards to
+ * `${RYBBIT_HOST}/api/track`. This bypasses ad-blockers that filter
+ * third-party analytics.
  */
 export function RybbitAnalytics() {
     if (!env.IS_HOSTED) return null;

--- a/src/lib/rybbit/proxy.ts
+++ b/src/lib/rybbit/proxy.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
+
+// Shared runtime proxy for Rybbit event endpoints (`track`, `identify`).
+// See `s.js/route.ts` for why this is a runtime route handler instead of a
+// `next.config.ts` rewrite.
+//
+// Rybbit derives the client IP from `X-Forwarded-For` (otherwise everything
+// looks like it came from our app's egress IP and geolocation collapses to
+// one country). Forward that, the User-Agent, and the original body
+// verbatim. Don't forward cookies or `Authorization` — same-origin pages
+// would otherwise leak our auth session cookies to the analytics backend.
+
+type Endpoint = "track" | "identify";
+
+export async function proxyRybbitEvent(
+    req: Request,
+    endpoint: Endpoint,
+): Promise<NextResponse> {
+    if (!env.IS_HOSTED || !env.RYBBIT_HOST || !env.RYBBIT_SITE_ID) {
+        return new NextResponse("Not found", { status: 404 });
+    }
+
+    const upstream = `${env.RYBBIT_HOST.replace(/\/$/, "")}/api/${endpoint}`;
+    const body = await req.arrayBuffer();
+
+    const headers = new Headers();
+    headers.set(
+        "Content-Type",
+        req.headers.get("content-type") ?? "application/json",
+    );
+    const ua = req.headers.get("user-agent");
+    if (ua) headers.set("User-Agent", ua);
+
+    // Preserve the original client IP for Rybbit's geolocation. Next.js
+    // doesn't expose req.ip on the standard Request, so we rebuild XFF
+    // from the inbound header (set by our reverse proxy / load balancer).
+    const xff = req.headers.get("x-forwarded-for");
+    if (xff) headers.set("X-Forwarded-For", xff);
+    const realIp = req.headers.get("x-real-ip");
+    if (realIp && !xff) headers.set("X-Forwarded-For", realIp);
+
+    let upstreamRes: Response;
+    try {
+        upstreamRes = await fetch(upstream, {
+            method: "POST",
+            headers,
+            body,
+            cache: "no-store",
+        });
+    } catch {
+        return new NextResponse("Bad gateway", { status: 502 });
+    }
+
+    const resHeaders = new Headers();
+    const ct = upstreamRes.headers.get("content-type");
+    if (ct) resHeaders.set("Content-Type", ct);
+
+    return new NextResponse(upstreamRes.body, {
+        status: upstreamRes.status,
+        headers: resHeaders,
+    });
+}

--- a/src/tests/regressions/90-rybbit-env.test.ts
+++ b/src/tests/regressions/90-rybbit-env.test.ts
@@ -7,9 +7,9 @@
  *   - RYBBIT_HOST is an optional URL; non-URL strings must be rejected.
  *   - Partial config (only one of the two set) parses fine at the schema
  *     level. The runtime gate in src/components/rybbit-analytics.tsx and
- *     next.config.ts requires BOTH to be set before activating analytics,
- *     so a half-configured hosted deploy stays disabled rather than
- *     half-broken.
+ *     the proxy route handlers under src/app/api/_int/* require BOTH to
+ *     be set before activating analytics, so a half-configured hosted
+ *     deploy stays disabled rather than half-broken.
  *
  * NEXT_PHASE is set so importing env.ts does not run the runtime
  * validation (DATABASE_URL etc) - we only need the schema here.
@@ -63,8 +63,8 @@ describe("PR #90: Rybbit env contract", () => {
 
     it("accepts only RYBBIT_SITE_ID without RYBBIT_HOST (partial config)", () => {
         // The schema allows partial config; runtime gates in the analytics
-        // component + next.config.ts enforce that BOTH must be set before
-        // analytics activates. This stays disabled, not half-broken.
+        // component + /api/_int/* route handlers enforce that BOTH must be
+        // set before analytics activates. This stays disabled, not half-broken.
         const parsed = envSchema.parse({ RYBBIT_SITE_ID: "abc123" });
         expect(parsed.RYBBIT_SITE_ID).toBe("abc123");
         expect(parsed.RYBBIT_HOST).toBeUndefined();

--- a/src/tests/regressions/rybbit-proxy-runtime.test.ts
+++ b/src/tests/regressions/rybbit-proxy-runtime.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression test for the Rybbit analytics proxy 404 bug:
+ *   https://openplaud.com/api/_int/s.js returned 404 even though
+ *   IS_HOSTED + RYBBIT_HOST + RYBBIT_SITE_ID were set on the host.
+ *
+ * Root cause: `next.config.ts` `rewrites()` is evaluated at `next build`.
+ * The published Docker image (`ghcr.io/openplaud/openplaud:*`) is built
+ * generically without those env vars, so the rewrite list was baked as
+ * `[]` and never reinstated at runtime. <RybbitAnalytics> reads env at
+ * request time and emitted <script src="/api/_int/s.js"> anyway -> 404.
+ *
+ * Fix: replace the build-time rewrites with runtime route handlers under
+ * src/app/api/_int/* that read env at request time, in lockstep with the
+ * component's render gate.
+ *
+ * This test verifies the runtime contract for those handlers:
+ *   - unconfigured (RYBBIT_HOST or RYBBIT_SITE_ID missing) -> 404
+ *   - configured -> proxies to ${RYBBIT_HOST}/api/{script.js,track,identify}
+ *     with body forwarded and (for events) client IP / UA preserved.
+ */
+
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from "vitest";
+
+// Mocked env module read by the route handlers. We mutate `mockEnv` per
+// test and the handlers see the updated values because they reference
+// `env.RYBBIT_HOST` etc. at request time, not at import time.
+const mockEnv: {
+    IS_HOSTED?: boolean;
+    RYBBIT_HOST?: string;
+    RYBBIT_SITE_ID?: string;
+} = {};
+
+vi.mock("@/lib/env", () => ({
+    get env() {
+        return mockEnv;
+    },
+}));
+
+type FetchMock = ReturnType<typeof vi.fn>;
+let fetchMock: FetchMock;
+let originalFetch: typeof globalThis.fetch;
+
+beforeAll(() => {
+    originalFetch = globalThis.fetch;
+});
+
+afterAll(() => {
+    globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+    mockEnv.IS_HOSTED = undefined;
+    mockEnv.RYBBIT_HOST = undefined;
+    mockEnv.RYBBIT_SITE_ID = undefined;
+    vi.restoreAllMocks();
+});
+
+function installFetchMock(response: Response) {
+    fetchMock = vi.fn().mockResolvedValue(response);
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+}
+
+describe("Rybbit proxy: /api/_int/s.js", () => {
+    it("returns 404 when IS_HOSTED is false (self-host)", async () => {
+        // Even if a self-hoster happens to set RYBBIT_*, the proxy stays
+        // off unless IS_HOSTED=true, matching <RybbitAnalytics>'s gate.
+        mockEnv.IS_HOSTED = false;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        const res = await GET();
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when RYBBIT_HOST is missing", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        const res = await GET();
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when RYBBIT_SITE_ID is missing", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        const res = await GET();
+        expect(res.status).toBe(404);
+    });
+
+    it("proxies to RYBBIT_HOST/api/script.js when configured", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(
+            new Response("/* rybbit script */", {
+                status: 200,
+                headers: { "content-type": "application/javascript" },
+            }),
+        );
+
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        const res = await GET();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://rybbit.example.com/api/script.js",
+            expect.objectContaining({ cache: "no-store" }),
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain(
+            "application/javascript",
+        );
+        expect(await res.text()).toBe("/* rybbit script */");
+    });
+
+    it("strips trailing slash from RYBBIT_HOST", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com/";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(new Response("ok", { status: 200 }));
+
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        await GET();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://rybbit.example.com/api/script.js",
+            expect.anything(),
+        );
+    });
+
+    it("returns 502 when upstream fails", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(new Response("nope", { status: 500 }));
+
+        const { GET } = await import("@/app/api/_int/s.js/route");
+        const res = await GET();
+        expect(res.status).toBe(502);
+    });
+});
+
+describe("Rybbit proxy: /api/_int/track", () => {
+    it("returns 404 when unconfigured", async () => {
+        const { POST } = await import("@/app/api/_int/track/route");
+        const res = await POST(
+            new Request("https://app.example.com/api/_int/track", {
+                method: "POST",
+                body: JSON.stringify({ event: "pageview" }),
+            }),
+        );
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when IS_HOSTED is false even if RYBBIT_* are set", async () => {
+        mockEnv.IS_HOSTED = false;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        const { POST } = await import("@/app/api/_int/track/route");
+        const res = await POST(
+            new Request("https://app.example.com/api/_int/track", {
+                method: "POST",
+                body: "{}",
+            }),
+        );
+        expect(res.status).toBe(404);
+    });
+
+    it("forwards body, content-type, UA, and X-Forwarded-For", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(new Response("{}", { status: 202 }));
+
+        const payload = JSON.stringify({ event: "pageview", path: "/" });
+        const { POST } = await import("@/app/api/_int/track/route");
+        const res = await POST(
+            new Request("https://app.example.com/api/_int/track", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "user-agent": "Mozilla/5.0 test",
+                    "x-forwarded-for": "203.0.113.7",
+                    // Auth cookies must NOT be forwarded to the analytics
+                    // backend - same-origin pages send them automatically.
+                    cookie: "session=secret",
+                    authorization: "Bearer secret",
+                },
+                body: payload,
+            }),
+        );
+
+        expect(res.status).toBe(202);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("https://rybbit.example.com/api/track");
+        expect(init.method).toBe("POST");
+        const headers = new Headers(init.headers);
+        expect(headers.get("content-type")).toBe("application/json");
+        expect(headers.get("user-agent")).toBe("Mozilla/5.0 test");
+        expect(headers.get("x-forwarded-for")).toBe("203.0.113.7");
+        expect(headers.get("cookie")).toBeNull();
+        expect(headers.get("authorization")).toBeNull();
+        const body = init.body as ArrayBuffer;
+        expect(new TextDecoder().decode(body)).toBe(payload);
+    });
+
+    it("falls back to X-Real-IP when X-Forwarded-For is absent", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(new Response("{}", { status: 202 }));
+
+        const { POST } = await import("@/app/api/_int/track/route");
+        await POST(
+            new Request("https://app.example.com/api/_int/track", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "x-real-ip": "203.0.113.9",
+                },
+                body: "{}",
+            }),
+        );
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        const headers = new Headers(init.headers);
+        expect(headers.get("x-forwarded-for")).toBe("203.0.113.9");
+    });
+
+    it("returns 502 when upstream fetch throws", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+        globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+        const { POST } = await import("@/app/api/_int/track/route");
+        const res = await POST(
+            new Request("https://app.example.com/api/_int/track", {
+                method: "POST",
+                body: "{}",
+            }),
+        );
+        expect(res.status).toBe(502);
+    });
+});
+
+describe("Rybbit proxy: /api/_int/identify", () => {
+    it("proxies to RYBBIT_HOST/api/identify", async () => {
+        mockEnv.IS_HOSTED = true;
+        mockEnv.RYBBIT_HOST = "https://rybbit.example.com";
+        mockEnv.RYBBIT_SITE_ID = "site-1";
+        installFetchMock(new Response("{}", { status: 202 }));
+
+        const { POST } = await import("@/app/api/_int/identify/route");
+        const res = await POST(
+            new Request("https://app.example.com/api/_int/identify", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ userId: "u_1" }),
+            }),
+        );
+
+        expect(res.status).toBe(202);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://rybbit.example.com/api/identify",
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+});

--- a/src/tests/regressions/rybbit-proxy-runtime.test.ts
+++ b/src/tests/regressions/rybbit-proxy-runtime.test.ts
@@ -60,6 +60,10 @@ afterEach(() => {
     mockEnv.IS_HOSTED = undefined;
     mockEnv.RYBBIT_HOST = undefined;
     mockEnv.RYBBIT_SITE_ID = undefined;
+    // Restore per-test, not just per-file: Vitest workers can execute
+    // multiple test files in the same process and a leaked `fetch` mock
+    // would cause order-dependent failures elsewhere.
+    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Description

`https://openplaud.com/api/_int/s.js` was returning 404 in hosted mode, breaking Rybbit analytics. Root cause: `next.config.ts` `rewrites()` runs at `next build`. The published Docker image (`ghcr.io/openplaud/openplaud:*`) is built generically without `IS_HOSTED` / `RYBBIT_HOST` / `RYBBIT_SITE_ID`, so the rewrite list was baked as `[]` and the `/api/_int/*` routes never existed at runtime even when those vars were set on the host. `<RybbitAnalytics>` reads env at request time and emitted `<script src="/api/_int/s.js">` anyway → 404.

Fix: replace the build-time rewrites with runtime route handlers that read `env` at request time, in lockstep with the component's render gate.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

No tracking issue.

## Changes Made

- Add runtime route handlers `src/app/api/_int/{s.js,track,identify}/route.ts` that proxy to `${RYBBIT_HOST}/api/{script.js,track,identify}` when `IS_HOSTED=true && RYBBIT_HOST && RYBBIT_SITE_ID`. Same gate as `<RybbitAnalytics>` so the component and the proxy can never disagree. `s.js` sets a `Content-Type: application/javascript` response and a short `Cache-Control: public, max-age=300, stale-while-revalidate=86400` so we're not proxying on every page load.
- Add `src/lib/rybbit/proxy.ts` shared by the `track` and `identify` handlers. Forwards request body, `Content-Type`, `User-Agent`, and `X-Forwarded-For` (with `X-Real-IP` fallback) so Rybbit's geolocation keeps working behind our reverse proxy. Drops `Cookie` and `Authorization` so same-origin auth sessions don't leak to the analytics backend. Returns 502 on upstream failure instead of bubbling exceptions.
- Remove the dead `async rewrites()` block from `next.config.ts` and document the build-vs-runtime trap that caused this so the same mistake doesn't get reintroduced.
- Update the `<RybbitAnalytics>` docstring and a stale `next.config.ts` reference in `90-rybbit-env.test.ts` to point at the new gate location.

## Testing

### Test Environment
- OS: macOS
- Node version: project pinned (Bun/Next 15)

### Test Steps
- `pnpm test src/tests/regressions/rybbit-proxy-runtime.test.ts` → 12 tests pass
- `pnpm test` → 295 tests pass, 3 skipped (Plaud integration, unchanged)
- `pnpm format-and-lint:fix` → clean
- `pnpm type-check` → clean

New regression test `src/tests/regressions/rybbit-proxy-runtime.test.ts` covers:

- 404 when self-host (`IS_HOSTED=false`) even if `RYBBIT_*` are set
- 404 when `RYBBIT_HOST` or `RYBBIT_SITE_ID` is missing
- Correct upstream URL for all three endpoints, including trailing-slash normalization on `RYBBIT_HOST`
- Body, `Content-Type`, `User-Agent`, `X-Forwarded-For` forwarded
- `X-Real-IP` fallback when `X-Forwarded-For` is absent
- `Cookie` and `Authorization` dropped (no auth leakage to analytics)
- 502 on upstream `fetch` failure and on non-2xx for the script route

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. Behavior on self-host is unchanged — `<RybbitAnalytics>` still returns `null` without `IS_HOSTED`, and the new route handlers return 404 in that case too. Hosted behavior is restored to what was originally intended.

## Additional Notes

The fix takes effect on the next deploy without a rebuild: the published image will start serving `/api/_int/*` correctly the moment `IS_HOSTED=true` + `RYBBIT_HOST` + `RYBBIT_SITE_ID` are present in the runtime environment. No CDN/cache invalidation needed beyond rolling the app pods.

## For Reviewers

- Confirm the IP-forwarding behavior in `src/lib/rybbit/proxy.ts` matches what our load balancer actually sets (`X-Forwarded-For` vs `X-Real-IP`).
- Confirm the `Cache-Control` on `s.js` is acceptable; happy to tighten to `no-store` if there's a reason to want immediate script updates on hosted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s for Rybbit analytics in hosted mode by serving `/api/_int/{s.js,track,identify}` via runtime route handlers instead of build-time rewrites. Restores script loading and event posting without rebuilding the generic Docker image, and adds safer error handling on the script proxy.

- **Bug Fixes**
  - Added runtime routes under `src/app/api/_int/*` that proxy to `${RYBBIT_HOST}/api/{script.js,track,identify}` only when `IS_HOSTED=true` and both `RYBBIT_HOST` and `RYBBIT_SITE_ID` are set (otherwise 404).
  - Event proxies and the script handler forward body, `Content-Type`, `User-Agent`, and client IP (`X-Forwarded-For` with `X-Real-IP` fallback); drop `Cookie`/`Authorization`; return 502 on upstream non-2xx or fetch errors (script handler now wraps fetch in try/catch).
  - Set `s.js` headers: `Content-Type: application/javascript` and `Cache-Control: public, max-age=300, stale-while-revalidate=86400`.
  - Removed `rewrites()` in `next.config.ts`; updated references; added regression tests for routing, headers, and error paths; ensure test `fetch` mocks are restored per test.

<sup>Written for commit f7597659a8bf1fc8b05ef0d483f9f41954b66fd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

