### PR TITLE
fix(transcription): send chunking_strategy for diarize models, consolidate manual + sync paths

### DIFF
--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -1,228 +1,65 @@
-import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { OpenAI } from "openai";
-import { db } from "@/db";
-import { apiCredentials, recordings, transcriptions } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
-import { decrypt } from "@/lib/encryption";
-import { decryptText, encryptText } from "@/lib/encryption/fields";
 import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
-import { createUserStorageProvider } from "@/lib/storage/factory";
 import {
-    getResponseFormat,
-    parseTranscriptionResponse,
-} from "@/lib/transcription/format";
-import { emitEvent } from "@/lib/webhooks/emit";
+    type TranscribeErrorCode,
+    transcribeRecording,
+} from "@/lib/transcription/transcribe-recording";
 
 type IdContext = { params: Promise<{ id: string }> };
 
+/**
+ * Manual "Transcribe" / "Re-transcribe" endpoint. Thin wrapper around the
+ * shared `transcribeRecording` worker so the manual and sync-triggered
+ * paths cannot drift (issue #101 traced back to this duplication: the
+ * manual path was missing the `chunking_strategy` parameter, the OpenAI
+ * chat-style provider routing for OpenRouter, and the `language` hint).
+ *
+ * Request body (all optional):
+ *   - `providerId`: use a specific configured provider instead of the
+ *     user's default transcription provider. Looked up user-scoped.
+ *   - `model`: override the provider's default model for this call.
+ */
 export const POST = apiHandler<IdContext>(async (request, context) => {
     const session = await requireApiSession(request);
     const { id } = await (context as IdContext).params;
 
-    try {
-        const body = (await request.json().catch(() => ({}))) as Record<
-            string,
-            unknown
-        >;
-        const overrideProviderId =
-            typeof body.providerId === "string" ? body.providerId : undefined;
-        const overrideModel =
-            typeof body.model === "string" ? body.model : undefined;
+    const body = (await request.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+    >;
+    const providerId =
+        typeof body.providerId === "string" ? body.providerId : undefined;
+    const model = typeof body.model === "string" ? body.model : undefined;
 
-        const [recording] = await db
-            .select()
-            .from(recordings)
-            .where(
-                and(
-                    eq(recordings.id, id),
-                    eq(recordings.userId, session.user.id),
-                    isNull(recordings.deletedAt),
-                ),
-            )
-            .limit(1);
+    const result = await transcribeRecording(session.user.id, id, {
+        providerId,
+        model,
+    });
 
-        if (!recording) {
-            throw new AppError(
-                ErrorCode.RECORDING_NOT_FOUND,
-                "Recording not found",
-                404,
-            );
-        }
-
-        const [credentials] = overrideProviderId
-            ? await db
-                  .select()
-                  .from(apiCredentials)
-                  .where(
-                      and(
-                          eq(apiCredentials.id, overrideProviderId),
-                          eq(apiCredentials.userId, session.user.id),
-                      ),
-                  )
-                  .limit(1)
-            : await db
-                  .select()
-                  .from(apiCredentials)
-                  .where(
-                      and(
-                          eq(apiCredentials.userId, session.user.id),
-                          eq(apiCredentials.isDefaultTranscription, true),
-                      ),
-                  )
-                  .limit(1);
-
-        if (!credentials) {
-            throw new AppError(
-                ErrorCode.NO_TRANSCRIPTION_PROVIDER,
-                "No transcription API configured",
-                400,
-            );
-        }
-
-        const apiKey = decrypt(credentials.apiKey);
-        const openai = new OpenAI({
-            apiKey,
-            baseURL: credentials.baseUrl || undefined,
-        });
-
-        const storage = await createUserStorageProvider(session.user.id);
-        const audioBuffer = await storage.downloadFile(recording.storagePath);
-
-        const header = new Uint8Array(audioBuffer.slice(0, 4));
-        const isOgg =
-            header[0] === 0x4f &&
-            header[1] === 0x67 &&
-            header[2] === 0x67 &&
-            header[3] === 0x53;
-
-        const ext = isOgg
-            ? "ogg"
-            : recording.storagePath.split(".").pop() || "mp3";
-        const contentType = isOgg
-            ? "audio/ogg"
-            : recording.storagePath.endsWith(".mp3")
-              ? "audio/mpeg"
-              : "audio/opus";
-
-        const decryptedFilename = decryptText(recording.filename);
-        const filename = decryptedFilename.match(/\.\w{2,4}$/)
-            ? decryptedFilename
-            : `${decryptedFilename}.${ext}`;
-
-        const audioFile = new File([new Uint8Array(audioBuffer)], filename, {
-            type: contentType,
-        });
-
-        const model = overrideModel || credentials.defaultModel || "whisper-1";
-        const responseFormat = getResponseFormat(model);
-
-        const transcription = await openai.audio.transcriptions.create({
-            file: audioFile,
-            model,
-            response_format: responseFormat,
-        });
-
-        const { text: transcriptionText, detectedLanguage } =
-            parseTranscriptionResponse(transcription, responseFormat);
-
-        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
-        try {
-            await db.transaction(async (tx) => {
-                const [stillActive] = await tx
-                    .select({ deletedAt: recordings.deletedAt })
-                    .from(recordings)
-                    .where(
-                        and(
-                            eq(recordings.id, id),
-                            eq(recordings.userId, session.user.id),
-                        ),
-                    )
-                    .for("update")
-                    .limit(1);
-
-                if (!stillActive || stillActive.deletedAt) {
-                    throw RECORDING_TOMBSTONED;
-                }
-
-                const [existingTranscription] = await tx
-                    .select()
-                    .from(transcriptions)
-                    .where(
-                        and(
-                            eq(transcriptions.recordingId, id),
-                            eq(transcriptions.userId, session.user.id),
-                        ),
-                    )
-                    .limit(1);
-
-                const encryptedText = encryptText(transcriptionText);
-
-                if (existingTranscription) {
-                    await tx
-                        .update(transcriptions)
-                        .set({
-                            text: encryptedText,
-                            detectedLanguage,
-                            transcriptionType: "server",
-                            provider: credentials.provider,
-                            model,
-                        })
-                        .where(
-                            and(
-                                eq(transcriptions.id, existingTranscription.id),
-                                eq(transcriptions.userId, session.user.id),
-                            ),
-                        );
-                } else {
-                    await tx.insert(transcriptions).values({
-                        recordingId: id,
-                        userId: session.user.id,
-                        text: encryptedText,
-                        detectedLanguage,
-                        transcriptionType: "server",
-                        provider: credentials.provider,
-                        model,
-                    });
-                }
-
-                await tx
-                    .update(recordings)
-                    .set({ updatedAt: new Date() })
-                    .where(
-                        and(
-                            eq(recordings.id, id),
-                            eq(recordings.userId, session.user.id),
-                            isNull(recordings.deletedAt),
-                        ),
-                    );
-            });
-        } catch (txError) {
-            if (txError === RECORDING_TOMBSTONED) {
-                throw new AppError(
-                    ErrorCode.NOT_FOUND,
-                    "Recording was deleted",
-                    410,
-                );
-            }
-            throw txError;
-        }
-
-        await emitEvent("transcription.completed", session.user.id, id);
-
-        return NextResponse.json({
-            transcription: transcriptionText,
-            detectedLanguage,
-        });
-    } catch (error) {
-        await emitEvent("transcription.failed", session.user.id, id, {
-            error: error instanceof Error ? error.message : String(error),
-        }).catch((eventError) => {
-            console.error(
-                "Failed to emit transcription failure event:",
-                eventError,
-            );
-        });
-        throw error;
+    if (!result.success) {
+        throw mapErrorCodeToAppError(result.errorCode, result.error);
     }
+
+    return NextResponse.json({
+        transcription: result.text ?? "",
+        detectedLanguage: result.detectedLanguage ?? null,
+    });
 });
+
+function mapErrorCodeToAppError(
+    code: TranscribeErrorCode | undefined,
+    message: string | undefined,
+): AppError {
+    const msg = message ?? "Transcription failed";
+    switch (code) {
+        case "RECORDING_NOT_FOUND":
+            return new AppError(ErrorCode.RECORDING_NOT_FOUND, msg, 404);
+        case "RECORDING_DELETED":
+            return new AppError(ErrorCode.NOT_FOUND, msg, 410);
+        case "NO_TRANSCRIPTION_PROVIDER":
+            return new AppError(ErrorCode.NO_TRANSCRIPTION_PROVIDER, msg, 400);
+        default:
+            return new AppError(ErrorCode.TRANSCRIPTION_FAILED, msg, 500);
+    }
+}

--- a/src/app/api/recordings/[id]/transcribe/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/route.ts
@@ -32,9 +32,14 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         typeof body.providerId === "string" ? body.providerId : undefined;
     const model = typeof body.model === "string" ? body.model : undefined;
 
+    // `force: true` so a manual "Re-transcribe" click always re-hits the
+    // provider and overwrites the existing transcript. Without this the
+    // worker's idempotent short-circuit would silently no-op the click
+    // (and any providerId/model override sent with it).
     const result = await transcribeRecording(session.user.id, id, {
         providerId,
         model,
+        force: true,
     });
 
     if (!result.success) {

--- a/src/lib/transcription/audio-file.ts
+++ b/src/lib/transcription/audio-file.ts
@@ -1,0 +1,74 @@
+/**
+ * Audio file construction for the server-side OpenAI-style transcription
+ * path. Shared by both the sync worker (`transcribeRecording`) and the
+ * manual `/api/recordings/[id]/transcribe` route so they cannot drift.
+ *
+ * Why this exists separately from the call sites:
+ *   - Plaud audio lands on disk as `.mp3` (sync hardcodes the extension)
+ *     but storage adapters or direct uploads can also produce `.opus` and
+ *     `.ogg` files. The OpenAI SDK uses the `File`'s name + content-type
+ *     to decide how to label the multipart part, so getting both right
+ *     matters for non-mp3 inputs.
+ *   - We sniff the OGG magic bytes (`OggS`) so an audio body that's
+ *     actually OGG but happens to be stored under another extension still
+ *     gets the right content-type. Without this, a renamed file confuses
+ *     OpenAI into a 400.
+ */
+
+export interface BuildAudioFileResult {
+    file: File;
+    contentType: string;
+}
+
+/**
+ * Detect OGG by magic bytes (`OggS`). All Plaud opus files we've seen
+ * are actually OGG-Opus containers; sniffing the header is more reliable
+ * than trusting the filename extension.
+ */
+function isOggContainer(audioBuffer: Buffer): boolean {
+    if (audioBuffer.length < 4) return false;
+    return (
+        audioBuffer[0] === 0x4f && // O
+        audioBuffer[1] === 0x67 && // g
+        audioBuffer[2] === 0x67 && // g
+        audioBuffer[3] === 0x53 // S
+    );
+}
+
+/**
+ * Build the `File` object passed to `openai.audio.transcriptions.create`.
+ *
+ * - `storagePath` is the on-disk path (used as an extension hint when the
+ *   buffer is not OGG).
+ * - `decryptedFilename` is the user-facing filename (already decrypted
+ *   via `decryptText`). We append the correct extension if the title
+ *   doesn't already carry one so providers that key off the filename
+ *   get a clean hint.
+ */
+export function buildAudioFile(
+    audioBuffer: Buffer,
+    storagePath: string,
+    decryptedFilename: string,
+): BuildAudioFileResult {
+    const isOgg = isOggContainer(audioBuffer);
+
+    const ext = isOgg
+        ? "ogg"
+        : storagePath.split(".").pop()?.toLowerCase() || "mp3";
+
+    const contentType = isOgg
+        ? "audio/ogg"
+        : storagePath.endsWith(".mp3")
+          ? "audio/mpeg"
+          : "audio/opus";
+
+    const filename = decryptedFilename.match(/\.\w{2,4}$/)
+        ? decryptedFilename
+        : `${decryptedFilename}.${ext}`;
+
+    const file = new File([new Uint8Array(audioBuffer)], filename, {
+        type: contentType,
+    });
+
+    return { file, contentType };
+}

--- a/src/lib/transcription/audio-file.ts
+++ b/src/lib/transcription/audio-file.ts
@@ -5,15 +5,21 @@
  *
  * Why this exists separately from the call sites:
  *   - Plaud audio lands on disk as `.mp3` (sync hardcodes the extension)
- *     but storage adapters or direct uploads can also produce `.opus` and
- *     `.ogg` files. The OpenAI SDK uses the `File`'s name + content-type
- *     to decide how to label the multipart part, so getting both right
- *     matters for non-mp3 inputs.
+ *     but storage adapters or direct uploads can also produce `.opus`,
+ *     `.ogg`, `.wav`, `.m4a`, etc. The OpenAI SDK uses the `File`'s name
+ *     + content-type to decide how to label the multipart part, so
+ *     getting both right matters for non-mp3 inputs.
  *   - We sniff the OGG magic bytes (`OggS`) so an audio body that's
  *     actually OGG but happens to be stored under another extension still
  *     gets the right content-type. Without this, a renamed file confuses
  *     OpenAI into a 400.
+ *   - Everything else routes through the shared `getAudioMimeType` map
+ *     (wav, m4a, mp4, flac, webm, aac, ...) so the manual upload path
+ *     can transcribe a `.wav` direct upload without being misreported as
+ *     opus.
  */
+
+import { getAudioMimeType } from "@/lib/utils";
 
 export interface BuildAudioFileResult {
     file: File;
@@ -56,17 +62,28 @@ export function buildAudioFile(
         ? "ogg"
         : storagePath.split(".").pop()?.toLowerCase() || "mp3";
 
-    const contentType = isOgg
-        ? "audio/ogg"
-        : storagePath.endsWith(".mp3")
-          ? "audio/mpeg"
-          : "audio/opus";
+    // Trust the OGG magic byte over any path-derived guess, otherwise
+    // delegate to the shared MIME map so wav/m4a/flac/etc. don't fall
+    // back to opus.
+    const contentType = isOgg ? "audio/ogg" : getAudioMimeType(storagePath);
 
     const filename = decryptedFilename.match(/\.\w{2,4}$/)
         ? decryptedFilename
         : `${decryptedFilename}.${ext}`;
 
-    const file = new File([new Uint8Array(audioBuffer)], filename, {
+    // Zero-copy view over the existing Buffer. We can't pass the Buffer
+    // straight to `new File([...])` because the DOM `BlobPart` type
+    // requires `ArrayBufferView<ArrayBuffer>`, and Node's `Buffer.buffer`
+    // is `ArrayBufferLike` (potentially `SharedArrayBuffer`). Node never
+    // backs a `Buffer` with a `SharedArrayBuffer` in normal flows, so the
+    // cast is safe and avoids the extra full-audio-buffer copy that the
+    // previous `new Uint8Array(audioBuffer)` form caused.
+    const view = new Uint8Array(
+        audioBuffer.buffer as ArrayBuffer,
+        audioBuffer.byteOffset,
+        audioBuffer.byteLength,
+    );
+    const file = new File([view], filename, {
         type: contentType,
     });
 

--- a/src/lib/transcription/format.ts
+++ b/src/lib/transcription/format.ts
@@ -1,9 +1,10 @@
 import type {
+    TranscriptionCreateParamsNonStreaming,
     TranscriptionDiarized,
     TranscriptionVerbose,
 } from "openai/resources/audio/transcriptions";
 
-type ResponseFormat = "diarized_json" | "json" | "verbose_json";
+export type ResponseFormat = "diarized_json" | "json" | "verbose_json";
 
 /**
  * Pick the correct `response_format` for a given transcription model.
@@ -48,4 +49,38 @@ export function parseTranscriptionResponse(
     const text =
         typeof transcription === "string" ? transcription : (plain.text ?? "");
     return { text, detectedLanguage: null };
+}
+
+/**
+ * Build the parameter object passed to `openai.audio.transcriptions.create`.
+ *
+ * Centralised so the sync-worker path and the manual
+ * `/api/recordings/[id]/transcribe` route cannot drift on required
+ * parameters (issue #101 — `gpt-4o-transcribe-diarize` requires
+ * `chunking_strategy`; OpenAI returns HTTP 400 without it).
+ *
+ * Rules encoded here:
+ *  - When `response_format === "diarized_json"` we send
+ *    `chunking_strategy: "auto"`. OpenAI rejects diarize requests that
+ *    omit this field (documented as required for inputs >30s, in
+ *    practice rejected for all diarize calls regardless of length).
+ *  - `language` is only included when set. The SDK accepts it alongside
+ *    diarize.
+ */
+export function buildTranscriptionParams(args: {
+    file: File;
+    model: string;
+    responseFormat: ResponseFormat;
+    language?: string;
+}): TranscriptionCreateParamsNonStreaming {
+    const { file, model, responseFormat, language } = args;
+    return {
+        file,
+        model,
+        response_format: responseFormat,
+        ...(responseFormat === "diarized_json"
+            ? { chunking_strategy: "auto" as const }
+            : {}),
+        ...(language ? { language } : {}),
+    };
 }

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -14,17 +14,48 @@ import { decrypt } from "@/lib/encryption";
 import { decryptText, encryptText } from "@/lib/encryption/fields";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
+import { buildAudioFile } from "@/lib/transcription/audio-file";
 import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
 import {
+    buildTranscriptionParams,
     getResponseFormat,
     parseTranscriptionResponse,
 } from "@/lib/transcription/format";
 import { emitEvent } from "@/lib/webhooks/emit";
 
+/**
+ * Discriminator for typed error handling at the route boundary. Internal
+ * sync callers can ignore it; the manual
+ * `/api/recordings/[id]/transcribe` route maps these to HTTP status codes.
+ */
+export type TranscribeErrorCode =
+    | "RECORDING_NOT_FOUND"
+    | "NO_TRANSCRIPTION_PROVIDER"
+    | "RECORDING_DELETED"
+    | "TRANSCRIPTION_FAILED";
+
+export interface TranscribeOptions {
+    /** Use a specific provider (by id, user-scoped) instead of the user's default. */
+    providerId?: string;
+    /** Override the provider's default model for this single call. */
+    model?: string;
+}
+
+export interface TranscribeResult {
+    success: boolean;
+    error?: string;
+    errorCode?: TranscribeErrorCode;
+    /** Present on success. Plaintext transcript. */
+    text?: string;
+    /** Present on success when the provider returned a language. */
+    detectedLanguage?: string | null;
+}
+
 export async function transcribeRecording(
     userId: string,
     recordingId: string,
-): Promise<{ success: boolean; error?: string }> {
+    opts: TranscribeOptions = {},
+): Promise<TranscribeResult> {
     try {
         const [recording] = await db
             .select()
@@ -44,7 +75,11 @@ export async function transcribeRecording(
             .limit(1);
 
         if (!recording) {
-            return { success: false, error: "Recording not found" };
+            return {
+                success: false,
+                error: "Recording not found",
+                errorCode: "RECORDING_NOT_FOUND",
+            };
         }
 
         const [existingTranscription] = await db
@@ -59,22 +94,48 @@ export async function transcribeRecording(
             .limit(1);
 
         if (existingTranscription?.text) {
-            return { success: true };
+            // Idempotent: a prior run already produced a transcript. The
+            // manual re-transcribe path purges the transcription row
+            // before calling us, so this short-circuit only fires when a
+            // duplicate auto-transcribe was scheduled.
+            return {
+                success: true,
+                text: decryptText(existingTranscription.text),
+                detectedLanguage: existingTranscription.detectedLanguage,
+            };
         }
 
-        const [credentials] = await db
-            .select()
-            .from(apiCredentials)
-            .where(
-                and(
-                    eq(apiCredentials.userId, userId),
-                    eq(apiCredentials.isDefaultTranscription, true),
-                ),
-            )
-            .limit(1);
+        // Provider selection: explicit `providerId` (manual override
+        // from the route, user-scoped lookup by id) takes precedence
+        // over the user's default transcription provider.
+        const [credentials] = opts.providerId
+            ? await db
+                  .select()
+                  .from(apiCredentials)
+                  .where(
+                      and(
+                          eq(apiCredentials.id, opts.providerId),
+                          eq(apiCredentials.userId, userId),
+                      ),
+                  )
+                  .limit(1)
+            : await db
+                  .select()
+                  .from(apiCredentials)
+                  .where(
+                      and(
+                          eq(apiCredentials.userId, userId),
+                          eq(apiCredentials.isDefaultTranscription, true),
+                      ),
+                  )
+                  .limit(1);
 
         if (!credentials) {
-            return { success: false, error: "No transcription API configured" };
+            return {
+                success: false,
+                error: "No transcription API configured",
+                errorCode: "NO_TRANSCRIPTION_PROVIDER",
+            };
         }
 
         const [settings] = await db
@@ -100,21 +161,16 @@ export async function transcribeRecording(
         const storage = await createUserStorageProvider(userId);
         const audioBuffer = await storage.downloadFile(recording.storagePath);
 
-        const contentType = recording.storagePath.endsWith(".mp3")
-            ? "audio/mpeg"
-            : "audio/opus";
         // `recording.filename` is encrypted at rest; decrypt before passing
         // to the transcription provider as a filename hint.
         const decryptedFilename = decryptText(recording.filename);
-        const audioFile = new File(
-            [new Uint8Array(audioBuffer)],
+        const { file: audioFile, contentType } = buildAudioFile(
+            audioBuffer,
+            recording.storagePath,
             decryptedFilename,
-            {
-                type: contentType,
-            },
         );
 
-        const model = credentials.defaultModel || "whisper-1";
+        const model = opts.model || credentials.defaultModel || "whisper-1";
 
         // Chat-style providers (OpenRouter today) don't implement
         // `/v1/audio/transcriptions` — calling that path returns a 404
@@ -138,12 +194,14 @@ export async function transcribeRecording(
             detectedLanguage = result.detectedLanguage;
         } else {
             const responseFormat = getResponseFormat(model);
-            const transcription = await openai.audio.transcriptions.create({
-                file: audioFile,
-                model,
-                response_format: responseFormat,
-                ...(defaultLanguage ? { language: defaultLanguage } : {}),
-            });
+            const transcription = await openai.audio.transcriptions.create(
+                buildTranscriptionParams({
+                    file: audioFile,
+                    model,
+                    responseFormat,
+                    language: defaultLanguage,
+                }),
+            );
             const parsed = parseTranscriptionResponse(
                 transcription,
                 responseFormat,
@@ -185,6 +243,9 @@ export async function transcribeRecording(
                 const encryptedTranscriptionText =
                     encryptText(transcriptionText);
 
+                // Persist the *actual* model used (which may differ from
+                // the provider default when the manual route supplied an
+                // override). Mirrors what the OpenAI request really ran.
                 if (currentTranscription) {
                     await tx
                         .update(transcriptions)
@@ -193,7 +254,7 @@ export async function transcribeRecording(
                             detectedLanguage,
                             transcriptionType: "server",
                             provider: credentials.provider,
-                            model: credentials.defaultModel || "whisper-1",
+                            model,
                         })
                         .where(
                             and(
@@ -209,7 +270,7 @@ export async function transcribeRecording(
                         detectedLanguage,
                         transcriptionType: "server",
                         provider: credentials.provider,
-                        model: credentials.defaultModel || "whisper-1",
+                        model,
                     });
                 }
 
@@ -229,6 +290,7 @@ export async function transcribeRecording(
                 return {
                     success: false,
                     error: "Recording was deleted before transcription finished",
+                    errorCode: "RECORDING_DELETED",
                 };
             }
             throw txError;
@@ -317,7 +379,11 @@ export async function transcribeRecording(
 
         await emitEvent("transcription.completed", userId, recordingId);
 
-        return { success: true };
+        return {
+            success: true,
+            text: transcriptionText,
+            detectedLanguage,
+        };
     } catch (error) {
         console.error("Error transcribing recording:", error);
         await emitEvent("transcription.failed", userId, recordingId, {
@@ -327,6 +393,7 @@ export async function transcribeRecording(
             success: false,
             error:
                 error instanceof Error ? error.message : "Transcription failed",
+            errorCode: "TRANSCRIPTION_FAILED",
         };
     }
 }

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -39,6 +39,15 @@ export interface TranscribeOptions {
     providerId?: string;
     /** Override the provider's default model for this single call. */
     model?: string;
+    /**
+     * Re-run the provider call even when a transcript already exists.
+     * Used by the manual "Re-transcribe" button so a user clicking it
+     * with an override (or just wanting a fresh result) actually re-hits
+     * the API and overwrites the stored transcript. The sync worker
+     * leaves this `false` so duplicate post-sync auto-transcribes remain
+     * idempotent.
+     */
+    force?: boolean;
 }
 
 export interface TranscribeResult {
@@ -93,11 +102,13 @@ export async function transcribeRecording(
             )
             .limit(1);
 
-        if (existingTranscription?.text) {
-            // Idempotent: a prior run already produced a transcript. The
-            // manual re-transcribe path purges the transcription row
-            // before calling us, so this short-circuit only fires when a
-            // duplicate auto-transcribe was scheduled.
+        if (existingTranscription?.text && !opts.force) {
+            // Idempotent short-circuit: a prior run already produced a
+            // transcript and the caller hasn't asked for a forced re-run.
+            // The sync worker relies on this so duplicate post-sync
+            // auto-transcribes are no-ops. The manual "Re-transcribe"
+            // route passes `force: true` to bypass it (so provider/model
+            // overrides actually take effect).
             return {
                 success: true,
                 text: decryptText(existingTranscription.text),

--- a/src/tests/regressions/101-diarize-chunking-strategy.test.ts
+++ b/src/tests/regressions/101-diarize-chunking-strategy.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Regression: issue #101
+ *
+ * Before this fix, transcribing with `gpt-4o-transcribe-diarize` (or any
+ * model whose name contains "diarize") failed at the OpenAI API boundary
+ * with HTTP 400:
+ *   `chunking_strategy is required for diarization models`
+ *
+ * The request was built without `chunking_strategy`, so the OpenAI SDK
+ * never even reached the diarized-response parser. After the fix, the
+ * shared `buildTranscriptionParams` helper injects
+ * `chunking_strategy: "auto"` whenever `response_format === "diarized_json"`,
+ * and both call sites (the sync worker and the manual transcribe route)
+ * go through that helper.
+ *
+ * This file pins both halves:
+ *   1. Unit: helper produces the right params.
+ *   2. Integration: `transcribeRecording` actually sends the param to
+ *      `openai.audio.transcriptions.create` for a diarize model, and does
+ *      not send it for non-diarize models.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import {
+    buildTranscriptionParams,
+    getResponseFormat,
+} from "@/lib/transcription/format";
+
+describe("issue #101 — buildTranscriptionParams sends chunking_strategy for diarize", () => {
+    const fakeFile = new File([new Uint8Array([1, 2, 3])], "x.mp3", {
+        type: "audio/mpeg",
+    });
+
+    it("adds chunking_strategy: 'auto' when response_format is diarized_json", () => {
+        const params = buildTranscriptionParams({
+            file: fakeFile,
+            model: "gpt-4o-transcribe-diarize",
+            responseFormat: getResponseFormat("gpt-4o-transcribe-diarize"),
+        });
+        expect(params.response_format).toBe("diarized_json");
+        expect(
+            (params as { chunking_strategy?: unknown }).chunking_strategy,
+        ).toBe("auto");
+    });
+
+    it("omits chunking_strategy for whisper-1 (verbose_json)", () => {
+        const params = buildTranscriptionParams({
+            file: fakeFile,
+            model: "whisper-1",
+            responseFormat: getResponseFormat("whisper-1"),
+        });
+        expect(params.response_format).toBe("verbose_json");
+        expect(
+            (params as { chunking_strategy?: unknown }).chunking_strategy,
+        ).toBeUndefined();
+    });
+
+    it("omits chunking_strategy for plain gpt-4o-transcribe (json)", () => {
+        const params = buildTranscriptionParams({
+            file: fakeFile,
+            model: "gpt-4o-transcribe",
+            responseFormat: getResponseFormat("gpt-4o-transcribe"),
+        });
+        expect(params.response_format).toBe("json");
+        expect(
+            (params as { chunking_strategy?: unknown }).chunking_strategy,
+        ).toBeUndefined();
+    });
+
+    it("forwards an explicit language hint when provided", () => {
+        const params = buildTranscriptionParams({
+            file: fakeFile,
+            model: "whisper-1",
+            responseFormat: "verbose_json",
+            language: "en",
+        });
+        expect((params as { language?: string }).language).toBe("en");
+    });
+
+    it("omits language when not provided (no empty string leaking through)", () => {
+        const params = buildTranscriptionParams({
+            file: fakeFile,
+            model: "whisper-1",
+            responseFormat: "verbose_json",
+        });
+        expect((params as { language?: string }).language).toBeUndefined();
+    });
+});
+
+// Integration: end-to-end through `transcribeRecording`. Verifies both the
+// sync-worker path and the manual-route override path arrive at
+// `openai.audio.transcriptions.create` with chunking_strategy when a
+// diarize model is in play.
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    decrypt: vi.fn().mockReturnValue("fake-api-key"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+}));
+
+vi.mock("@/lib/encryption/fields", async () => {
+    const actual = await vi.importActual<
+        typeof import("@/lib/encryption/fields")
+    >("@/lib/encryption/fields");
+    return {
+        ...actual,
+        decryptText: vi.fn((value: string) => value),
+        encryptText: vi.fn((value: string) => `enc:${value}`),
+    };
+});
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("fake-mp3-bytes")),
+    }),
+}));
+
+const audioCreate = vi.fn();
+const chatCreate = vi.fn();
+
+vi.mock("openai", () => {
+    const MockOpenAI = vi.fn(() => ({
+        audio: { transcriptions: { create: audioCreate } },
+        chat: { completions: { create: chatCreate } },
+    }));
+    return { OpenAI: MockOpenAI };
+});
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/ai/generate-title", () => ({
+    generateTitleFromTranscription: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+import { OpenAI } from "openai";
+import { db } from "@/db";
+import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+
+describe("issue #101 — transcribeRecording sends chunking_strategy for diarize models", () => {
+    const userId = "user-101";
+    const recordingId = "rec-101";
+
+    function mockRecordingFlow(opts: {
+        defaultModel: string;
+        overrideProviderId?: string;
+    }) {
+        const recordingRow = {
+            id: recordingId,
+            userId,
+            plaudFileId: "plaud-1",
+            filename: "Some Recording",
+            storagePath: "rec-101.mp3",
+            deletedAt: null,
+        };
+        const credsRow = {
+            id: "creds-1",
+            provider: "OpenAI",
+            apiKey: "encrypted-key",
+            baseUrl: null,
+            defaultModel: opts.defaultModel,
+        };
+
+        (db.select as Mock)
+            // recording lookup
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([recordingRow]),
+                    }),
+                }),
+            })
+            // existing transcription (none)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([]),
+                    }),
+                }),
+            })
+            // credentials (default OR by id — same shape returned)
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([credsRow]),
+                    }),
+                }),
+            })
+            // user settings
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([
+                            {
+                                autoGenerateTitle: false,
+                                syncTitleToPlaud: false,
+                                transcriptionQuality: "balanced",
+                                defaultTranscriptionLanguage: null,
+                            },
+                        ]),
+                    }),
+                }),
+            });
+
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            for: vi.fn().mockReturnValue({
+                                limit: vi
+                                    .fn()
+                                    .mockResolvedValue([{ deletedAt: null }]),
+                            }),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([]),
+                        }),
+                    }),
+                }),
+            insert: vi.fn().mockReturnValue({
+                values: vi.fn().mockResolvedValue(undefined),
+            }),
+            update: vi.fn().mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+        );
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        audioCreate.mockReset();
+        chatCreate.mockReset();
+        // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+        (OpenAI as unknown as Mock).mockImplementation(function () {
+            return {
+                audio: { transcriptions: { create: audioCreate } },
+                chat: { completions: { create: chatCreate } },
+            };
+        });
+    });
+
+    it("sends chunking_strategy: 'auto' when defaultModel is gpt-4o-transcribe-diarize", async () => {
+        audioCreate.mockResolvedValue({
+            segments: [
+                { speaker: "speaker_1", text: "hello" },
+                { speaker: "speaker_2", text: "world" },
+            ],
+        });
+        mockRecordingFlow({ defaultModel: "gpt-4o-transcribe-diarize" });
+
+        const result = await transcribeRecording(userId, recordingId);
+
+        expect(result.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+        const args = audioCreate.mock.calls[0]?.[0];
+        expect(args.model).toBe("gpt-4o-transcribe-diarize");
+        expect(args.response_format).toBe("diarized_json");
+        expect(args.chunking_strategy).toBe("auto");
+    });
+
+    it("does NOT send chunking_strategy for non-diarize models", async () => {
+        audioCreate.mockResolvedValue({
+            text: "plain whisper transcript",
+            language: "en",
+        });
+        mockRecordingFlow({ defaultModel: "whisper-1" });
+
+        const result = await transcribeRecording(userId, recordingId);
+
+        expect(result.success).toBe(true);
+        const args = audioCreate.mock.calls[0]?.[0];
+        expect(args.response_format).toBe("verbose_json");
+        expect(args.chunking_strategy).toBeUndefined();
+    });
+
+    it("respects manual model override and sends chunking_strategy when the override is diarize", async () => {
+        audioCreate.mockResolvedValue({
+            segments: [{ speaker: "speaker_1", text: "override path" }],
+        });
+        // Provider default is plain whisper-1; the manual route overrides
+        // it to the diarize model. The shared helper must still inject
+        // chunking_strategy.
+        mockRecordingFlow({ defaultModel: "whisper-1" });
+
+        const result = await transcribeRecording(userId, recordingId, {
+            model: "gpt-4o-transcribe-diarize",
+        });
+
+        expect(result.success).toBe(true);
+        const args = audioCreate.mock.calls[0]?.[0];
+        expect(args.model).toBe("gpt-4o-transcribe-diarize");
+        expect(args.chunking_strategy).toBe("auto");
+    });
+});

--- a/src/tests/regressions/101-diarize-chunking-strategy.test.ts
+++ b/src/tests/regressions/101-diarize-chunking-strategy.test.ts
@@ -156,7 +156,11 @@ describe("issue #101 — transcribeRecording sends chunking_strategy for diarize
 
     function mockRecordingFlow(opts: {
         defaultModel: string;
-        overrideProviderId?: string;
+        /**
+         * Stub an existing transcription row. Used to exercise the
+         * idempotent short-circuit vs. the `force: true` re-run path.
+         */
+        existingTranscription?: { id: string; text: string };
     }) {
         const recordingRow = {
             id: recordingId,
@@ -183,11 +187,17 @@ describe("issue #101 — transcribeRecording sends chunking_strategy for diarize
                     }),
                 }),
             })
-            // existing transcription (none)
+            // existing transcription
             .mockReturnValueOnce({
                 from: vi.fn().mockReturnValue({
                     where: vi.fn().mockReturnValue({
-                        limit: vi.fn().mockResolvedValue([]),
+                        limit: vi
+                            .fn()
+                            .mockResolvedValue(
+                                opts.existingTranscription
+                                    ? [opts.existingTranscription]
+                                    : [],
+                            ),
                     }),
                 }),
             })
@@ -303,16 +313,58 @@ describe("issue #101 — transcribeRecording sends chunking_strategy for diarize
         });
         // Provider default is plain whisper-1; the manual route overrides
         // it to the diarize model. The shared helper must still inject
-        // chunking_strategy.
+        // chunking_strategy. `force: true` mirrors the real route so the
+        // existing-transcription short-circuit can't hide the override.
         mockRecordingFlow({ defaultModel: "whisper-1" });
 
         const result = await transcribeRecording(userId, recordingId, {
             model: "gpt-4o-transcribe-diarize",
+            force: true,
         });
 
         expect(result.success).toBe(true);
         const args = audioCreate.mock.calls[0]?.[0];
         expect(args.model).toBe("gpt-4o-transcribe-diarize");
         expect(args.chunking_strategy).toBe("auto");
+    });
+
+    it("force: true re-runs the provider even when a transcript already exists", async () => {
+        // Without `force`, the worker would short-circuit on the existing
+        // transcription row and the manual override would never reach the
+        // provider. The manual route passes `force: true` for exactly
+        // this reason.
+        audioCreate.mockResolvedValue({
+            segments: [{ speaker: "speaker_1", text: "fresh diarized run" }],
+        });
+        mockRecordingFlow({
+            defaultModel: "whisper-1",
+            existingTranscription: { id: "tr-1", text: "enc:stale" },
+        });
+
+        const result = await transcribeRecording(userId, recordingId, {
+            model: "gpt-4o-transcribe-diarize",
+            force: true,
+        });
+
+        expect(result.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+        const args = audioCreate.mock.calls[0]?.[0];
+        expect(args.model).toBe("gpt-4o-transcribe-diarize");
+        expect(args.chunking_strategy).toBe("auto");
+    });
+
+    it("without force, short-circuits on an existing transcript and skips the provider call", async () => {
+        mockRecordingFlow({
+            defaultModel: "gpt-4o-transcribe-diarize",
+            existingTranscription: {
+                id: "tr-1",
+                text: "enc:already transcribed",
+            },
+        });
+
+        const result = await transcribeRecording(userId, recordingId);
+
+        expect(result.success).toBe(true);
+        expect(audioCreate).not.toHaveBeenCalled();
     });
 });

--- a/src/tests/regressions/79-v1-incremental-updates.test.ts
+++ b/src/tests/regressions/79-v1-incremental-updates.test.ts
@@ -169,6 +169,12 @@ describe("Issue #79 - v1 incremental update timestamps", () => {
     });
 
     it("bumps recording updatedAt inside the manual transcription transaction", async () => {
+        // The manual route now delegates to the shared `transcribeRecording`
+        // worker (issue #101 consolidation), so the select chain is:
+        //   1. recording lookup
+        //   2. existing transcription (none — manual re-transcribe path)
+        //   3. credentials (default transcription provider)
+        //   4. user settings
         (db.select as Mock)
             .mockReturnValueOnce(
                 selectRows([
@@ -181,6 +187,7 @@ describe("Issue #79 - v1 incremental update timestamps", () => {
                     },
                 ]),
             )
+            .mockReturnValueOnce(selectRows([]))
             .mockReturnValueOnce(
                 selectRows([
                     {
@@ -189,6 +196,16 @@ describe("Issue #79 - v1 incremental update timestamps", () => {
                         apiKey: "encrypted-key",
                         baseUrl: null,
                         defaultModel: "whisper-1",
+                    },
+                ]),
+            )
+            .mockReturnValueOnce(
+                selectRows([
+                    {
+                        autoGenerateTitle: false,
+                        syncTitleToPlaud: false,
+                        transcriptionQuality: "balanced",
+                        defaultTranscriptionLanguage: null,
                     },
                 ]),
             );


### PR DESCRIPTION
## Description

`gpt-4o-transcribe-diarize` (and any model whose name contains `diarize`) currently fails with HTTP 400 from OpenAI:

```
chunking_strategy is required for diarization models
```

We never sent `chunking_strategy`. The OpenAI SDK reaches that parameter (`openai/resources/audio/transcriptions.d.ts:525`) and the docs flag it as required for diarize models. Adding `chunking_strategy: "auto"` fixes the immediate bug.

Tracing the bug surfaced that the manual `/api/recordings/[id]/transcribe` route was a ~225-line copy of `transcribeRecording()` that had drifted on several other fronts:

- missing `chunking_strategy` (this issue)
- missing `language` hint (`userSettings.defaultTranscriptionLanguage`)
- missing chat-style provider routing — OpenRouter manual clicks still hit the 404 path that #122 fixed for sync
- missing title generation / `syncTitleToPlaud`

Collapsed both call sites onto a single shared worker. Net **-44 lines**, with three latent bugs fixed alongside #101.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Related Issues

Fixes #101
Relates to #122

## Changes Made

- New `src/lib/transcription/format.ts::buildTranscriptionParams()` centrally injects `chunking_strategy: "auto"` when `response_format === "diarized_json"`. Typed against `TranscriptionCreateParamsNonStreaming` so SDK overload resolution stays clean.
- New `src/lib/transcription/audio-file.ts::buildAudioFile()` extracts the OGG magic-byte sniff + filename-extension preservation that previously only lived in the manual route. Used by the shared worker now.
- `transcribeRecording()` accepts `opts: { providerId?, model? }`, returns `{ success, error?, errorCode?, text?, detectedLanguage? }`, and persists the **actual** model used (override-aware) instead of always the provider default.
- `/api/recordings/[id]/transcribe` route collapsed from 226 → 67 lines: thin wrapper that reads body overrides, delegates to `transcribeRecording`, and maps the discriminated `errorCode` to HTTP status (`RECORDING_NOT_FOUND` → 404, `RECORDING_DELETED` → 410, `NO_TRANSCRIPTION_PROVIDER` → 400). Route response shape preserved.
- Existing UI consumers (`workstation.tsx`, `recording-workstation.tsx`, `transcription-section.tsx`) untouched — they only `router.refresh()`, don't read the JSON body.

## Testing

### Commands run
- `pnpm test` — 300 passed / 3 skipped / 0 failed (was 299 passed before; +8 new tests, -1 redundant assertion, +2 mock entries in #79 test for the new select sequence).
- `pnpm type-check` — clean.
- `pnpm format-and-lint:fix` — clean (the 2 remaining infos are pre-existing unsafe-fix suggestions in unrelated files).

### New regression suite
`src/tests/regressions/101-diarize-chunking-strategy.test.ts` (8 tests):

- **Unit (5)**: `buildTranscriptionParams` adds `chunking_strategy: "auto"` only for `diarized_json`; omits it for `verbose_json` and plain `json`; forwards `language` when provided; omits `language` when not.
- **Integration (3)**: end-to-end through `transcribeRecording` with a mocked OpenAI SDK — diarize default model triggers the param, non-diarize doesn't, and the manual `model` override path still triggers it when the override is a diarize model.

### Updated test
`src/tests/regressions/79-v1-incremental-updates.test.ts` — the manual route's `db.select` chain grew from 2 to 4 (recording → existing transcription → credentials → user settings) because it now flows through the shared worker. Existing `updatedAt` assertions still pass.

## Checklist

- [x] `pnpm format-and-lint`
- [x] Self-review
- [x] Comments on non-obvious code (helper docstrings, mock-chain comment in #79 test)
- [x] No new warnings/errors
- [x] Added regression tests
- [x] `pnpm test` passes
- [x] `pnpm type-check` passes

## Database Changes

None.

## Breaking Changes

None on the deploy surface (no schema, env, docker-compose, or `/api/v1/*` change). Route response shape preserved.

**Internal behaviour change worth flagging**: a manual "Transcribe" click now respects `userSettings.autoGenerateTitle` and `syncTitleToPlaud` (was previously inconsistent with the auto-sync path, which already honoured them). The user setting is the single source of truth, so this is a consistency fix rather than a new feature.

## For Reviewers

- The chosen abstraction boundary — extract `buildTranscriptionParams` + `buildAudioFile`, collapse the route — vs. a one-line `chunking_strategy: "auto"` fix at each call site. AGENTS.md ("refactor freely on internal code") and three latent bugs on the manual path made the consolidation the right call; happy to slim it down if you'd prefer.
- The route error-code mapping (`RECORDING_DELETED` → 410 via `ErrorCode.NOT_FOUND` because there's no dedicated 410 code) matches the pre-existing route behaviour. Open to a new `ErrorCode.RECORDING_DELETED` if useful.
- `chunking_strategy: "auto"` is OpenAI's default VAD chunker. Safe for short audio (one chunk). Did not surface as a UI knob; a future per-provider setting (`server_vad` config) is a separate enhancement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes diarization transcription errors by sending chunking_strategy: "auto" and unifying manual and sync transcribes behind one worker. Manual re-transcribes now always hit the provider and both paths behave the same. Fixes #101.

- **Bug Fixes**
  - Send chunking_strategy: "auto" when response_format is "diarized_json" (diarize models no longer 400).
  - Forward language hint; manual path uses chat-style provider routing like sync.
  - Manual “Transcribe” respects title generation/Plaud sync and forces a provider re-run (no silent no-ops).
  - Broaden audio content-type detection (wav/m4a/flac/webm) with OGG sniff to avoid mislabeling.

- **Refactors**
  - Collapsed `/api/recordings/[id]/transcribe` into a thin wrapper over the shared worker; maps worker error codes to 404/410/400; response unchanged.
  - Added shared helpers for param building and audio file creation; `buildAudioFile` now uses a zero-copy buffer view.
  - Worker accepts `providerId`/`model` overrides, persists the actual model used, and returns text + detectedLanguage; added tests incl. force vs. short-circuit.

<sup>Written for commit 2def3d7996b02500f9a1134e8d2e7380d01036c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

