### PR TITLE
fix(settings): hide self-host storage backend card on hosted dashboard

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
 import { isAdminEmail } from "@/lib/admin/guard";
 import { requireAuth } from "@/lib/auth-server";
 import { decryptText } from "@/lib/encryption/fields";
+import { env } from "@/lib/env";
 import { initialSettingsFromRow } from "@/lib/settings/initial-settings";
 import { serializeRecording } from "@/types/recording";
 
@@ -104,6 +105,7 @@ export default async function DashboardPage() {
             isAdmin={isAdminEmail(session.user.email)}
             userEmail={session.user.email ?? null}
             initialSettings={initialSettings}
+            isHosted={env.IS_HOSTED}
         />
     );
 }

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -66,9 +66,11 @@ interface WorkstationProps {
      * True when running in OpenPlaud's hosted mode (`IS_HOSTED=true`).
      * Forwarded into SettingsDialog so hosted-only UI gating (e.g. the
      * self-host-only storage backend card) reflects the deployment mode.
-     * Server-supplied; never derive client-side.
+     * Server-supplied; never derive client-side. Required (no default)
+     * so a future caller can't silently regress hosted-mode behavior
+     * by forgetting to thread the value through.
      */
-    isHosted?: boolean;
+    isHosted: boolean;
 }
 
 export function Workstation({
@@ -77,7 +79,7 @@ export function Workstation({
     isAdmin = false,
     userEmail = null,
     initialSettings,
-    isHosted = false,
+    isHosted,
 }: WorkstationProps) {
     const router = useRouter();
     const [currentRecording, setCurrentRecording] = useState<Recording | null>(

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -62,6 +62,13 @@ interface WorkstationProps {
      */
     userEmail?: string | null;
     initialSettings: InitialSettings;
+    /**
+     * True when running in OpenPlaud's hosted mode (`IS_HOSTED=true`).
+     * Forwarded into SettingsDialog so hosted-only UI gating (e.g. the
+     * self-host-only storage backend card) reflects the deployment mode.
+     * Server-supplied; never derive client-side.
+     */
+    isHosted?: boolean;
 }
 
 export function Workstation({
@@ -70,6 +77,7 @@ export function Workstation({
     isAdmin = false,
     userEmail = null,
     initialSettings,
+    isHosted = false,
 }: WorkstationProps) {
     const router = useRouter();
     const [currentRecording, setCurrentRecording] = useState<Recording | null>(
@@ -676,6 +684,7 @@ export function Workstation({
                 open={settingsOpen}
                 onOpenChange={setSettingsOpen}
                 initialProviders={providers}
+                isHosted={isHosted}
                 onReRunOnboarding={() => {
                     setSettingsOpen(false);
                     setOnboardingOpen(true);


### PR DESCRIPTION
## Description

When `IS_HOSTED=true`, the Storage settings panel was still rendering the self-host-only "Backend" card on the dashboard (the one showing the storage type and explaining that storage is configured via env vars at the instance level). The `/settings` page didn't have this bug — only the dialog opened from the dashboard's Workstation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/app/(app)/dashboard/page.tsx`: forward `env.IS_HOSTED` to `Workstation`.
- `src/components/dashboard/workstation.tsx`: accept `isHosted` prop and pass it into `SettingsDialog`.

## Root Cause

`StorageSection` already gated the Backend card with `{!isHosted && ...}`, and `SettingsDialog` → `SettingsContent` → `StorageSection` all forwarded the prop. The `/settings` route (`src/app/(app)/settings/page.tsx`) passes `isHosted={env.IS_HOSTED}` correctly, but the dashboard's `Workstation` mounted its own `SettingsDialog` without threading the prop, so `isHosted` defaulted to `false` for that codepath.

## Testing

- `pnpm type-check` — passes.
- Not run: `pnpm test`, manual hosted-mode verification (not requested).

## Checklist

- [x] Type checking passes (`pnpm type-check`)
- [ ] `pnpm test` (not run)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes storage settings visibility on the hosted dashboard by threading `env.IS_HOSTED` from the dashboard page into `Workstation` and then `SettingsDialog`, hiding the self-host-only “Backend” card to match `/settings`.

- **Refactors**
  - Made `Workstation` `isHosted` prop required to enforce passing the server value and prevent future hosted-mode regressions.

<sup>Written for commit 58479eaeb341cc725f89a06702a32ad902fc7954. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

