### PR TITLE
feat(docs): add /docs site with Guides, Self Hosting, and Reference sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ plans/
 
 # bun (we use pnpm; bun is only a runtime for scripts/tests)
 bun.lock
+/src/.source

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,8 @@
         "includes": [
             "src/**/*.{js,jsx,ts,tsx,json,css}",
             "*.{js,jsx,ts,tsx,json}",
-            "!src/db/migrations"
+            "!src/db/migrations",
+            "!src/.source"
         ]
     },
     "formatter": {

--- a/content/docs/guides/ai-providers.mdx
+++ b/content/docs/guides/ai-providers.mdx
@@ -1,0 +1,83 @@
+---
+title: AI providers
+description: Configure OpenAI-compatible transcription and summarization providers.
+---
+
+OpenPlaud uses the OpenAI SDK with a configurable `baseURL`. Any provider
+that exposes an OpenAI-compatible API works: OpenAI itself, Groq,
+OpenRouter, Together, Azure OpenAI, LM Studio, Ollama, and anything else
+that speaks the same wire format.
+
+You can configure multiple providers and pick which one runs
+transcription and which runs summarization on a per-recording basis.
+
+## Adding a provider
+
+**Settings → AI providers → Add provider** opens a dialog with a preset
+list. Each preset pre-fills `baseURL`, default model, and a hint about
+which API surface the transcription worker should use:
+
+- **Whisper-style** (`/v1/audio/transcriptions`, multipart upload) — the
+  classic OpenAI Whisper surface. Used by OpenAI, Groq Whisper, Together
+  Whisper, LM Studio, Ollama.
+- **Chat-style** (`/v1/chat/completions` with an `input_audio` content
+  part) — for providers that expose audio-input LLMs instead of a
+  dedicated transcription endpoint. Used by OpenRouter routing
+  Gemini / GPT-audio / Voxtral.
+
+Pick a preset, paste your API key, choose a default model, save. Repeat
+for additional providers.
+
+## Preset reference
+
+| Preset      | Base URL                                     | Notes                                                            |
+| ----------- | -------------------------------------------- | ---------------------------------------------------------------- |
+| OpenAI      | *(blank, defaults to api.openai.com)*        | Production quality; `whisper-1`, `gpt-4o-transcribe`             |
+| Groq        | `https://api.groq.com/openai/v1`             | Free Whisper API, very fast                                      |
+| OpenRouter  | `https://openrouter.ai/api/v1`               | Chat-style transcription; many summarization models in one key   |
+| Together AI | `https://api.together.xyz/v1`                | Cost-effective, broad model selection                            |
+| Azure       | `https://<resource>.openai.azure.com/...`    | Enterprise compliance, deployment-scoped URLs                    |
+| LM Studio   | `http://localhost:1234/v1`                   | Local, 100% offline                                              |
+| Ollama      | `http://localhost:11434/v1`                  | Local, easy model management                                     |
+| Custom      | *(freeform)*                                 | Anything else OpenAI-compatible                                  |
+
+LM Studio and Ollama presets default to `http://localhost`. From inside
+a Docker container, `localhost` is the container itself, not the host
+machine — use `http://host.docker.internal:<port>` on Mac/Windows, or
+the Docker bridge IP on Linux, to reach an AI server running on the
+host. If you run Ollama in the same Docker network as OpenPlaud, use the
+service hostname (`http://ollama:11434/v1`).
+
+## Choosing models
+
+The preset list ships with a curated set of known transcription model
+ids per provider. When the API exposes structured capability metadata
+(today only OpenRouter), the Add/Edit dialog can fetch the live list of
+audio-capable models for you. For everyone else, the curated list drives
+the dropdown and a **Custom…** option lets you type an id by hand for
+new releases that ship before our next version bump.
+
+Summarization is more forgiving — any chat model that follows the
+OpenAI `chat/completions` shape works. Pick something fast and cheap
+(e.g. `gpt-4o-mini`, `llama-3.1-70b-versatile`) unless you have a
+specific reason to use a larger model.
+
+## What gets sent to the provider
+
+Plaintext audio (for transcription) and plaintext transcript text
+(for summarization). The trust boundary is the provider you picked.
+OpenPlaud's at-rest encryption protects the database, not the network
+hop to your AI provider — see
+[Encryption at rest](../reference/encryption-at-rest) for the explicit
+list of what that layer does and does not cover.
+
+If you need to minimise that trust boundary, run a local provider (LM
+Studio or Ollama) on the same machine as a self-host instance. Both
+transcription and summarization stay on your hardware.
+
+## Switching the active provider
+
+On any recording, the workstation panel exposes a transcription provider
+picker and a summary provider picker. Changes apply immediately; you can
+re-run a transcription with a different provider if the first result was
+poor.

--- a/content/docs/guides/automation-and-webhooks.mdx
+++ b/content/docs/guides/automation-and-webhooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Automation API and webhooks
-description: Personal API keys, signed webhook deliveries, and using the /api/v1surface from external tools.
+description: Personal API keys, signed webhook deliveries, and using the /api/v1 surface from external tools.
 ---
 
 OpenPlaud exposes a small, stable automation surface for external

--- a/content/docs/guides/automation-and-webhooks.mdx
+++ b/content/docs/guides/automation-and-webhooks.mdx
@@ -1,0 +1,145 @@
+---
+title: Automation API and webhooks
+description: Personal API keys, signed webhook deliveries, and using the /api/v1surface from external tools.
+---
+
+OpenPlaud exposes a small, stable automation surface for external
+tools — Zapier-style integrations, n8n flows, your own scripts. Two
+moving parts:
+
+- **Personal API keys** authenticate read access to the `/api/v1/*`
+  surface.
+- **Webhook endpoints** push events at your own server when something
+  interesting happens (a new recording, a finished transcription).
+
+For the full endpoint reference and code samples, see
+[Public API](../reference/public-api).
+
+## Personal API keys
+
+**Settings → Developer → API keys → Create API key.** Give it a name,
+optionally an expiry, and copy the key shown once. The key is shown
+exactly once — store it in your password manager or the secret manager
+of whatever tool will use it.
+
+Format: `op_<24 url-safe chars>` (e.g. `op_K7vR8x...`). Keys carry
+read-only scope today; writes are not part of the public surface.
+
+You authenticate by sending the key as a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer op_K7vR8x..." \
+  https://your-openplaud-host/api/v1/recordings
+```
+
+Internally, OpenPlaud stores an HMAC-SHA256 hash of the key (keyed off
+`API_TOKEN_HASH_SECRET`, falling back to `BETTER_AUTH_SECRET`) rather
+than the key itself. A database breach does not leak usable tokens. The
+key prefix (first 12 characters) is stored in plaintext so the UI can
+show you "which key was that?" without being able to reconstruct it.
+
+**Revoking a key** is a soft revoke — the row is marked `revokedAt` and
+authentication starts rejecting it immediately. You can also set an
+`expiresAt` at creation time; expired keys are rejected the same way.
+
+## Webhook endpoints
+
+**Settings → Developer → Webhooks → Create webhook.** Provide:
+
+- **URL** the endpoint to POST events to.
+- **Events** one or more of the supported event types (see below).
+- **Description** optional, for your own bookkeeping.
+
+You get back a signing secret of the form `whsec_<32 chars>`. The
+secret is shown once and stored encrypted at rest. Use it to verify
+incoming requests.
+
+### Supported events
+
+| Event                       | When it fires                                  |
+| --------------------------- | ---------------------------------------------- |
+| `recording.synced`          | A new recording finished syncing from Plaud    |
+| `recording.updated`         | An existing recording's metadata changed       |
+| `recording.deleted`         | A recording was soft-deleted                   |
+| `transcription.completed`   | Transcription finished successfully            |
+| `transcription.failed`      | Transcription failed (final, after retries)    |
+
+### Delivery shape
+
+Each delivery is a `POST` to your URL with a JSON body and these
+headers:
+
+| Header                  | Meaning                                                 |
+| ----------------------- | ------------------------------------------------------- |
+| `X-OpenPlaud-Event`     | The event name (e.g. `recording.synced`)                |
+| `X-OpenPlaud-Delivery`  | Unique delivery id, useful for idempotent receivers     |
+| `X-OpenPlaud-Timestamp` | Unix seconds, also embedded in the signature payload    |
+| `X-OpenPlaud-Signature` | `t=<timestamp>,v1=<hex hmac>` — see below               |
+
+The body always contains the event name, the affected recording id,
+and a serialized recording payload matching the
+[`/api/v1/recordings/{id}`](../reference/public-api) shape.
+
+### Verifying signatures
+
+Signature header format: `t=1700000000,v1=<hex>`.
+
+The signed payload is `${timestamp}.${rawBody}` and the algorithm is
+HMAC-SHA256 with your `whsec_…` secret. Reject deliveries where:
+
+- The `t=` value is more than **five minutes** away from the receiver's
+  clock (replay protection).
+- The recomputed `v1` digest does not match in constant time.
+
+Reference Node.js receiver:
+
+```js
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+function verify(secret, header, rawBody, toleranceSeconds = 300) {
+  const parts = new Map(
+    header.split(",").map((p) => p.split("=")),
+  );
+  const t = Number(parts.get("t"));
+  const sig = parts.get("v1");
+  if (!Number.isFinite(t) || !sig) return false;
+  if (Math.abs(Date.now() / 1000 - t) > toleranceSeconds) return false;
+
+  const expected = createHmac("sha256", secret)
+    .update(`${t}.${rawBody}`)
+    .digest("hex");
+
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(sig, "hex");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+```
+
+The exact same algorithm lives in `src/lib/webhooks/signature.ts`.
+
+### Allowed URLs
+
+By default, webhook URLs may use `http://` or `https://` and may point
+at any host the OpenPlaud container can reach. Docker-bridge service
+hostnames work (`http://n8n:5678/...`), so do private-network IPs.
+Credentials embedded in the URL are rejected.
+
+If you want stricter validation — HTTPS only, public-IP destinations
+only, RFC1918/loopback/link-local/ULA explicitly rejected — set
+`WEBHOOKS_REQUIRE_PUBLIC_TARGETS=true` in your `.env`. Useful if your
+OpenPlaud instance is exposed to other people and you don't want it to
+be usable as an SSRF relay against your private network.
+
+### Retry behaviour
+
+Webhook deliveries are queued and processed by a background worker. A
+non-2xx response or network failure schedules an exponential-backoff
+retry. After the worker exhausts retries the delivery is marked failed
+and visible in **Settings → Developer → Webhooks → Recent deliveries**.
+
+## What writes look like
+
+There aren't any public write endpoints yet. The current `/api/v1/*`
+surface is read-only by design: list recordings, get a recording, get
+its transcript, stream its audio. If you need to push data *in*, run
+the OpenPlaud UI or sync the source Plaud account.

--- a/content/docs/guides/backup-and-restore.mdx
+++ b/content/docs/guides/backup-and-restore.mdx
@@ -1,0 +1,109 @@
+---
+title: Backup and restore
+description: Export your recordings, transcripts, and audio so you can leave at any time.
+---
+
+OpenPlaud has two separate export paths, deliberately. They serve
+different jobs:
+
+- **`/api/backup`** — a complete JSON archive of every recording row
+  and transcript that belongs to you. Built for full disaster
+  recovery and migration off the instance.
+- **`/api/export`** — single-recording transcripts in human-readable
+  formats (`txt`, `srt`, `vtt`) or a `json` dump. Built for sharing
+  individual transcripts, not for backup.
+
+The audio files themselves live in your configured storage backend
+(local volume or S3 bucket) and are backed up the same way you'd back
+up any other binary blob.
+
+## Backup the database state
+
+**Settings → Export → Create backup** (or `POST /api/backup`) produces
+a single JSON file:
+
+```json
+{
+  "version": "1.0",
+  "createdAt": "2026-05-13T12:00:00.000Z",
+  "userId": "...",
+  "recordings": [
+    {
+      "id": "...",
+      "filename": "Team standup",
+      "duration": 1820,
+      "startTime": "...",
+      "endTime": "...",
+      "filesize": 1234567,
+      "deviceSn": "...",
+      "transcription": {
+        "text": "Plaintext transcript text...",
+        "provider": "...",
+        "model": "..."
+      }
+    }
+  ]
+}
+```
+
+The archive is **plaintext**. OpenPlaud's at-rest encryption decrypts
+all fields before serialization because the backup is *your* export of
+your own data — you own it from this point. Treat the file the same
+way you'd treat an unencrypted database dump: store it encrypted,
+restrict access, don't email it.
+
+The backup does **not** include audio files. Back those up separately.
+
+## Backup the audio files
+
+- **Local storage backend.** The Docker volume that mounts at
+  `/app/audio` inside the container holds every audio file. Snapshot
+  it the same way you snapshot any other volume — `restic`, `rsync`,
+  ZFS snapshots, your choice.
+- **S3 backend.** Whichever bucket you configured already lives
+  outside the instance. Enable versioning, cross-region replication,
+  or a lifecycle copy job on the bucket itself.
+
+The path layout inside the bucket / directory is
+`{userId}/{filename}.mp3`, with `(2)`, `(3)`,&nbsp;… suffixes appended
+on collisions.
+
+## Single-recording export
+
+`GET /api/export?format=<fmt>` returns transcripts in one of:
+
+| Format | Content                                                  |
+| ------ | -------------------------------------------------------- |
+| `json` | One JSON document with every recording + transcript      |
+| `txt`  | Plaintext, one block per recording (filename, time, text)|
+| `srt`  | SubRip subtitles                                         |
+| `vtt`  | WebVTT subtitles                                         |
+
+The default format is whatever you set as **Settings → Export →
+Default export format**, falling back to `json`. Per-recording UI
+buttons populate the `?format=` query param for you.
+
+## Restore
+
+There is no `POST /api/backup/restore` endpoint today. The backup file
+is the export half of the contract — it lets you leave the instance
+with your data intact, which is what "export parity" guarantees. If
+you need to import a backup into a fresh instance, the supported path
+is a Postgres-level restore (the snapshot of the database volume), not
+a JSON re-import.
+
+If you need a programmatic re-import — for migrating between
+self-host instances, for instance — file an issue with the use case.
+It's a deliberate gap, not an oversight, and the right shape depends
+on the use case.
+
+## What's encrypted vs. what's plaintext
+
+A reminder, because this trips people up:
+
+- **In the database**, sensitive fields are encrypted at rest with
+  AES-256-GCM (see [Encryption at rest](../reference/encryption-at-rest)).
+- **In a backup file produced by `/api/backup`**, those fields are
+  decrypted before serialization. Your responsibility from there.
+- **Audio files in storage** are *not* encrypted by OpenPlaud's
+  app-layer encryption — use bucket-level SSE if you need that.

--- a/content/docs/guides/backup-and-restore.mdx
+++ b/content/docs/guides/backup-and-restore.mdx
@@ -9,9 +9,9 @@ different jobs:
 - **`/api/backup`** — a complete JSON archive of every recording row
   and transcript that belongs to you. Built for full disaster
   recovery and migration off the instance.
-- **`/api/export`** — single-recording transcripts in human-readable
-  formats (`txt`, `srt`, `vtt`) or a `json` dump. Built for sharing
-  individual transcripts, not for backup.
+- **`/api/export`** — every recording's transcript flattened into one
+  human-readable file (`txt`, `srt`, `vtt`) or a `json` dump. Built
+  for handing transcripts to other tools, not for backup.
 
 The audio files themselves live in your configured storage backend
 (local volume or S3 bucket) and are backed up the same way you'd back
@@ -19,8 +19,8 @@ up any other binary blob.
 
 ## Backup the database state
 
-**Settings → Export → Create backup** (or `POST /api/backup`) produces
-a single JSON file:
+**Settings → Export/Backup → Create Backup** (or `POST /api/backup`)
+produces a single JSON file:
 
 ```json
 {
@@ -68,20 +68,21 @@ The path layout inside the bucket / directory is
 `{userId}/{filename}.mp3`, with `(2)`, `(3)`,&nbsp;… suffixes appended
 on collisions.
 
-## Single-recording export
+## Bulk transcript export
 
-`GET /api/export?format=<fmt>` returns transcripts in one of:
+`GET /api/export?format=<fmt>` flattens every one of your recordings
+into a single file:
 
 | Format | Content                                                  |
 | ------ | -------------------------------------------------------- |
 | `json` | One JSON document with every recording + transcript      |
 | `txt`  | Plaintext, one block per recording (filename, time, text)|
-| `srt`  | SubRip subtitles                                         |
-| `vtt`  | WebVTT subtitles                                         |
+| `srt`  | SubRip subtitles, all recordings concatenated            |
+| `vtt`  | WebVTT subtitles, all recordings concatenated            |
 
-The default format is whatever you set as **Settings → Export →
-Default export format**, falling back to `json`. Per-recording UI
-buttons populate the `?format=` query param for you.
+The default format is whatever you set as **Settings → Export/Backup
+→ Default export format**, falling back to `json`. The **Export All**
+button in that same panel calls this endpoint.
 
 ## Restore
 

--- a/content/docs/guides/connect-plaud-account.mdx
+++ b/content/docs/guides/connect-plaud-account.mdx
@@ -1,0 +1,86 @@
+---
+title: Connect your Plaud account
+description: Sign in to Plaud from OpenPlaud, including the Google/Apple workaround.
+---
+
+OpenPlaud signs into Plaud directly — the same way the official Plaud app
+does. No screen-scraping, no headless browser, no reverse-engineered
+mobile-app traffic. The flow you'll use depends on how you originally
+created your Plaud account.
+
+## Email-and-code (default path)
+
+If you signed up to Plaud with an email address and password, you can sign
+in from OpenPlaud directly:
+
+1. Enter the email address you use on [plaud.ai](https://plaud.ai).
+2. Plaud emails you a 6-digit verification code.
+3. Paste it into OpenPlaud.
+
+The code is forwarded to Plaud's servers and **never stored locally**.
+After login, the returned access token is encrypted with AES-256-GCM
+before it hits the database — see
+[Encryption at rest](../reference/encryption-at-rest) for what that
+covers.
+
+Plaud's account region (Global, EU, Asia Pacific) is detected
+automatically: if the global endpoint responds with `status: -302` and a
+regional API host in `data.domains.api`, OpenPlaud follows the redirect
+and stores the per-account region alongside the token.
+
+## Signed up with Google or Apple?
+
+If you originally tapped **Continue with Google** or **Continue with
+Apple** on Plaud, the email-and-code flow will *appear* to succeed but
+sync will return zero recordings. That's because the email/password
+identity and the Google/Apple identity are two different accounts on
+Plaud's side, even when they share an email address
+([#65](https://github.com/openplaud/openplaud/issues/65)).
+
+Real "Sign in with Google / Apple" inside OpenPlaud is structurally
+blocked by Google's authorized-origins policy on Plaud's OAuth client.
+There are two workarounds.
+
+### Easy path: the connector extension
+
+Install the [OpenPlaud Connector](https://github.com/openplaud/connector/releases/latest)
+browser extension (AGPL-3.0) — grab the latest release from GitHub and
+load it as an unpacked extension. With the extension installed, the
+connect screen surfaces a **Sign in with Plaud** button. You sign in to
+`web.plaud.ai` the way you normally do; the extension forwards the
+resulting access token to your OpenPlaud instance. No copy-pasting, no
+devtools.
+
+### Manual fallback: paste the token
+
+If you can't or won't install the extension:
+
+1. Open [web.plaud.ai](https://web.plaud.ai) in a tab and sign in with
+   Google or Apple as usual.
+2. Open browser devtools (F12 / Cmd+Option+I) → **Network** tab. Refresh
+   the page.
+3. Click any request whose host starts with `api.plaud.ai`,
+   `api-euc1.plaud.ai`, or `api-apse1.plaud.ai`.
+4. Under **Headers → Request Headers**, find `Authorization`. Copy
+   everything after `Bearer ` — the long `eyJ…` JWT.
+5. In OpenPlaud, switch to the **Paste token** tab, pick the region that
+   matches the host you copied the token from (EU if it was
+   `api-euc1.plaud.ai`, APAC for `api-apse1.plaud.ai`, otherwise
+   Global), and paste.
+
+The pasted token is encrypted at rest the same way as a code-flow token.
+
+## What about refresh tokens?
+
+Plaud's API does not issue refresh tokens. The OTP login response
+contains only an access token, which is a long-lived JWT (roughly 300
+days observed). When it expires, the dashboard surfaces a reconnect
+banner and you repeat whichever flow above you used originally. There is
+no background refresh to fail silently.
+
+## Switching accounts
+
+You can disconnect or switch the connected Plaud account at any time
+from **Settings → Plaud account**. The encrypted bearer token is
+deleted; previously synced recordings stay where they are (you own that
+data on your own storage).

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -1,0 +1,10 @@
+{
+    "title": "Guides",
+    "pages": [
+        "connect-plaud-account",
+        "ai-providers",
+        "notifications",
+        "automation-and-webhooks",
+        "backup-and-restore"
+    ]
+}

--- a/content/docs/guides/notifications.mdx
+++ b/content/docs/guides/notifications.mdx
@@ -1,0 +1,70 @@
+---
+title: Notifications
+description: Bark push notifications, browser notifications, and email — backends and configuration.
+---
+
+OpenPlaud can notify you when a recording finishes syncing or a
+transcription completes. Three backends ship in the box: Bark
+(iOS push), browser notifications (Web Notifications API), and email
+(SMTP). Each backend is independent; you can enable any combination.
+
+Notifications never block the sync loop — each backend uses a hard
+timeout (three seconds for Bark, similar for email) and failures are
+logged, not retried into a queue.
+
+## Bark (iOS push)
+
+[Bark](https://github.com/Finb/Bark) is a free, self-hostable iOS push
+service. You install the Bark app, it gives you a personal push URL,
+and you paste that URL into OpenPlaud.
+
+**Settings → Notifications → Bark push URL.** Paste the URL Bark gave
+you (looks like `https://api.day.app/<your-key>`). The URL is stored
+per-user.
+
+OpenPlaud sends notifications with `level: "timeSensitive"` so they
+break through Focus modes on iOS. Failure is silent in the sense that
+sync continues — check the server logs if you expected a notification
+that didn't arrive.
+
+## Browser notifications
+
+Browser notifications use the standard Web Notifications API and work
+out of the box on Chrome, Firefox, Safari, and Edge once you grant
+permission.
+
+**Settings → Notifications → Browser notifications → Enable.** The
+browser prompts you for permission; OpenPlaud remembers the per-user
+toggle in the database.
+
+These only fire while the OpenPlaud tab is open in at least one
+browser. For background delivery, use Bark or email.
+
+## Email
+
+On the hosted instance at openplaud.com, email is already configured
+for you — just enable it. On a self-host instance, the operator has
+to wire up SMTP first; see
+[Email (SMTP) setup](../self-hosting/email-smtp).
+
+**Settings → Notifications → Email → Enable.** OpenPlaud will send a
+message to your account email when a recording finishes syncing or a
+transcription completes.
+
+To verify it works without waiting for a real event, hit
+**Settings → Notifications → Email → Send test email**. If your
+self-host operator hasn't configured SMTP, the backend short-circuits
+cleanly and logs a "SMTP not configured" warning on the server — no
+mail goes out and no error surfaces in the UI.
+
+## Picking a backend
+
+| Need                             | Use                  |
+| -------------------------------- | -------------------- |
+| Push to phone, away from desk    | Bark                 |
+| Notification while OpenPlaud open| Browser              |
+| Audit trail of completions       | Email                |
+| Multi-user team alerting         | Email                |
+
+Bark and browser are good for personal use. Email is the right choice
+when you want a persistent inbox record of every sync result.

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,0 +1,61 @@
+---
+title: OpenPlaud Docs
+description: Open-source transcription and summarization for Plaud Note devices.
+---
+
+OpenPlaud replaces Plaud's subscription with software you can use either
+way: sign up at [openplaud.com](https://openplaud.com) for the hosted
+instance, or run the same codebase on your own infrastructure with
+Docker Compose. Bring any OpenAI-compatible API key, keep your
+recordings, leave whenever you want.
+
+## For everyone
+
+These guides apply whether you're on hosted or self-host — they're
+about using OpenPlaud as a product.
+
+- **[Connect your Plaud account](/docs/guides/connect-plaud-account)** —
+  email-and-code login, plus the Google/Apple workaround.
+- **[AI providers](/docs/guides/ai-providers)** — wire up OpenAI, Groq,
+  OpenRouter, Ollama, LM Studio, or anything else OpenAI-compatible.
+- **[Notifications](/docs/guides/notifications)** — Bark, browser, and
+  email backends.
+- **[Automation API and webhooks](/docs/guides/automation-and-webhooks)** —
+  personal API keys and signed webhook deliveries.
+- **[Backup and restore](/docs/guides/backup-and-restore)** — export
+  every recording, transcript, and audio file so you can leave.
+
+## For self-hosters
+
+You run the stack yourself with `docker compose up`. These pages cover
+install, configuration, and ongoing operation.
+
+- **[Install](/docs/self-hosting/install)** — one-line Docker Compose
+  installer.
+- **[Environment variables](/docs/self-hosting/environment-variables)** —
+  every knob OpenPlaud reads at boot.
+- **[S3-compatible storage](/docs/self-hosting/storage-s3)** — AWS,
+  R2, MinIO, B2, and friends.
+- **[Email (SMTP) setup](/docs/self-hosting/email-smtp)** — wire up
+  outbound mail for the email notification backend.
+- **[Upgrading](/docs/self-hosting/upgrading)** — image tags, the
+  upgrade command, and what to back up first.
+
+## Reference
+
+Concepts, contracts, and the public API surface.
+
+- **[Public API](/docs/reference/public-api)** — the stable read surface
+  for external integrations.
+- **[Architecture](/docs/reference/architecture)** — how the pieces fit
+  together.
+- **[Security model](/docs/reference/security-model)** — authentication,
+  tokens, and trust boundaries.
+- **[Encryption at rest](/docs/reference/encryption-at-rest)** — what's
+  encrypted in the database, what isn't, and how to rotate keys.
+
+## How it ships
+
+OpenPlaud is AGPL-3.0 software. The hosted instance at openplaud.com is
+multi-tenant SaaS we operate; self-host deployments run the same image
+under your control. Both modes are first-class.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,0 +1,4 @@
+{
+    "title": "Docs",
+    "pages": ["index", "guides", "self-hosting", "reference"]
+}

--- a/content/docs/reference/architecture.mdx
+++ b/content/docs/reference/architecture.mdx
@@ -1,0 +1,125 @@
+---
+title: Architecture
+description: How the pieces fit together — Next.js app, Postgres, sync worker, pluggable storage and AI.
+---
+
+OpenPlaud is a single Next.js application backed by Postgres. There's
+no separate API service, no separate worker container, no message
+queue. Everything runs in one process; horizontal scaling means
+running more copies of that process behind a load balancer.
+
+## The runtime
+
+- **Web + API + worker** — all one Next.js process. The sync worker,
+  the transcription worker, and the webhook delivery worker are
+  background tasks inside the same process.
+- **Postgres** — the only stateful dependency. Better Auth uses it
+  for sessions, Drizzle ORM for everything else.
+- **Storage** — local filesystem or any S3-compatible bucket. Audio
+  files only; metadata is in Postgres.
+- **AI providers** — external HTTPS calls to whatever OpenAI-compatible
+  endpoints the user configured. Per-user, per-provider.
+
+## Tech stack
+
+| Layer        | Choice                                                  |
+| ------------ | ------------------------------------------------------- |
+| Framework    | Next.js (App Router)                                    |
+| Language     | TypeScript                                              |
+| Styling      | Tailwind CSS                                            |
+| Auth         | Better Auth                                             |
+| DB           | Postgres                                                |
+| ORM          | Drizzle                                                 |
+| AI           | OpenAI SDK with configurable `baseURL`                  |
+| Storage      | Local FS or any S3-compatible API                       |
+| Audio        | Wavesurfer.js for the player                            |
+| Test runner  | Bun                                                     |
+| Docs site    | Fumadocs (you're reading the output)                    |
+
+## Sync is pull-based
+
+Plaud has no push API. OpenPlaud's sync worker
+(`src/lib/sync/sync-recordings.ts`) is a pull loop:
+
+1. List recordings from the connected Plaud account (paginated).
+2. For each one, compare `plaudFileId` + `version_ms` to the database.
+   New rows get inserted; updated rows get refreshed; unchanged rows
+   are skipped.
+3. Download the audio file once per new recording, encode the storage
+   key, hand off to the configured storage provider.
+4. Emit `recording.synced` to any webhook endpoints subscribed.
+5. The sync loop is **idempotent**. Interrupted runs resume on the
+   next tick without producing duplicates.
+
+There is no Plaud webhook ingestion path because Plaud does not offer
+one. If they ever do, the loop becomes a thin shim.
+
+## Pluggable storage
+
+`StorageProvider` (`src/lib/storage/types.ts`) is the abstraction:
+`uploadFile`, `downloadFile`, `getSignedUrl`, `deleteFile`,
+`testConnection`. Two adapters ship today — `local-storage.ts` and
+`s3-storage.ts` — selected via the `createStorageProvider()` factory
+in `src/lib/storage/factory.ts`.
+
+Feature code never branches on storage type. The factory does that
+once; everywhere else gets a `StorageProvider`. Adding a new adapter
+is a five-step edit; see the README "Extension Points" section for the
+exact checklist.
+
+## Pluggable AI
+
+OpenPlaud doesn't have a per-provider abstraction class. Instead, the
+OpenAI SDK is configured with a per-user `baseURL` and the same SDK
+calls work against OpenAI, Groq, OpenRouter, Ollama, LM Studio, and
+anything else that speaks the OpenAI wire protocol.
+
+Two transcription "styles" coexist:
+
+- **Whisper-style** — `POST /v1/audio/transcriptions` with multipart
+  audio. The classic OpenAI surface.
+- **Chat-style** — `POST /v1/chat/completions` with an `input_audio`
+  content part. Used by providers that expose audio-input LLMs
+  instead of a dedicated transcription endpoint (today: OpenRouter
+  routing Gemini, GPT-audio, Voxtral).
+
+A `transcriptionStyle` field on each provider preset
+(`src/lib/ai/provider-presets.ts`) tells the worker which surface to
+hit. Adding a new provider with non-standard auth (e.g. AWS Bedrock
+SigV4) means writing an adapter that fronts the provider behind an
+OpenAI-compatible surface, **not** branching on provider name in
+feature code.
+
+## Transcription
+
+Transcription happens server-side via whichever OpenAI-compatible
+provider the user configured. Per-recording choice of provider and
+model, changeable from the workstation panel. See
+[AI providers](../guides/ai-providers).
+
+## Routes
+
+- `src/app/(app)/` — authenticated routes (dashboard, recordings,
+  settings, workstation).
+- `src/app/(auth)/` — login, register, OTP screens.
+- `src/app/(docs)/` — this docs site.
+- `src/app/api/` — internal routes (session-authenticated).
+- `src/app/api/v1/` — public, key-authenticated, stable read surface.
+  See [Public API](./public-api).
+
+## Multi-process safety
+
+Background workers are safe to run with multiple OpenPlaud processes
+against the same database. The sync worker, transcription worker, and
+webhook worker all claim work at the database level with
+`SELECT … FOR UPDATE SKIP LOCKED` rather than relying on an in-memory
+`running` flag. The in-memory flags are advisory only. The default
+Docker Compose deployment runs a single app container against one
+Postgres, but the code doesn't depend on that.
+
+## Where to look next
+
+- [Public API](./public-api) — the stable external surface.
+- [Security model](./security-model) — encryption, auth tokens, and
+  what's enforced where.
+- [Environment variables](../self-hosting/environment-variables) — every knob the self-host instance reads at boot.

--- a/content/docs/reference/architecture.mdx
+++ b/content/docs/reference/architecture.mdx
@@ -33,7 +33,7 @@ running more copies of that process behind a load balancer.
 | AI           | OpenAI SDK with configurable `baseURL`                  |
 | Storage      | Local FS or any S3-compatible API                       |
 | Audio        | Wavesurfer.js for the player                            |
-| Test runner  | Bun                                                     |
+| Test runner  | Vitest (Bun also used as a runtime for scripts)         |
 | Docs site    | Fumadocs (you're reading the output)                    |
 
 ## Sync is pull-based

--- a/content/docs/reference/encryption-at-rest.mdx
+++ b/content/docs/reference/encryption-at-rest.mdx
@@ -1,0 +1,117 @@
+---
+title: Encryption at rest
+description: AES-256-GCM envelope encryption for sensitive database fields.
+---
+
+OpenPlaud encrypts user content fields in the database with AES-256-GCM,
+keyed off the `ENCRYPTION_KEY` environment variable that the runtime
+already requires.
+
+This is **server-held-key envelope encryption.** It is not zero-knowledge.
+
+## What is encrypted
+
+| Column | Type | Notes |
+|---|---|---|
+| `recordings.filename` | text | Often carries topic info (e.g. AI-generated titles) |
+| `transcriptions.text` | text | Full transcript |
+| `ai_enhancements.summary` | text | LLM summary |
+| `ai_enhancements.key_points` | jsonb | Stored as `{ "c": "v1:..." }` envelope |
+| `ai_enhancements.action_items` | jsonb | Same envelope shape |
+| `user_settings.summary_prompt` | jsonb | Custom prompt configs may carry user context |
+| `user_settings.title_generation_prompt` | jsonb | Same |
+
+Pre-existing encryption (unchanged):
+
+- `plaud_connections.bearer_token`
+- `api_credentials.api_key`
+- `storage_config.s3_config`
+
+Out of scope for this layer:
+
+- **Audio files in storage** (local FS / S3). Object-level encryption is a
+  separate, heavier change. For S3, prefer server-side encryption at the
+  bucket level today; revisit per-object app-layer encryption later.
+- **Search.** No full-text search on transcripts is implemented today, so
+  encrypting `text` causes no regression. If search lands later, it will
+  need a tokenized HMAC index — not this PR.
+
+## What this protects against
+
+- Stolen DB backups or snapshots
+- Read-replica access without app-server access
+- A SQL-injection that reads but does not execute application code
+- Operators with DB-only access (e.g. via an admin console) cannot read
+  content without also having the app-server key
+
+## What this does not protect against
+
+- A compromised application server. The server holds the key and decrypts
+  content at request time so it can run AI on it. This is unavoidable while
+  server-side transcription and summarization are part of the product.
+- A compromised `ENCRYPTION_KEY`. Treat the key like a database master
+  credential.
+- A compromised AI provider. Plaintext is sent to whichever transcription /
+  enhancement provider the user configured. That trust boundary is the
+  user's choice and is independent of this layer.
+
+If you need to keep plaintext audio and transcripts off third-party
+infrastructure entirely, run a local AI provider (Ollama or LM Studio)
+on the same machine as your OpenPlaud instance. The server still holds
+the encryption key, but no plaintext leaves the box.
+
+## Key management
+
+`ENCRYPTION_KEY` must be a 64-character hex string (32 bytes). Generate one
+with:
+
+```bash
+node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))"
+```
+
+Losing the key makes encrypted content unrecoverable. Backup the key
+separately from the database.
+
+Backup files produced by `/api/backup` are **plaintext** by design — they
+are the user's own export. Store them with the same care you'd give the
+unencrypted database.
+
+## Versioning and key rotation
+
+New ciphertext written by this layer is prefixed with `v1:`. Older formats
+are still readable:
+
+- `v1:iv:tag:hex` — current. Identifies the key/version that produced it.
+- `iv:tag:hex` (no prefix) — pre-existing format used for Plaud bearer
+  tokens and AI keys. Read path tolerates it.
+- Anything else — treated as legacy plaintext and returned verbatim. This
+  is the deploy → backfill compatibility window.
+
+Key rotation is not implemented yet. The `v1:` prefix exists so a future
+rotation pass can identify which rows need re-encrypting.
+
+## Backfill
+
+Pre-rollout rows stay plaintext until rewritten. The read path tolerates
+both shapes during this window. To eagerly encrypt existing rows:
+
+**Docker / self-host (the supported path):** the script is bundled into the
+image at `/app/encrypt-backfill.js`.
+
+```bash
+# Report what would change (no writes)
+docker compose exec app bun encrypt-backfill.js --dry-run
+
+# Apply
+docker compose exec app bun encrypt-backfill.js
+```
+
+**From a source checkout (development):**
+
+```bash
+bun scripts/encrypt-backfill.ts --dry-run
+bun scripts/encrypt-backfill.ts
+```
+
+The script is idempotent (skips rows already in `v1:` form), batched, and
+safe to interrupt and resume.

--- a/content/docs/reference/meta.json
+++ b/content/docs/reference/meta.json
@@ -1,0 +1,9 @@
+{
+    "title": "Reference",
+    "pages": [
+        "architecture",
+        "public-api",
+        "encryption-at-rest",
+        "security-model"
+    ]
+}

--- a/content/docs/reference/public-api.mdx
+++ b/content/docs/reference/public-api.mdx
@@ -1,0 +1,240 @@
+---
+title: Public API
+description: The /api/v1/* read surface — authentication, endpoints, errors, rate limits.
+---
+
+The `/api/v1/*` surface is OpenPlaud's public, stable, read-only API.
+Personal API keys authenticate it; integrations like Zapier, n8n, and
+your own scripts call into it.
+
+For creating keys and configuring webhooks, see
+[Automation API and webhooks](../guides/automation-and-webhooks).
+
+## Base URL
+
+`https://<your-openplaud-host>/api/v1`
+
+That's whatever you set `APP_URL` to in your `.env`.
+
+## Authentication
+
+Send your personal API key as a Bearer token:
+
+```http
+Authorization: Bearer op_K7vR8x...
+```
+
+Keys are 27 characters: `op_` + 24 URL-safe random characters. Keys
+carry read-only scope today. Revoked or expired keys are rejected with
+`401 UNAUTHORIZED`. Tokens are HMAC-hashed at rest.
+
+## Rate limits
+
+Two buckets enforced on every `/api/v1/*` request:
+
+- **Per IP** — 1,200 requests/minute. Rejects unauth'd flooders.
+- **Per authenticated user** — 600 requests/minute.
+
+Limit responses are JSON with a `Retry-After` header and these
+RateLimit headers:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 17
+X-RateLimit-Limit: 600
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1700000017
+```
+
+```json
+{
+  "error": "Rate limit exceeded",
+  "code": "RATE_LIMITED",
+  "details": { "retryAfter": 17, "limit": 600, "remaining": 0, "resetAt": 1700000017 }
+}
+```
+
+## Error envelope
+
+Every error response follows the same shape:
+
+```json
+{
+  "error": "Human-readable message",
+  "code": "MACHINE_READABLE_CODE",
+  "details": { "field": "limit" }
+}
+```
+
+Common codes you should handle:
+
+| Code                     | HTTP | Meaning                                              |
+| ------------------------ | ---- | ---------------------------------------------------- |
+| `UNAUTHORIZED`           | 401  | Missing, malformed, revoked, or expired key          |
+| `FORBIDDEN`              | 403  | Authenticated but not allowed                        |
+| `ACCOUNT_SUSPENDED`      | 403  | User account is suspended                            |
+| `INVALID_INPUT`          | 400  | A query param or body field failed validation        |
+| `RECORDING_NOT_FOUND`    | 404  | Recording id doesn't exist (or isn't yours)          |
+| `NOT_FOUND`              | 404  | Generic — e.g. transcript not yet produced           |
+| `RATE_LIMITED`           | 429  | Hit one of the buckets above                         |
+
+The `error` field is safe to display. Never parse `error`; branch on
+`code`.
+
+## Endpoints
+
+### List recordings
+
+```http
+GET /api/v1/recordings
+```
+
+Query parameters (all optional):
+
+| Param               | Type           | Notes                                              |
+| ------------------- | -------------- | -------------------------------------------------- |
+| `limit`             | int (1–100)    | Page size. Default 50.                             |
+| `cursor`            | opaque string  | From a previous response's `next_cursor`.          |
+| `created_since`     | ISO timestamp  | Filter to recordings created at or after this time.|
+| `updated_since`     | ISO timestamp  | Filter to recordings updated at or after this time.|
+| `has_transcription` | `true`/`false` | Filter on transcription presence.                  |
+
+```bash
+curl -H "Authorization: Bearer op_K7vR8x..." \
+  "https://your-host/api/v1/recordings?limit=20&has_transcription=true"
+```
+
+```js
+const res = await fetch(
+  "https://your-host/api/v1/recordings?limit=20",
+  { headers: { Authorization: `Bearer ${process.env.OPENPLAUD_KEY}` } },
+);
+const { data, next_cursor, has_more } = await res.json();
+```
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "id": "...",
+      "title": "Team standup",
+      "created_at": "2026-05-13T12:00:00.000Z",
+      "updated_at": "2026-05-13T12:00:00.000Z",
+      "recorded_at": "2026-05-13T11:30:00.000Z",
+      "duration_ms": 1820000,
+      "filesize_bytes": 1234567,
+      "device": { "serial_number": "...", "name": "Plaud Note", "model": "..." },
+      "has_transcription": true,
+      "has_summary": false,
+      "links": {
+        "self": "/api/v1/recordings/...",
+        "transcript": "/api/v1/recordings/.../transcript",
+        "audio": "/api/v1/recordings/.../audio"
+      }
+    }
+  ],
+  "next_cursor": "eyJ1cGRhdGVkQXQiOi...",
+  "has_more": true
+}
+```
+
+Pagination is **cursor-based, descending by `updated_at`**. When
+`has_more` is `true`, pass `next_cursor` back in the next request.
+When it's `false`, you've reached the end.
+
+### Get a recording
+
+```http
+GET /api/v1/recordings/{id}
+```
+
+```bash
+curl -H "Authorization: Bearer op_..." \
+  https://your-host/api/v1/recordings/01J...
+```
+
+Returns the same shape as a list item, plus `transcript` and `summary`
+inline when they exist. Returns `404 RECORDING_NOT_FOUND` if the
+recording doesn't exist or isn't yours.
+
+### Get a transcript
+
+```http
+GET /api/v1/recordings/{id}/transcript
+```
+
+```bash
+curl -H "Authorization: Bearer op_..." \
+  https://your-host/api/v1/recordings/01J.../transcript
+```
+
+```json
+{
+  "language": "en",
+  "text": "Full plaintext transcript...",
+  "provider": "groq",
+  "model": "whisper-large-v3",
+  "created_at": "2026-05-13T12:01:23.000Z"
+}
+```
+
+Returns `404 NOT_FOUND` if the recording exists but no transcription
+has been produced for it yet. Listen for `transcription.completed`
+webhooks to know when to retry.
+
+### Stream audio
+
+```http
+GET /api/v1/recordings/{id}/audio
+```
+
+```bash
+curl -L -H "Authorization: Bearer op_..." \
+  -o recording.mp3 \
+  https://your-host/api/v1/recordings/01J.../audio
+```
+
+Supports HTTP `Range` requests (RFC 7233):
+
+```bash
+curl -L -H "Authorization: Bearer op_..." \
+  -H "Range: bytes=0-65535" \
+  -o head.mp3 \
+  https://your-host/api/v1/recordings/01J.../audio
+```
+
+- For recordings on **local storage**, the response is the audio bytes
+  with `Content-Type` derived from the file extension and
+  `Cache-Control: private, max-age=300`. Range requests return `206`
+  with `Content-Range`.
+- For recordings on **S3 storage**, the response is a `302` redirect
+  to a 5-minute pre-signed URL. Follow the redirect (`curl -L`); your
+  HTTP client will fetch the audio directly from S3 with no extra
+  egress through OpenPlaud.
+
+`416` with a `Content-Range: bytes */<size>` header is returned only
+for unsatisfiable starts (past EOF or `start > end`). Oversized `end`
+values are clamped to `fileSize - 1` per RFC 7233.
+
+## What about writes?
+
+There are no public write endpoints. The `/api/v1/*` surface is
+read-only by design today. If you need to push data *in*, run the
+OpenPlaud UI or sync the source Plaud account via the configured
+sync loop.
+
+## Stability
+
+The `/api/v1/*` surface is a versioned public contract. Once shipped:
+
+- Existing endpoints don't get breaking changes — fields are added,
+  not repurposed.
+- Error `code` values are stable. New codes get added; old ones don't
+  get renamed.
+- Removals or breaking changes go through a deprecation cycle with a
+  CHANGELOG note.
+
+If you need a new field, capability, or endpoint, file an issue. The
+shape gets discussed there before it ships.

--- a/content/docs/reference/security-model.mdx
+++ b/content/docs/reference/security-model.mdx
@@ -1,0 +1,160 @@
+---
+title: Security model
+description: Authentication, encryption at rest, API tokens, and trust boundaries.
+---
+
+This page sketches the full picture. The deep dive on database
+encryption lives in
+[Encryption at rest](./encryption-at-rest); cross-link there for the
+column-level details.
+
+## Authentication
+
+Two ways to authenticate to OpenPlaud's HTTP surface:
+
+1. **Browser session** (Better Auth). Email + password, with the
+   session cookie signed by `BETTER_AUTH_SECRET`. Used by every page
+   under `(app)`, the dashboard, and the internal `/api/*` routes.
+2. **Personal API key** (`op_<24 chars>`). Used by external
+   integrations against the `/api/v1/*` surface. Sent as a Bearer
+   token. Read-only scope.
+
+Rate limit buckets default to the request's direct client IP. If your
+instance sits behind a reverse proxy that overwrites
+`X-Forwarded-For`, set `RATE_LIMIT_TRUST_PROXY_HEADERS=true` so the
+bucket key uses the original client IP. Don't set it without a proxy
+that actually overwrites the header — clients can forge it and your
+rate limiter is then ornamental.
+
+## Encryption at rest
+
+Sensitive fields are encrypted with AES-256-GCM, keyed off
+`ENCRYPTION_KEY` (a required 64-char hex string).
+
+| Field                                   | Why                                    |
+| --------------------------------------- | -------------------------------------- |
+| `recordings.filename`                   | Often carries AI-generated titles      |
+| `transcriptions.text`                   | Full transcript                        |
+| `ai_enhancements.summary`               | LLM summary                            |
+| `ai_enhancements.key_points`            | Stored under `{ "c": "v1:..." }`       |
+| `ai_enhancements.action_items`          | Same envelope                          |
+| `user_settings.summary_prompt`          | May carry user context                 |
+| `user_settings.title_generation_prompt` | Same                                   |
+| `plaud_connections.bearer_token`        | Plaud OAuth-equivalent token           |
+| `api_credentials.api_key`               | Configured AI provider key             |
+| `storage_config.s3_config`              | S3 access + secret                     |
+| `webhook_endpoints.url`                 | User-configured webhook target         |
+| `webhook_endpoints.secret`              | The `whsec_…` signing secret           |
+
+**Out of scope** for the app-layer encryption:
+
+- Audio files on disk or in S3. Use bucket-level SSE on S3, or full-
+  disk encryption on the host, if you need that.
+- Postgres on disk. Use disk encryption or a managed DB that does it
+  for you.
+- The decryption-at-request-time path — the server holds the key and
+  decrypts content when it needs to run AI on it. This is unavoidable
+  while server-side transcription and summarization are part of the
+  product. If you require true zero-knowledge, see below.
+
+See [Encryption at rest](./encryption-at-rest) for ciphertext format,
+versioning prefix (`v1:`), and the backfill script.
+
+## API token hashing
+
+Personal API keys are HMAC-SHA256-hashed before being stored. The
+HMAC key is `API_TOKEN_HASH_SECRET` if set, otherwise
+`BETTER_AUTH_SECRET`. A database breach does not leak usable tokens
+(an attacker would still need the HMAC key, which lives only in the
+runtime environment).
+
+Two important consequences:
+
+- We never use plain SHA-256 for tokens. The high-entropy random key
+  doesn't fix that on its own — without an HMAC, a precomputed
+  table over the `op_` keyspace would be feasible at scale.
+- We never reuse `ENCRYPTION_KEY` as the HMAC key. That key is
+  reserved for AES-GCM at-rest encryption. Mixing key uses is a
+  cryptographic smell with no upside.
+
+## Webhook signatures
+
+Outbound webhook deliveries are signed:
+
+- Header: `X-OpenPlaud-Signature: t=<unix>,v1=<hex hmac>`
+- Algorithm: HMAC-SHA256 of `${timestamp}.${rawBody}` with the
+  endpoint's per-secret.
+- Replay window: ±5 minutes.
+
+Receivers must verify in constant time (timing-safe compare) — see
+[Automation API and webhooks](../guides/automation-and-webhooks) for
+a reference Node implementation.
+
+## Webhook target hardening
+
+By default, webhook URLs may use `http://` or `https://` and may point
+at anything the OpenPlaud container can reach (Docker-bridge service
+names, RFC1918 IPs, public hosts). Credentials embedded in the URL are
+rejected.
+
+If your instance is exposed to other people — multi-user self-host
+deployment, anyone you don't fully trust signing up — set
+`WEBHOOKS_REQUIRE_PUBLIC_TARGETS=true`. With that flag, webhook URLs
+must use HTTPS, resolve to a public IP, and not embed credentials.
+Loopback, RFC1918, link-local, ULA, multicast, and IPv6 documentation
+prefixes are all rejected. This stops your instance from being used as
+an SSRF relay against its own private network.
+
+## Per-user query isolation
+
+Every database query that touches user-scoped data carries
+`where(eq(table.userId, session.user.id))`. The codebase treats this
+as a hard requirement on **every** query, every time — not "I'll add
+it later," not "it's an internal endpoint." Code review enforces it
+on every PR.
+
+`/api/v1/*` routes get the user id from the personal API key after
+authentication; internal routes get it from the session. Either way,
+the same userId-scoped queries run.
+
+## Account suspension
+
+Suspended users (`users.suspendedAt` is non-null) are rejected
+**before** any feature code runs:
+
+- Session-authenticated requests get `403 ACCOUNT_SUSPENDED` from the
+  session check.
+- API-key-authenticated requests get the same code from the
+  `authenticateRequest` path.
+
+The check sits next to the auth lookup, not behind a per-route
+middleware, so it can't be forgotten on a new route.
+
+## Trust boundaries OpenPlaud does *not* own
+
+Some risks live outside the app entirely and we name them rather than
+pretending we cover them:
+
+- **Your AI provider.** Plaintext audio and plaintext transcripts go
+  to whichever provider you configured. The privacy of that data
+  depends on the provider's policy and infrastructure. If you don't
+  trust them, run a local provider (Ollama / LM Studio) on the same
+  machine as your OpenPlaud instance.
+- **A compromised application server.** The server holds
+  `ENCRYPTION_KEY` and decrypts data on demand. At-rest encryption
+  protects DB breaches, not RCE.
+- **A compromised `ENCRYPTION_KEY`.** Treat the key like a database
+  master credential. Lose it and encrypted content becomes
+  unrecoverable.
+
+## Compliance claims
+
+OpenPlaud does not claim HIPAA, SOC2, or attorney-client privilege.
+Those claims belong to your AI provider (which may itself be
+HIPAA-eligible) and your own self-host setup, which you fully
+control.
+
+## Reporting a vulnerability
+
+See [SECURITY.md](https://github.com/openplaud/openplaud/blob/main/SECURITY.md)
+in the repository for disclosure instructions.

--- a/content/docs/self-hosting/email-smtp.mdx
+++ b/content/docs/self-hosting/email-smtp.mdx
@@ -1,0 +1,46 @@
+---
+title: Email (SMTP) setup
+description: Configure an SMTP server so OpenPlaud can deliver email notifications.
+---
+
+Email notifications go out through any SMTP server you configure —
+Postmark, Resend, SES, Mailgun, your own postfix, anything that speaks
+SMTP. This is an operator concern: hosted instances configure SMTP
+once for everyone. The per-user side (enabling email, sending a test
+email) lives in [Notifications](../guides/notifications).
+
+## Configuration
+
+Set these in the environment that runs OpenPlaud:
+
+```bash
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587                  # 465 if SMTP_SECURE=true, else 587
+SMTP_SECURE=false              # true => implicit TLS on 465
+SMTP_USER=apikey-or-username
+SMTP_PASSWORD=secret
+SMTP_FROM="OpenPlaud <noreply@example.com>"
+```
+
+`SMTP_FROM` accepts either a bare email (`noreply@example.com`) or a
+display-name form (`Name <user@example.com>`). The env loader rejects
+anything else.
+
+See [Environment variables](./environment-variables) for the full
+list of SMTP knobs and their defaults.
+
+## When SMTP is unset
+
+When `SMTP_HOST` is unset, the email backend disables itself — calls
+into `sendEmail()` short-circuit and log a "SMTP not configured"
+warning. No silent failures, no swallowed exceptions, no half-working
+state. Users who enable email in Settings will see no errors in the
+UI, but no mail will be sent.
+
+## Verifying the configuration
+
+Once SMTP is set, any user can verify it without waiting for a real
+event: **Settings → Notifications → Email → Send test email**. That
+button calls the `/api/settings/test-email` route, which exercises
+the full nodemailer + template-render path against your configured
+SMTP server.

--- a/content/docs/self-hosting/environment-variables.mdx
+++ b/content/docs/self-hosting/environment-variables.mdx
@@ -1,0 +1,80 @@
+---
+title: Environment variables
+description: Every env var that OpenPlaud reads, what it does, and what it defaults to.
+---
+
+OpenPlaud validates every environment variable through a Zod schema in
+`src/lib/env.ts` at process start. A misconfigured env crashes the
+server with a precise error message rather than booting into a broken
+state — that's intentional. Read this page as the source of truth for
+the self-host install.
+
+## Required at runtime
+
+These must be set whenever the server actually runs (dev or prod).
+They're optional at the **build** layer so `next build` doesn't depend
+on production secrets.
+
+| Variable                    | Type     | Notes                                                                  |
+| --------------------------- | -------- | ---------------------------------------------------------------------- |
+| `DATABASE_URL`              | string   | Postgres connection string                                             |
+| `BETTER_AUTH_SECRET`        | string   | At least 32 chars; signs session cookies                               |
+| `APP_URL`                   | URL      | Public origin (e.g. `https://openplaud.example.com`)                   |
+| `ENCRYPTION_KEY`            | hex(64)  | Exactly 64 hex chars (32 bytes); see [Encryption](../reference/encryption-at-rest)|
+
+## Optional knobs
+
+| Variable                            | Default                            | Effect                                                                                                              |
+| ----------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `DISABLE_REGISTRATION`              | `false`                            | When `true`, sign-up is rejected server-side and the `/register` page is disabled. Existing users keep working.     |
+| `DISABLE_UPDATE_CHECK`              | `false`                            | When `true`, the footer never calls `api.github.com` to check for new release tags.                                 |
+| `OPENPLAUD_VERSION`                 | `latest`                           | Read by Docker Compose, not the app. Sets which image tag Compose pulls.                                            |
+| `WEBHOOKS_REQUIRE_PUBLIC_TARGETS`   | `false`                            | When `true`, webhook URLs must be HTTPS and resolve to public IPs. Useful when your instance is exposed to others.  |
+| `RATE_LIMIT_TRUST_PROXY_HEADERS`    | `false`                            | When `true`, trust `X-Forwarded-For` for rate-limit buckets. Only safe behind a reverse proxy that overwrites the header. |
+| `API_TOKEN_HASH_SECRET`             | falls back to `BETTER_AUTH_SECRET` | At least 32 chars. HMAC key for personal API token hashing. Set independently if you want token-hash rotation without rotating session secrets. |
+
+Setting `RATE_LIMIT_TRUST_PROXY_HEADERS=true` without a proxy that
+overwrites forwarding headers lets clients forge their own IPs and
+defeats rate limiting. If you're not sure your proxy strips/overwrites
+these headers, leave the value unset.
+
+## Storage
+
+| Variable                | Default     | Effect                                                              |
+| ----------------------- | ----------- | ------------------------------------------------------------------- |
+| `DEFAULT_STORAGE_TYPE`  | `local`     | `local` or `s3`. The default new users get; per-user override in UI.|
+| `LOCAL_STORAGE_PATH`    | `./storage` | Filesystem path when `DEFAULT_STORAGE_TYPE=local`.                  |
+| `S3_ENDPOINT`           | —           | Endpoint URL. Blank for AWS S3.                                     |
+| `S3_BUCKET`             | —           | Bucket name.                                                        |
+| `S3_REGION`             | —           | Region (`auto` on R2).                                              |
+| `S3_ACCESS_KEY_ID`      | —           |                                                                     |
+| `S3_SECRET_ACCESS_KEY`  | —           |                                                                     |
+
+See [S3-compatible storage](./storage-s3) for per-provider
+config templates.
+
+## SMTP (email notifications)
+
+| Variable        | Default                | Effect                                                                                |
+| --------------- | ---------------------- | ------------------------------------------------------------------------------------- |
+| `SMTP_HOST`     | —                      | When unset, email backend is disabled cleanly.                                        |
+| `SMTP_PORT`     | 465 if secure, else 587| Integer.                                                                              |
+| `SMTP_SECURE`   | `false`                | `true` => implicit TLS (port 465). `false` => STARTTLS (port 587).                    |
+| `SMTP_USER`     | —                      |                                                                                       |
+| `SMTP_PASSWORD` | —                      |                                                                                       |
+| `SMTP_FROM`     | —                      | Either `user@example.com` or `Name <user@example.com>`. Validated.                    |
+
+## When values are missing
+
+At server boot, the env loader does two passes:
+
+1. **Schema validation** — types, formats, ranges. Failures produce a
+   multi-line `Environment validation failed:` error listing the
+   problem fields.
+2. **Runtime presence checks** — required-at-runtime vars
+   (`DATABASE_URL`, `BETTER_AUTH_SECRET`, `APP_URL`, `ENCRYPTION_KEY`)
+   are confirmed non-empty and strong enough. These checks are skipped
+   during `next build` (phase `phase-production-build`) so the
+   front-end build doesn't depend on server-only secrets.
+
+If a value is wrong, the server refuses to start. That's the contract.

--- a/content/docs/self-hosting/index.mdx
+++ b/content/docs/self-hosting/index.mdx
@@ -1,0 +1,28 @@
+---
+title: Self Hosting
+description: Run OpenPlaud on your own infrastructure with Docker Compose.
+---
+
+OpenPlaud is AGPL-3.0 software you can run yourself. The same codebase
+powers the hosted instance at openplaud.com and self-host deployments
+behind `docker compose up`. This section is the operator surface —
+everything you don't need if you're using the hosted instance.
+
+## Where to start
+
+- **[Install](./install)** — one-line Docker Compose installer.
+- **[Environment variables](./environment-variables)** — every knob
+  OpenPlaud reads at boot, with required-at-runtime values called out.
+- **[S3-compatible storage](./storage-s3)** — point audio at AWS S3,
+  Cloudflare R2, MinIO, Backblaze B2, or anything S3-shaped.
+- **[Email (SMTP) setup](./email-smtp)** — wire up an SMTP server so
+  the email notification backend can deliver mail.
+- **[Upgrading](./upgrading)** — image tags, the upgrade command, and
+  what to back up before a major version bump.
+
+## Not here
+
+Per-user product behavior — connecting a Plaud account, choosing AI
+providers, enabling notifications, using the public API, exporting
+your data — lives under [Guides](../guides) and applies to both
+hosted and self-host users.

--- a/content/docs/self-hosting/install.mdx
+++ b/content/docs/self-hosting/install.mdx
@@ -1,0 +1,38 @@
+---
+title: Install
+description: Install OpenPlaud on your own infrastructure with Docker Compose.
+---
+
+## Prerequisites
+
+- Docker and Docker Compose
+- A Plaud account with at least one device
+- An OpenAI-compatible API key (OpenAI, Groq, OpenRouter, Ollama, LM Studio,
+  or any other compatible endpoint). Optional — browser-based transcription
+  via Transformers.js works without an API key.
+
+## Install
+
+The one-line installer pulls the published `docker-compose.yml`, prompts for
+the values it needs, and starts the stack:
+
+```bash
+curl -fsSL https://openplaud.com/install.sh | bash
+```
+
+Pin to a specific release:
+
+```bash
+curl -fsSL https://openplaud.com/v0.4.2/install.sh | bash
+```
+
+Once the containers are healthy, open `http://localhost:3000` and create an
+account. You'll be walked through connecting your Plaud account and picking
+a transcription provider.
+
+## Next
+
+- See **[Encryption at rest](/docs/reference/encryption-at-rest)** for how
+  sensitive fields are stored.
+- The README in the repository has a fuller feature tour and configuration
+  reference while these docs are being built out.

--- a/content/docs/self-hosting/meta.json
+++ b/content/docs/self-hosting/meta.json
@@ -1,0 +1,11 @@
+{
+    "title": "Self Hosting",
+    "pages": [
+        "index",
+        "install",
+        "environment-variables",
+        "storage-s3",
+        "email-smtp",
+        "upgrading"
+    ]
+}

--- a/content/docs/self-hosting/storage-s3.mdx
+++ b/content/docs/self-hosting/storage-s3.mdx
@@ -1,0 +1,124 @@
+---
+title: S3-compatible storage
+description: Configure AWS S3, Cloudflare R2, MinIO, Backblaze B2, or any S3-compatible service.
+---
+
+By default, OpenPlaud stores audio on the local filesystem (Docker
+volume mounted at `/app/audio`). That's the right default — zero setup,
+works offline, lives entirely under your control. Switch to S3 when you
+want offsite durability, lower per-byte cost, or to share storage
+between multiple instances.
+
+OpenPlaud talks to any service that implements the S3 wire protocol —
+AWS S3, Cloudflare R2, MinIO, Backblaze B2, DigitalOcean Spaces, Wasabi,
+and so on.
+
+## Configuring S3
+
+You can configure storage in two ways:
+
+1. **Per-user, via the Settings UI** — `Settings → Storage`. Each user
+   on a self-host instance can point at a different bucket. Credentials
+   are encrypted at rest.
+2. **Instance-wide, via environment variables** — set the
+   `DEFAULT_STORAGE_TYPE=s3` plus the `S3_*` vars listed below. Useful
+   when you want every new account to default to a shared bucket.
+
+The env-var config is the **default** that new users get. The UI config
+overrides it per user. See
+[Environment variables](./environment-variables) for the full
+list.
+
+## Provider settings
+
+### AWS S3
+
+```bash
+S3_ENDPOINT=        # leave blank
+S3_BUCKET=your-bucket-name
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=YOUR_KEY
+S3_SECRET_ACCESS_KEY=YOUR_SECRET
+```
+
+### Cloudflare R2
+
+```bash
+S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+S3_BUCKET=openplaud
+S3_REGION=auto
+S3_ACCESS_KEY_ID=YOUR_KEY
+S3_SECRET_ACCESS_KEY=YOUR_SECRET
+```
+
+R2 has 10 GB free storage and no egress fees, which makes it a good
+default for personal self-host instances.
+
+### MinIO (self-hosted)
+
+```bash
+S3_ENDPOINT=http://minio:9000
+S3_BUCKET=openplaud
+S3_REGION=us-east-1
+S3_ACCESS_KEY_ID=minioadmin
+S3_SECRET_ACCESS_KEY=minioadmin
+```
+
+If MinIO runs in the same Docker network as OpenPlaud, the endpoint is
+the service hostname (`http://minio:9000`), not `localhost`.
+
+### Backblaze B2
+
+```bash
+S3_ENDPOINT=https://s3.<region>.backblazeb2.com
+S3_BUCKET=your-bucket-name
+S3_REGION=<region>
+S3_ACCESS_KEY_ID=YOUR_KEY
+S3_SECRET_ACCESS_KEY=YOUR_SECRET
+```
+
+B2 is the cheapest option for long-term cold storage.
+
+### DigitalOcean Spaces
+
+```bash
+S3_ENDPOINT=https://<region>.digitaloceanspaces.com
+S3_BUCKET=your-space-name
+S3_REGION=<region>
+S3_ACCESS_KEY_ID=YOUR_KEY
+S3_SECRET_ACCESS_KEY=YOUR_SECRET
+```
+
+## Test the connection
+
+The Settings UI exposes a **Test connection** button that calls
+`testConnection()` on the storage provider — a cheap round-trip that
+will surface bucket-permission and credentials issues before you flip
+the active backend.
+
+## Encryption at the storage layer
+
+OpenPlaud's at-rest encryption applies to **database** fields, not audio
+objects in storage. For S3, prefer **bucket-level server-side
+encryption** (SSE-S3, SSE-KMS, or the equivalent on your provider). Per-
+object app-layer encryption is a heavier change and not implemented
+today.
+
+See [Encryption at rest](../reference/encryption-at-rest) for the
+explicit scope of the database-layer encryption.
+
+## Migrating between backends
+
+OpenPlaud does not ship a built-in "move all audio from local to S3"
+tool. The supported flow today:
+
+1. Stop sync (so no new files are written).
+2. Mirror the local audio directory to your bucket using `aws s3 sync`,
+   `rclone`, or the equivalent.
+3. Switch the storage config in Settings.
+4. Re-enable sync.
+
+Recording rows store the storage key directly; the layout is the same
+across backends (`{userId}/{filename}.mp3`, with `(2)`, `(3)`,&nbsp;…
+suffixes on collisions), so a straight mirror of the local audio
+directory into the bucket is enough.

--- a/content/docs/self-hosting/upgrading.mdx
+++ b/content/docs/self-hosting/upgrading.mdx
@@ -77,8 +77,9 @@ Two things to back up before a major-version upgrade:
 2. The audio volume (`/app/audio` in the app container) — or your S3
    bucket if you've migrated to remote storage.
 
-You can also create a logical export via **Settings → Backup → Create
-backup**, which produces a JSON archive of recordings + transcripts.
+You can also create a logical export via **Settings → Export/Backup
+→ Create Backup**, which produces a JSON archive of recordings +
+transcripts.
 That export is **plaintext** by design (it's your data), so store it
 with the same care you'd give your unencrypted database. See
 [Backup and restore](../guides/backup-and-restore).

--- a/content/docs/self-hosting/upgrading.mdx
+++ b/content/docs/self-hosting/upgrading.mdx
@@ -1,0 +1,84 @@
+---
+title: Upgrading
+description: Pull a new image, restart the stack, and pick the right tag for your risk tolerance.
+---
+
+OpenPlaud ships as a single Docker image on GitHub Container Registry.
+Upgrades are an image pull and a restart; migrations run automatically
+on container start.
+
+## Standard upgrade
+
+From the directory that holds your `docker-compose.yml` and `.env`:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+The application container starts, runs any pending database migrations
+in the same process before opening the HTTP listener, and reports
+healthy via `/api/health` once ready. There is no separate "migration
+container" — failure to migrate is failure to start, which is the
+behaviour you want.
+
+## Picking a tag
+
+`OPENPLAUD_VERSION` in your `.env` controls which image tag Compose
+pulls.
+
+| Tag             | What you get                              | Use when                                |
+| --------------- | ----------------------------------------- | --------------------------------------- |
+| `latest`        | Newest stable release                     | Default; most users                     |
+| `0.4.2`, `0.4`  | Specific version / minor line             | Production; pin for reproducibility     |
+| `dev`           | Rolling build from `main`                 | Bleeding edge; accept occasional breakage |
+
+`main` is a **rolling integration branch** and may be broken at any
+commit. Stable deploys come from tagged releases. Do **not** deploy by
+cloning the repo and building from `main`; use the tagged images
+above. See [BRANCHING.md](https://github.com/openplaud/openplaud/blob/main/BRANCHING.md)
+for the branching model.
+
+## Update badge
+
+The footer shows a small "Update available" badge when a newer release
+tag is available on GitHub. The badge is purely informational — it
+does not auto-update anything.
+
+The check calls `api.github.com` once per session. If your instance
+shouldn't phone home at all, set `DISABLE_UPDATE_CHECK=true` in your
+`.env` and the badge disappears unconditionally.
+
+## Rolling back
+
+To roll back, set `OPENPLAUD_VERSION` to the previous tag and re-run
+the upgrade command:
+
+```bash
+# In .env
+OPENPLAUD_VERSION=0.4.1
+```
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+This works because OpenPlaud's database migrations are
+**additive by default** — dropping columns is treated as a deliberate
+breaking change with a CHANGELOG migration note. If you're rolling
+back across a release that explicitly dropped state (rare; called out
+loudly in CHANGELOG), check the release notes first.
+
+## Backing up before an upgrade
+
+Two things to back up before a major-version upgrade:
+
+1. The Postgres volume (whichever path your compose file binds to
+   `postgres:/var/lib/postgresql/data`).
+2. The audio volume (`/app/audio` in the app container) — or your S3
+   bucket if you've migrated to remote storage.
+
+You can also create a logical export via **Settings → Backup → Create
+backup**, which produces a JSON archive of recordings + transcripts.
+That export is **plaintext** by design (it's your data), so store it
+with the same care you'd give your unencrypted database. See
+[Backup and restore](../guides/backup-and-restore).

--- a/next.config.ts
+++ b/next.config.ts
@@ -57,7 +57,8 @@ const nextConfig: NextConfig = {
 };
 
 // Fumadocs MDX integration. `createMDX()` reads `source.config.ts`, emits
-// compiled content into `.source/`, and registers the `.mdx` webpack loader.
+// compiled content into `src/.source/` (see `outDir` below), and registers
+// the `.mdx` webpack loader.
 // The wrapper is a no-op for non-MDX routes — self-host and hosted builds are
 // identical with or without docs content present.
 // `outDir` is set under `src/` so the existing `@/*` -> `./src/*` tsconfig

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
 
 // Note: we read `process.env` directly here instead of importing the
@@ -55,4 +56,13 @@ const nextConfig: NextConfig = {
     },
 };
 
-export default nextConfig;
+// Fumadocs MDX integration. `createMDX()` reads `source.config.ts`, emits
+// compiled content into `.source/`, and registers the `.mdx` webpack loader.
+// The wrapper is a no-op for non-MDX routes — self-host and hosted builds are
+// identical with or without docs content present.
+// `outDir` is set under `src/` so the existing `@/*` -> `./src/*` tsconfig
+// path alias resolves `@/.source` without adding a second alias. Keep this
+// in lockstep with the `.gitignore` entry and the import in `src/lib/source.ts`.
+const withMDX = createMDX({ outDir: "src/.source" });
+
+export default withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "scripts": {
         "dev": "next dev",
         "build": "next build",
+        "postinstall": "fumadocs-mdx source.config.ts src/.source",
         "start": "next start",
         "test": "vitest run",
         "test:watch": "vitest",
@@ -59,6 +60,9 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "drizzle-orm": "^0.44.7",
+        "fumadocs-core": "^16.8.10",
+        "fumadocs-mdx": "^15.0.4",
+        "fumadocs-ui": "^16.8.10",
         "lucide-react": "^0.554.0",
         "music-metadata": "^11.12.3",
         "nanoid": "^5.1.6",
@@ -80,6 +84,7 @@
     "devDependencies": {
         "@biomejs/biome": "^2.3.7",
         "@tailwindcss/postcss": "^4",
+        "@types/mdx": "^2.0.13",
         "@types/node": "^20",
         "@types/nodemailer": "^7.0.4",
         "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,15 @@ importers:
       drizzle-orm:
         specifier: ^0.44.7
         version: 0.44.7(@neondatabase/serverless@1.0.2)(@types/pg@8.15.6)(kysely@0.28.8)(pg@8.16.3)(postgres@3.4.7)
+      fumadocs-core:
+        specifier: ^16.8.10
+        version: 16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12)
+      fumadocs-mdx:
+        specifier: ^15.0.4
+        version: 15.0.4(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.6)(fumadocs-core@16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2))
+      fumadocs-ui:
+        specifier: ^16.8.10
+        version: 16.8.10(@tailwindcss/oxide@4.1.17)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(fumadocs-core@16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.17)
       lucide-react:
         specifier: ^0.554.0
         version: 0.554.0(react@19.2.0)
@@ -115,7 +124,7 @@ importers:
         version: 3.4.0
       vitest:
         specifier: ^4.0.12
-        version: 4.0.12(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 4.0.12(@types/debug@4.1.13)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -126,6 +135,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
+      '@types/mdx':
+        specifier: ^2.0.13
+        version: 2.0.13
       '@types/node':
         specifier: ^20
         version: 20.19.25
@@ -460,6 +472,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -468,6 +486,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -484,6 +508,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -492,6 +522,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -508,6 +544,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -516,6 +558,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -532,6 +580,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -540,6 +594,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -556,6 +616,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -564,6 +630,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -580,6 +652,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -588,6 +666,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -604,6 +688,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -612,6 +702,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -628,6 +724,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -636,6 +738,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -652,8 +760,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -670,8 +790,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -688,8 +820,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -706,6 +850,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -714,6 +864,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -730,6 +886,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -738,6 +900,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -756,6 +924,17 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fumadocs/tailwind@0.0.5':
+    resolution: {integrity: sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==}
+    peerDependencies:
+      '@tailwindcss/oxide': ^4.0.0
+      tailwindcss: ^4.0.0
+    peerDependenciesMeta:
+      '@tailwindcss/oxide':
+        optional: true
+      tailwindcss:
+        optional: true
 
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
@@ -932,6 +1111,9 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
@@ -994,6 +1176,10 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@orama/orama@3.1.18':
+    resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
+    engines: {node: '>= 20.0.0'}
 
   '@peculiar/asn1-android@2.6.0':
     resolution: {integrity: sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==}
@@ -2079,6 +2265,37 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@simplewebauthn/browser@13.2.2':
     resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
 
@@ -2308,6 +2525,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2412,14 +2632,32 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.25':
     resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
@@ -2440,6 +2678,15 @@ packages:
 
   '@types/react@19.2.6':
     resolution: {integrity: sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@vitest/expect@4.0.12':
     resolution: {integrity: sha512-is+g0w8V3/ZhRNrRizrJNr8PFQKwYmctWlU4qg8zy5r9aIV5w8IxXLlfbbxJCwSpsVl2PXPTm2/zruqTqz3QSg==}
@@ -2477,6 +2724,16 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2504,6 +2761,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -2516,6 +2776,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   atomically@2.1.0:
     resolution: {integrity: sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==}
 
@@ -2526,6 +2790,9 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
@@ -2619,6 +2886,9 @@ packages:
   caniuse-lite@1.0.30001756:
     resolution: {integrity: sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.1:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
@@ -2627,9 +2897,25 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -2661,6 +2947,9 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2675,9 +2964,15 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  compute-scroll-into-view@3.1.1:
+    resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
   conf@15.0.2:
     resolution: {integrity: sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==}
@@ -2738,6 +3033,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -2753,12 +3051,19 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2904,12 +3209,22 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -2925,6 +3240,36 @@ packages:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-value-to-estree@3.5.0:
+    resolution: {integrity: sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2942,6 +3287,9 @@ packages:
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2976,6 +3324,20 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -2983,6 +3345,116 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fumadocs-core@16.8.10:
+    resolution: {integrity: sha512-dXSk2tVMAlQQ5NOCwtu2n+2nw0nB6JCYvTKmCCImHJk8ZVy3Y3Y3qDIU9QUScD5Fsa/t3+k5Wce+mPdwqlcGRw==}
+    peerDependencies:
+      '@mdx-js/mdx': '*'
+      '@mixedbread/sdk': 0.x.x
+      '@orama/core': 1.x.x
+      '@oramacloud/client': 2.x.x
+      '@tanstack/react-router': 1.x.x
+      '@types/estree-jsx': '*'
+      '@types/hast': '*'
+      '@types/mdast': '*'
+      '@types/react': '*'
+      algoliasearch: 5.x.x
+      flexsearch: '*'
+      lucide-react: '*'
+      next: 16.x.x
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      react-router: 7.x.x
+      waku: ^0.26.0 || ^0.27.0 || ^1.0.0
+      zod: 4.x.x
+    peerDependenciesMeta:
+      '@mdx-js/mdx':
+        optional: true
+      '@mixedbread/sdk':
+        optional: true
+      '@orama/core':
+        optional: true
+      '@oramacloud/client':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      '@types/estree-jsx':
+        optional: true
+      '@types/hast':
+        optional: true
+      '@types/mdast':
+        optional: true
+      '@types/react':
+        optional: true
+      algoliasearch:
+        optional: true
+      flexsearch:
+        optional: true
+      lucide-react:
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-router:
+        optional: true
+      waku:
+        optional: true
+      zod:
+        optional: true
+
+  fumadocs-mdx@15.0.4:
+    resolution: {integrity: sha512-swJ7VB9x8fPjVAcH4xMg7qplgm7m6Hy3woB5s/yssBWVPkvET7wGOHoYZ05iW9TDIWruk5vyqwEDrwq3t4PZUw==}
+    hasBin: true
+    peerDependencies:
+      '@types/mdast': '*'
+      '@types/mdx': '*'
+      '@types/react': '*'
+      fumadocs-core: ^16.7.0
+      mdast-util-directive: '*'
+      next: ^15.3.0 || ^16.0.0
+      react: ^19.2.0
+      rolldown: '*'
+      vite: 7.x.x || 8.x.x
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+      '@types/mdx':
+        optional: true
+      '@types/react':
+        optional: true
+      mdast-util-directive:
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      rolldown:
+        optional: true
+      vite:
+        optional: true
+
+  fumadocs-ui@16.8.10:
+    resolution: {integrity: sha512-sw+ZBoNBFRqiKVK7Ig5r0E4TgOhdY/Eq2+rFRTpxN/eq0Bys9OSoIXxLNkUBzaj+YGaXU8jHY4qOsDQgymHVTQ==}
+    peerDependencies:
+      '@takumi-rs/image-response': '*'
+      '@types/mdx': '*'
+      '@types/react': '*'
+      fumadocs-core: 16.8.10
+      next: 16.x.x
+      react: ^19.2.0
+      react-dom: ^19.2.0
+    peerDependenciesMeta:
+      '@takumi-rs/image-response':
+        optional: true
+      '@types/mdx':
+        optional: true
+      '@types/react':
+        optional: true
+      next:
+        optional: true
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
@@ -2998,6 +3470,9 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
@@ -3009,9 +3484,39 @@ packages:
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -3025,15 +3530,34 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-unicode-supported@1.3.0:
@@ -3064,6 +3588,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3173,6 +3701,9 @@ packages:
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.2.2:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
@@ -3182,17 +3713,182 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
     hasBin: true
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3231,6 +3927,26 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3318,6 +4034,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   onnx-proto@4.0.4:
     resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
 
@@ -3349,6 +4071,12 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -3408,6 +4136,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
@@ -3459,6 +4191,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   protobufjs@6.11.4:
     resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
@@ -3527,6 +4262,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -3549,8 +4294,59 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3576,6 +4372,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scroll-into-view-if-needed@3.1.0:
+    resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -3603,6 +4402,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3651,6 +4454,13 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -3683,6 +4493,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3712,6 +4525,12 @@ packages:
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -3731,6 +4550,9 @@ packages:
 
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.1.17:
     resolution: {integrity: sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==}
@@ -3761,8 +4583,16 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.0.3:
@@ -3772,6 +4602,12 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -3812,6 +4648,30 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -3843,6 +4703,15 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@7.2.4:
     resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
@@ -3921,6 +4790,9 @@ packages:
       jsdom:
         optional: true
 
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
@@ -3970,6 +4842,12 @@ packages:
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4646,10 +5524,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -4658,10 +5542,16 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -4670,10 +5560,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -4682,10 +5578,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -4694,10 +5596,16 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -4706,10 +5614,16 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -4718,10 +5632,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -4730,10 +5650,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -4742,7 +5668,13 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -4751,7 +5683,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -4760,7 +5698,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.18.20':
@@ -4769,10 +5713,16 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.18.20':
@@ -4781,10 +5731,16 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@floating-ui/core@1.7.3':
@@ -4803,6 +5759,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.1.17)(tailwindcss@4.1.17)':
+    optionalDependencies:
+      '@tailwindcss/oxide': 4.1.17
+      tailwindcss: 4.1.17
 
   '@hexagon/base64@1.1.28': {}
 
@@ -4941,6 +5902,36 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.13
+      acorn: 8.16.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@neondatabase/serverless@1.0.2':
     dependencies:
       '@types/node': 22.19.1
@@ -4976,6 +5967,8 @@ snapshots:
   '@noble/ciphers@2.0.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@orama/orama@3.1.18': {}
 
   '@peculiar/asn1-android@2.6.0':
     dependencies:
@@ -6079,6 +7072,46 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/types@4.0.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@simplewebauthn/browser@13.2.2': {}
 
   '@simplewebauthn/server@13.2.2':
@@ -6434,6 +7467,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -6525,11 +7560,31 @@ snapshots:
     dependencies:
       '@types/node': 20.19.25
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/long@4.0.2': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.13': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.25':
     dependencies:
@@ -6561,6 +7616,12 @@ snapshots:
   '@types/react@19.2.6':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@vitest/expect@4.0.12':
     dependencies:
@@ -6618,6 +7679,12 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -6639,6 +7706,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  argparse@2.0.1: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -6651,12 +7720,16 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  astring@1.9.0: {}
+
   atomically@2.1.0:
     dependencies:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
   b4a@1.7.3: {}
+
+  bail@2.0.2: {}
 
   bare-events@2.8.2: {}
 
@@ -6745,13 +7818,27 @@ snapshots:
 
   caniuse-lite@1.0.30001756: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.1: {}
 
   chalk@5.6.2: {}
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
 
   chownr@1.1.4: {}
 
@@ -6785,6 +7872,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6801,7 +7890,11 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  comma-separated-tokens@2.0.3: {}
+
   commander@13.1.0: {}
+
+  compute-scroll-into-view@3.1.1: {}
 
   conf@15.0.2:
     dependencies:
@@ -6852,6 +7945,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -6862,9 +7959,15 @@ snapshots:
 
   defu@6.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6942,9 +8045,25 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   env-paths@3.0.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.16.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
@@ -7007,6 +8126,70 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-value-to-estree@3.5.0:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -7023,6 +8206,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -7036,6 +8221,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-type@21.3.4:
     dependencies:
@@ -7053,10 +8242,117 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  framer-motion@12.38.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  fumadocs-core@16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12):
+    dependencies:
+      '@orama/orama': 3.1.18
+      estree-util-value-to-estree: 3.5.0
+      github-slugger: 2.0.0
+      hast-util-to-estree: 3.1.3
+      hast-util-to-jsx-runtime: 2.3.6
+      js-yaml: 4.1.1
+      mdast-util-mdx: 3.0.0
+      mdast-util-to-markdown: 2.1.2
+      remark: 15.0.1
+      remark-gfm: 4.0.1
+      remark-rehype: 11.1.2
+      scroll-into-view-if-needed: 3.1.0
+      shiki: 4.0.2
+      tinyglobby: 0.2.16
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    optionalDependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.6
+      lucide-react: 0.554.0(react@19.2.0)
+      next: 16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      zod: 4.1.12
+    transitivePeerDependencies:
+      - supports-color
+
+  fumadocs-mdx@15.0.4(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.6)(fumadocs-core@16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@standard-schema/spec': 1.1.0
+      chokidar: 5.0.0
+      esbuild: 0.28.0
+      estree-util-value-to-estree: 3.5.0
+      fumadocs-core: 16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12)
+      js-yaml: 4.1.1
+      mdast-util-mdx: 3.0.0
+      picocolors: 1.1.1
+      picomatch: 4.0.4
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.6
+      next: 16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      vite: 7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  fumadocs-ui@16.8.10(@tailwindcss/oxide@4.1.17)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(fumadocs-core@16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.17):
+    dependencies:
+      '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.1.17)(tailwindcss@4.1.17)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.6)(react@19.2.0)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.6)(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      class-variance-authority: 0.7.1
+      fumadocs-core: 16.8.10(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.6)(lucide-react@0.554.0(react@19.2.0))(next@16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod@4.1.12)
+      lucide-react: 1.14.0(react@19.2.0)
+      motion: 12.38.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      next-themes: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.6)(react@19.2.0)
+      rehype-raw: 7.0.0
+      scroll-into-view-if-needed: 3.1.0
+      shiki: 4.0.2
+      tailwind-merge: 3.6.0
+      unist-util-visit: 5.1.0
+    optionalDependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.6
+      next: 16.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@tailwindcss/oxide'
+      - '@types/react-dom'
+      - tailwindcss
 
   get-east-asian-width@1.4.0: {}
 
@@ -7067,6 +8363,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
+
+  github-slugger@2.0.0: {}
 
   glob@11.1.0:
     dependencies:
@@ -7081,6 +8379,114 @@ snapshots:
 
   guid-typescript@1.0.9: {}
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -7088,6 +8494,8 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -7102,11 +8510,26 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.3.4: {}
+
+  is-decimal@2.0.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@2.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-unicode-supported@1.3.0: {}
 
@@ -7125,6 +8548,10 @@ snapshots:
   jose@6.1.2: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 
@@ -7201,9 +8628,15 @@ snapshots:
 
   long@4.0.0: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.2.2: {}
 
   lucide-react@0.554.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+
+  lucide-react@1.14.0(react@19.2.0):
     dependencies:
       react: 19.2.0
 
@@ -7211,9 +8644,440 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-extensions@2.0.0: {}
+
+  markdown-table@3.0.4: {}
+
   marked@15.0.12: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   media-typer@1.1.0: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -7240,6 +9104,20 @@ snapshots:
   minipass@7.1.2: {}
 
   mkdirp-classic@0.5.3: {}
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  motion@12.38.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   ms@2.1.3: {}
 
@@ -7324,6 +9202,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   onnx-proto@4.0.4:
     dependencies:
       protobufjs: 6.11.4
@@ -7361,6 +9247,20 @@ snapshots:
       strip-ansi: 7.1.2
 
   package-json-from-dist@1.0.1: {}
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:
@@ -7424,6 +9324,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
@@ -7483,6 +9385,8 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  property-information@7.1.0: {}
 
   protobufjs@6.11.4:
     dependencies:
@@ -7633,6 +9537,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.6
 
+  react-remove-scroll@2.7.2(@types/react@19.2.6)(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.6)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.2.6)(react@19.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.6)(react@19.2.0)
+      use-sidecar: 1.1.3(@types/react@19.2.6)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.6
+
   react-style-singleton@2.2.3(@types/react@19.2.6)(react@19.2.0):
     dependencies:
       get-nonce: 1.0.1
@@ -7651,7 +9566,112 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readdirp@5.0.0: {}
+
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   reflect-metadata@0.2.2: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   require-from-string@2.0.2: {}
 
@@ -7695,6 +9715,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   scheduler@0.27.0: {}
+
+  scroll-into-view-if-needed@3.1.0:
+    dependencies:
+      compute-scroll-into-view: 3.1.1
 
   selderee@0.11.0:
     dependencies:
@@ -7756,6 +9780,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   siginfo@2.0.0: {}
 
@@ -7819,6 +9854,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0:
     optional: true
 
@@ -7859,6 +9898,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7883,6 +9927,14 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   styled-jsx@5.1.6(react@19.2.0):
     dependencies:
       client-only: 0.0.1
@@ -7891,6 +9943,8 @@ snapshots:
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.4.0: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.1.17: {}
 
@@ -7942,10 +9996,17 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 
@@ -7954,6 +10015,10 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -7987,6 +10052,48 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   use-callback-ref@1.3.3(@types/react@19.2.6)(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -8010,6 +10117,21 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.25.12
@@ -8024,7 +10146,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitest@4.0.12(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2):
+  vitest@4.0.12(@types/debug@4.1.13)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 4.0.12
       '@vitest/mocker': 4.0.12(vite@7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -8047,6 +10169,7 @@ snapshots:
       vite: 7.2.4(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.13
       '@types/node': 20.19.25
     transitivePeerDependencies:
       - jiti
@@ -8061,6 +10184,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-namespaces@2.0.1: {}
 
   when-exit@2.1.5: {}
 
@@ -8097,3 +10222,7 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   zod@4.1.12: {}
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/source.config.ts
+++ b/source.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import lastModified from "fumadocs-mdx/plugins/last-modified";
+
+// Fumadocs source config. Content lives in `content/docs/` and is compiled
+// at build time into `src/.source/` by the `fumadocs-mdx` CLI (wired into
+// `next.config.ts` via `createMDX()` and the `postinstall` script in
+// `package.json`). Raw MDX is NOT read at request time, so the Next.js
+// standalone output doesn't need to trace `content/`.
+export const docs = defineDocs({
+    dir: "content/docs",
+});
+
+export default defineConfig({
+    // `lastModified` reads `git log` for each MDX file and exports a
+    // `lastModified` field on every page. The plugin no-ops cleanly when
+    // git history is missing, which is the case inside our Docker build
+    // (`.git` is in `.dockerignore`) -- self-hosters running the published
+    // image will see no timestamp. Dev and source-checkout builds get the
+    // real value. If we ever want timestamps in the image, drop `.git`
+    // from `.dockerignore`; cost is +a few MB of build context.
+    plugins: [lastModified()],
+    mdxOptions: {
+        // Warm dual-theme shiki palette that lives close to the OpenPlaud
+        // OKLCH tokens defined in `src/app/globals.css`. `vitesse-light`
+        // sits well on the cream background; `vesper` matches the dark
+        // mocha surface without the high-contrast neon of e.g. `dracula`.
+        // The `.dark` class on `<html>` (driven by the app-wide theme
+        // provider) flips between the two automatically.
+        rehypeCodeOptions: {
+            themes: {
+                light: "vitesse-light",
+                dark: "vesper",
+            },
+        },
+    },
+});

--- a/src/app/(docs)/docs.css
+++ b/src/app/(docs)/docs.css
@@ -1,0 +1,76 @@
+/*
+ * Map Fumadocs UI's design tokens onto OpenPlaud's existing palette so the
+ * docs surface inherits the audiophile color scheme defined in
+ * `src/app/globals.css`. Imported AFTER `fumadocs-ui/style.css` in
+ * `src/app/(docs)/layout.tsx` so these overrides win.
+ *
+ * Fumadocs exposes ~20 `--color-fd-*` tokens. We remap only the ones that
+ * meaningfully affect layout chrome (background, surfaces, text, borders,
+ * primary accents). Status colors (success/warning/error/info/idea) and the
+ * code-diff symbols are left at Fumadocs defaults -- they're tuned for
+ * MDX callouts and don't clash with the theme.
+ *
+ * `.dark` rules live next to their light counterparts so the dark-mode
+ * fork is visible at a glance. The Fumadocs root sets `.dark` on `<html>`
+ * via the same `next-themes` provider used app-wide (see
+ * `src/components/theme-provider.tsx`), so a single class flip switches
+ * both surfaces together.
+ */
+
+:root {
+    --color-fd-background: var(--background);
+    --color-fd-foreground: var(--foreground);
+    --color-fd-muted: var(--muted);
+    --color-fd-muted-foreground: var(--muted-foreground);
+    --color-fd-popover: var(--popover);
+    --color-fd-popover-foreground: var(--popover-foreground);
+    --color-fd-card: var(--card);
+    --color-fd-card-foreground: var(--card-foreground);
+    --color-fd-border: var(--border);
+    --color-fd-primary: var(--primary);
+    --color-fd-primary-foreground: var(--primary-foreground);
+    --color-fd-secondary: var(--secondary);
+    --color-fd-secondary-foreground: var(--secondary-foreground);
+    --color-fd-accent: var(--accent);
+    --color-fd-accent-foreground: var(--accent-foreground);
+    --color-fd-ring: var(--ring);
+}
+
+/*
+ * Fumadocs' page footer renders a previous/next nav as a grid that flips
+ * between `grid-cols-2` (both neighbors exist) and `grid-cols-1` (only
+ * one). On the docs index there's no previous sibling, so the lone
+ * "next" card stretches to 100% width. Cap the solo card to the same
+ * width it would have in the two-column layout (`50% - gap/2`, where
+ * `gap-4` resolves to `calc(var(--spacing) * 4)` in Fumadocs' grid) and
+ * align it to the side that matches its arrow direction. Brittle to an
+ * upstream rename of `.text-end` but the rest of `docs.css` already
+ * relies on Fumadocs' class names, so the coupling is consistent.
+ */
+.grid.grid-cols-1.gap-4 > a.text-end {
+    max-width: calc(50% - var(--spacing) * 2);
+    margin-inline-start: auto;
+}
+.grid.grid-cols-1.gap-4 > a:not(.text-end) {
+    max-width: calc(50% - var(--spacing) * 2);
+    margin-inline-end: auto;
+}
+
+.dark {
+    --color-fd-background: var(--background);
+    --color-fd-foreground: var(--foreground);
+    --color-fd-muted: var(--muted);
+    --color-fd-muted-foreground: var(--muted-foreground);
+    --color-fd-popover: var(--popover);
+    --color-fd-popover-foreground: var(--popover-foreground);
+    --color-fd-card: var(--card);
+    --color-fd-card-foreground: var(--card-foreground);
+    --color-fd-border: var(--border);
+    --color-fd-primary: var(--primary);
+    --color-fd-primary-foreground: var(--primary-foreground);
+    --color-fd-secondary: var(--secondary);
+    --color-fd-secondary-foreground: var(--secondary-foreground);
+    --color-fd-accent: var(--accent);
+    --color-fd-accent-foreground: var(--accent-foreground);
+    --color-fd-ring: var(--ring);
+}

--- a/src/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/src/app/(docs)/docs/[[...slug]]/page.tsx
@@ -1,0 +1,102 @@
+import { createRelativeLink } from "fumadocs-ui/mdx";
+import {
+    DocsBody,
+    DocsDescription,
+    DocsPage,
+    DocsTitle,
+} from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { source } from "@/lib/source";
+import { getMDXComponents } from "@/mdx-components";
+
+interface PageProps {
+    params: Promise<{ slug?: string[] }>;
+}
+
+// GitHub repo coordinates for the `editOnGithub` prop. Always tracks
+// `main` because docs reflect tip-of-tree (see plan: no versioning).
+// Self-hosters on a pinned tag are reading their tag's bundled docs; the
+// edit link is still aimed at where contributions go, not at the tag.
+const GITHUB_OWNER = "openplaud";
+const GITHUB_REPO = "openplaud";
+
+export default async function Page({ params }: PageProps) {
+    const { slug } = await params;
+    const page = source.getPage(slug);
+    if (!page) notFound();
+
+    const MDX = page.data.body;
+    const lastModified = page.data.lastModified;
+
+    return (
+        <DocsPage
+            toc={page.data.toc}
+            full={page.data.full}
+            // `editOnGithub` + `lastUpdate` use Fumadocs' dedicated page
+            // slots, which render as a small inline link + timestamp under
+            // the body -- not the full-width block the `footer.children`
+            // slot would produce. `lastUpdate` is undefined inside the
+            // Docker image because `.git` is dockerignored; Fumadocs
+            // simply doesn't render the timestamp in that case.
+            editOnGithub={{
+                owner: GITHUB_OWNER,
+                repo: GITHUB_REPO,
+                sha: "main",
+                path: `content/docs/${page.path}`,
+            }}
+            lastUpdate={lastModified}
+        >
+            <DocsTitle>{page.data.title}</DocsTitle>
+            <DocsDescription>{page.data.description}</DocsDescription>
+            <DocsBody>
+                <MDX
+                    components={getMDXComponents({
+                        // Rewrites relative MDX links (e.g. `./encryption`)
+                        // into route-correct URLs so authors don't have to
+                        // hardcode `/docs/...` paths. Resilient to IA moves.
+                        a: createRelativeLink(source, page),
+                    })}
+                />
+            </DocsBody>
+        </DocsPage>
+    );
+}
+
+// Pre-render every doc at build time. Fumadocs pages are static -- there's
+// no per-user data, no auth, no cookies -- so SSG is the right default.
+export function generateStaticParams() {
+    return source.generateParams();
+}
+
+export async function generateMetadata({
+    params,
+}: PageProps): Promise<Metadata> {
+    const { slug } = await params;
+    const page = source.getPage(slug);
+    if (!page) notFound();
+
+    // Per-page OG image rendered by `src/app/docs-og/[...slug]/route.tsx`.
+    // The slug is appended as `.png` so the same `[...slug]` shape works
+    // for both the page and its OG endpoint. See that file for the actual
+    // ImageResponse.
+    const ogSegments = (page.slugs.length ? page.slugs : ["index"]).join("/");
+    const ogImage = `/docs-og/${ogSegments}.png`;
+
+    return {
+        title: page.data.title,
+        description: page.data.description,
+        openGraph: {
+            title: page.data.title,
+            description: page.data.description,
+            type: "article",
+            images: [ogImage],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: page.data.title,
+            description: page.data.description,
+            images: [ogImage],
+        },
+    };
+}

--- a/src/app/(docs)/layout.tsx
+++ b/src/app/(docs)/layout.tsx
@@ -1,0 +1,29 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { RootProvider } from "fumadocs-ui/provider/next";
+import type { ReactNode } from "react";
+import { baseOptions, docsTabs } from "@/app/layout.config";
+import { source } from "@/lib/source";
+import "fumadocs-ui/style.css";
+import "./docs.css";
+
+// Docs route group. Renders unconditionally in both self-host and hosted
+// modes \u2014 self-hosters need offline access to operator docs, hosted users
+// need them too. No `IS_HOSTED` gate here on purpose.
+//
+// `RootProvider` is Fumadocs-specific and lives inside this segment instead
+// of the app-wide root layout so the rest of the app (dashboard, recordings,
+// settings) doesn't pay for its context providers.
+export default function DocsRootLayout({ children }: { children: ReactNode }) {
+    // `theme={{ enabled: false }}` disables Fumadocs' bundled `next-themes`
+    // provider so we don't double-mount one (the app root already wraps the
+    // tree in `<ThemeProvider>` via `src/components/theme-provider.tsx`).
+    // The app-wide toggle continues to flip `.dark` on `<html>`, and the
+    // docs.css remap reacts to it the same as every other surface.
+    return (
+        <RootProvider theme={{ enabled: false }}>
+            <DocsLayout tree={source.pageTree} tabs={docsTabs} {...baseOptions}>
+                {children}
+            </DocsLayout>
+        </RootProvider>
+    );
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,9 @@
+import { createFromSource } from "fumadocs-core/search/server";
+import { source } from "@/lib/source";
+
+// Static FlexSearch index built from the docs source. The index is generated
+// at build time and served as a static JSON payload \u2014 no per-request work,
+// no DB hit, safe to cache aggressively. Lives under `/api/search` because
+// Fumadocs' default client search hook (`useDocsSearch`) defaults to that
+// path; override there if the path ever needs to move.
+export const { GET } = createFromSource(source);

--- a/src/app/docs-og/[...slug]/route.tsx
+++ b/src/app/docs-og/[...slug]/route.tsx
@@ -1,0 +1,63 @@
+import { generateOGImage } from "fumadocs-ui/og";
+import { notFound } from "next/navigation";
+import { source } from "@/lib/source";
+
+interface RouteContext {
+    params: Promise<{ slug: string[] }>;
+}
+
+// Per-doc OG image, generated on-demand via `next/og` (`@vercel/og` under
+// the hood). The URL shape is `/docs-og/<slug-path>.png` -- see
+// `generateMetadata` in `src/app/(docs)/docs/[[...slug]]/page.tsx` for the
+// reverse mapping.
+//
+// We strip the trailing `.png` from the last slug segment, then look the
+// page up through the same fumadocs `source` the docs pages use. This
+// keeps slugs and OG URLs in lockstep automatically.
+//
+// `generateOGImage` returns an `ImageResponse`, which Next.js handles by
+// streaming the rendered PNG. Image caching is left to the platform's
+// default headers -- the route output is deterministic per build.
+export async function GET(_req: Request, { params }: RouteContext) {
+    const { slug } = await params;
+    if (slug.length === 0) notFound();
+
+    const last = slug[slug.length - 1];
+    if (!last.endsWith(".png")) notFound();
+
+    const pageSlug = [...slug.slice(0, -1), last.replace(/\.png$/, "")];
+    // The docs landing (`/docs`) is keyed as an empty slug array in the
+    // fumadocs source; we shape `/docs-og/index.png` for that case in
+    // `generateMetadata`, so reverse it here.
+    const lookupSlug =
+        pageSlug.length === 1 && pageSlug[0] === "index" ? [] : pageSlug;
+
+    const page = source.getPage(lookupSlug);
+    if (!page) notFound();
+
+    return generateOGImage({
+        title: page.data.title,
+        description: page.data.description,
+        site: "OpenPlaud",
+        // Match the OpenPlaud primary token (warm terracotta). Hardcoded as
+        // a literal because the OG runtime is the edge ImageResponse
+        // environment -- it can't read CSS custom properties from
+        // `globals.css`. Keep this in sync if the brand color shifts.
+        primaryColor: "oklch(0.6171 0.1375 39.0427)",
+        primaryTextColor: "oklch(1 0 0)",
+    });
+}
+
+export function generateStaticParams() {
+    return source.getPages().map((page) => ({
+        // Mirror the slug shape produced in `generateMetadata`: empty
+        // slug -> `index.png`, otherwise `<...slug>.png` on the last segment.
+        slug:
+            page.slugs.length === 0
+                ? ["index.png"]
+                : [
+                      ...page.slugs.slice(0, -1),
+                      `${page.slugs[page.slugs.length - 1]}.png`,
+                  ],
+    }));
+}

--- a/src/app/docs-og/[...slug]/route.tsx
+++ b/src/app/docs-og/[...slug]/route.tsx
@@ -42,9 +42,13 @@ export async function GET(_req: Request, { params }: RouteContext) {
         // Match the OpenPlaud primary token (warm terracotta). Hardcoded as
         // a literal because the OG runtime is the edge ImageResponse
         // environment -- it can't read CSS custom properties from
-        // `globals.css`. Keep this in sync if the brand color shifts.
-        primaryColor: "oklch(0.6171 0.1375 39.0427)",
-        primaryTextColor: "oklch(1 0 0)",
+        // `globals.css`. Satori (the renderer behind `next/og`) does NOT
+        // support the `oklch()` color function; passing one fails the
+        // prerender with "Unexpected token type: function". The hex below
+        // is the sRGB conversion of `oklch(0.6171 0.1375 39.0427)` from
+        // `globals.css` -- keep both in sync if the brand color shifts.
+        primaryColor: "#c96442",
+        primaryTextColor: "#ffffff",
     });
 }
 

--- a/src/app/layout.config.tsx
+++ b/src/app/layout.config.tsx
@@ -1,0 +1,26 @@
+import type { DocsLayoutProps } from "fumadocs-ui/layouts/docs";
+import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
+
+// Shared Fumadocs layout config (nav title, repo link). Currently only
+// consumed by the docs layout under `src/app/(docs)/layout.tsx`; extracted
+// so a future Fumadocs "home" layout (landing-shaped docs index) can reuse
+// it without duplication.
+export const baseOptions: BaseLayoutProps = {
+    nav: {
+        title: "OpenPlaud Docs",
+        // Clicking the nav title returns to the docs landing instead of
+        // bouncing the reader to the marketing root.
+        url: "/docs",
+    },
+    githubUrl: "https://github.com/openplaud/openplaud",
+};
+
+// Sidebar tabs that split the docs into two top-level sections.
+// `url` matches the `baseUrl` + folder name in `content/docs/`. Adding a
+// new top-level section is two edits: a new folder under `content/docs/`
+// and a new entry here.
+export const docsTabs: NonNullable<DocsLayoutProps["tabs"]> = [
+    { title: "Guides", url: "/docs/guides" },
+    { title: "Self Hosting", url: "/docs/self-hosting" },
+    { title: "Reference", url: "/docs/reference" },
+];

--- a/src/app/layout.config.tsx
+++ b/src/app/layout.config.tsx
@@ -15,7 +15,7 @@ export const baseOptions: BaseLayoutProps = {
     githubUrl: "https://github.com/openplaud/openplaud",
 };
 
-// Sidebar tabs that split the docs into two top-level sections.
+// Sidebar tabs that split the docs into three top-level sections.
 // `url` matches the `baseUrl` + folder name in `content/docs/`. Adding a
 // new top-level section is two edits: a new folder under `content/docs/`
 // and a new entry here.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { RybbitAnalytics } from "@/components/rybbit-analytics";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { env } from "@/lib/env";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -18,6 +19,14 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+    // Resolves relative URLs in `openGraph.images` / `twitter.images`
+    // (e.g. `/docs-og/<slug>.png` emitted by per-doc `generateMetadata`)
+    // against the deployment origin. Without this, Next falls back to
+    // `http://localhost:3000` in production and ships broken social
+    // previews. `APP_URL` is allowed to be unset during `next build`
+    // (see `src/lib/env.ts`); the fallback keeps the build green and
+    // self-host deployments override it at runtime via env.
+    metadataBase: new URL(env.APP_URL ?? "https://openplaud.com"),
     title: "OpenPlaud - Professional Audio Workstation",
     description:
         "Professional audio workstation for Plaud devices with AI-powered transcription",

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,42 @@
+import { source } from "@/lib/source";
+
+// Flattened full-content variant of `/llms.txt`. Concatenates every doc's
+// raw markdown body so readers (humans or LLMs) can ingest the whole
+// surface in a single fetch. Fumadocs exposes the processed markdown on
+// `page.data._markdown` when `includeProcessedMarkdown` is enabled in the
+// MDX postprocess pipeline -- we let it stay disabled and fall back to the
+// page title + description + URL when no body markdown is available, since
+// the corpus is small and pure-prose ingestion is the goal.
+//
+// Kept as a separate route from `/llms.txt` because that file follows the
+// llmstxt.org spec (index only); concatenated full text is a de-facto
+// extension, not the spec.
+export function GET() {
+    const lines: string[] = ["# OpenPlaud docs", ""];
+
+    for (const page of source.getPages()) {
+        lines.push(`## ${page.data.title}`);
+        lines.push(`URL: ${page.url}`);
+        if (page.data.description) {
+            lines.push("");
+            lines.push(page.data.description);
+        }
+        // `_markdown` only present when the MDX pipeline is configured to
+        // export it; treat as best-effort.
+        const md = (page.data as { _markdown?: string })._markdown;
+        if (md) {
+            lines.push("");
+            lines.push(md);
+        }
+        lines.push("");
+        lines.push("---");
+        lines.push("");
+    }
+
+    return new Response(lines.join("\n"), {
+        headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "Cache-Control": "public, max-age=3600, s-maxage=86400",
+        },
+    });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,20 @@
+import { llms } from "fumadocs-core/source/llms";
+import { source } from "@/lib/source";
+
+// Standard `llms.txt` (https://llmstxt.org/) -- a small markdown index of
+// the docs surface, hand-shippable into Claude/ChatGPT/etc. Our audience
+// overlaps heavily with people pasting docs into LLMs, so this is high
+// signal for low cost. For the flattened full-content variant see
+// `src/app/llms-full.txt/route.ts`.
+const index = llms(source);
+
+export function GET() {
+    return new Response(index.index(), {
+        headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            // Cache aggressively at the CDN; route output only changes
+            // when the deployed build does.
+            "Cache-Control": "public, max-age=3600, s-maxage=86400",
+        },
+    });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,15 +8,20 @@ import { source } from "@/lib/source";
 // hosted, extend this with explicit entries rather than letting it sniff
 // the file system.
 //
-// `APP_URL` is required in non-build runtimes (see `src/lib/env.ts`).
-// During `next build` the env validator allows it to be unset; the
-// fallback keeps the build from crashing -- crawlers will see whatever
-// the deployed runtime emits.
-const BASE_URL = env.APP_URL ?? "https://openplaud.com";
+// `APP_URL` is required at runtime (see `src/lib/env.ts`) but allowed
+// to be unset at build time so `next build` doesn't depend on production
+// secrets. Forcing this route dynamic means `env.APP_URL` is read on the
+// first request from the actual deployed environment -- if we let it stay
+// static, a self-host Docker image built without APP_URL would ship a
+// sitemap pinned to the `https://openplaud.com` fallback below. The
+// fallback only kicks in for the genuinely-missing-at-runtime case (which
+// the env validator already prevents in practice).
+export const dynamic = "force-dynamic";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+    const baseUrl = env.APP_URL ?? "https://openplaud.com";
     return source.getPages().map((page) => ({
-        url: `${BASE_URL}${page.url}`,
+        url: `${baseUrl}${page.url}`,
         // `lastModified` from the fumadocs-mdx `lastModified` plugin (see
         // `source.config.ts`). Undefined in Docker builds where `.git` is
         // absent, in which case crawlers fall back to their own heuristics.

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/lib/env";
+import { source } from "@/lib/source";
+
+// Sitemap currently lists docs pages only. The marketing landing and legal
+// pages are mounted under hosted-only conditions (see comments in
+// `src/components/landing-footer.tsx`); when those need indexing on
+// hosted, extend this with explicit entries rather than letting it sniff
+// the file system.
+//
+// `APP_URL` is required in non-build runtimes (see `src/lib/env.ts`).
+// During `next build` the env validator allows it to be unset; the
+// fallback keeps the build from crashing -- crawlers will see whatever
+// the deployed runtime emits.
+const BASE_URL = env.APP_URL ?? "https://openplaud.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return source.getPages().map((page) => ({
+        url: `${BASE_URL}${page.url}`,
+        // `lastModified` from the fumadocs-mdx `lastModified` plugin (see
+        // `source.config.ts`). Undefined in Docker builds where `.git` is
+        // absent, in which case crawlers fall back to their own heuristics.
+        lastModified: page.data.lastModified,
+        changeFrequency: "weekly",
+        priority: 0.7,
+    }));
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -66,6 +66,12 @@ export function Footer() {
                         >
                             {APP_VERSION_TAG}
                         </Link>
+                        <Link
+                            href="/docs"
+                            className="hover:text-foreground transition-colors"
+                        >
+                            Docs
+                        </Link>
                         {env.IS_HOSTED ? (
                             <Link
                                 href="mailto:support@openplaud.com"

--- a/src/components/landing-footer.tsx
+++ b/src/components/landing-footer.tsx
@@ -34,9 +34,6 @@ type FooterColumn = {
     links: FooterLink[];
 };
 
-// Docs link points at the README for now; swap to `/docs` once that
-// route lands (issue/PR pending). Never ship a known-broken link on
-// a marketing surface.
 const COLUMNS: FooterColumn[] = [
     {
         title: "Product",
@@ -59,11 +56,7 @@ const COLUMNS: FooterColumn[] = [
     {
         title: "Resources",
         links: [
-            {
-                label: "Documentation",
-                href: "https://github.com/openplaud/openplaud#readme",
-                external: true,
-            },
+            { label: "Documentation", href: "/docs" },
             { label: "Install script", href: "/install" },
             {
                 label: "Discussions",

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -1,0 +1,10 @@
+import { loader } from "fumadocs-core/source";
+import { docs } from "@/.source/server";
+
+// Single Fumadocs source instance used by docs pages and the search route.
+// `baseUrl` matches the route group mount point (`src/app/(docs)/docs`).
+// Keep these two in lockstep \u2014 a mismatch silently breaks sidebar links.
+export const source = loader({
+    baseUrl: "/docs",
+    source: docs.toFumadocsSource(),
+});

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,0 +1,41 @@
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Card, Cards } from "fumadocs-ui/components/card";
+import { File, Files, Folder } from "fumadocs-ui/components/files";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import type { MDXComponents } from "mdx/types";
+
+/**
+ * MDX components surfaced to every `content/docs/**.mdx` file at render time.
+ *
+ * Adds the Fumadocs UI primitives that we expect content authors to reach
+ * for most often (callouts, tabs, steps, cards, accordions, file trees) on
+ * top of the defaults (`<a>`, headings, code blocks, etc.) shipped by
+ * `fumadocs-ui/mdx`. Keep this list curated -- every component listed here
+ * ships its CSS to the docs route. New additions only when content actually
+ * needs them.
+ *
+ * Page-specific overrides (e.g. `createRelativeLink` for the `<a>` tag) are
+ * applied inside the `[[...slug]]/page.tsx` render so they can close over
+ * the current `page`. This module is intentionally page-agnostic.
+ */
+export function getMDXComponents(overrides?: MDXComponents): MDXComponents {
+    return {
+        ...defaultMdxComponents,
+        Callout,
+        Tabs,
+        Tab,
+        Steps,
+        Step,
+        Cards,
+        Card,
+        Accordions,
+        Accordion,
+        Files,
+        File,
+        Folder,
+        ...overrides,
+    };
+}


### PR DESCRIPTION
## Description

Adds a Fumadocs-powered documentation site mounted at `/docs`. Same site serves both audiences from a single codebase: end users of the hosted instance at openplaud.com and operators running self-host stacks.

Sidebar splits into three top-level tabs:

- **Guides** — per-user product behavior that applies to both hosted and self-host: connect Plaud account, AI providers, notifications, automation API and webhooks, backup and restore.
- **Self Hosting** — operator-only surface: Docker Compose install, environment variables, S3-compatible storage, SMTP setup for email notifications, upgrading.
- **Reference** — stable concepts and contracts: architecture, public `/api/v1` surface, security model, encryption at rest.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

None.

## Changes Made

- Wired Fumadocs into the Next.js app: `next.config.ts` (`createMDX` wrapper, `src/.source` build output), `source.config.ts` (content dir, `lastModified` plugin, dual-theme shiki), `src/lib/source.ts`, `src/mdx-components.tsx`, `.gitignore` + `biome.json` ignores for `src/.source`.
- New routes: `src/app/(docs)/` (layout + `[[...slug]]` page with `editOnGithub` + `lastUpdate`), `src/app/api/search/route.ts`, `src/app/docs-og/[...slug]/route.tsx` (per-page OG images), `src/app/llms.txt/route.ts`, `src/app/llms-full.txt/route.ts`, `src/app/sitemap.ts`. `RootProvider` scoped to the docs route group so the rest of the app doesn't pay for its context.
- Layout config in `src/app/layout.config.tsx` with three sidebar tabs: Guides, Self Hosting, Reference.
- Content under `content/docs/`: index landing, `guides/` (5 pages), `self-hosting/` (index + 5 pages including the new `email-smtp.mdx` operator extraction), `reference/` (4 pages). `meta.json` per folder controls ordering.
- `notifications.mdx` Email section rewritten for the end-user surface; SMTP env var setup extracted into `self-hosting/email-smtp.mdx` with cross-links both directions.
- Footer Docs link now points at `/docs` instead of the README (`src/components/footer.tsx`, `src/components/landing-footer.tsx`).
- Added dev dependencies: `fumadocs-core`, `fumadocs-mdx`, `fumadocs-ui`, `@types/mdx`. `postinstall` script regenerates `src/.source` after install.

## Testing

- `pnpm format-and-lint:fix` — clean for changed files (2 pre-existing infos in `src/tests/admin/elevated-cookie.test.ts`, untouched).
- `pnpm type-check` — passes.
- `pnpm test` — not run (no test files added or modified).
- `pnpm build` / `pnpm dev` — not run (not requested).

### Test Steps

1. `pnpm install` to populate `src/.source`.
2. `pnpm dev`, open `/docs`, click through each sidebar tab and verify every cross-link.
3. Confirm `/sitemap.xml`, `/llms.txt`, and `/llms-full.txt` include `/docs/self-hosting/*` entries.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. Docs render unconditionally in both `IS_HOSTED=true` and self-host modes — hosted users get the same site as self-hosters, including the Self Hosting tab (operators on openplaud.com may still want to read it).

## For Reviewers

- Audience split in `content/docs/`: anything user-facing belongs in `guides/`; anything that needs operator access to env, DNS, or Docker belongs in `self-hosting/`.
- The Email split (`guides/notifications.mdx` user-side + `self-hosting/email-smtp.mdx` operator-side) is the one section deliberately separated mid-feature — every other guide stayed whole.
- `src/app/(docs)/layout.tsx` mounts `RootProvider` with `theme={{ enabled: false }}` to avoid double-mounting `next-themes` (the app already wraps the tree in `ThemeProvider`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Fumadocs-powered docs site at /docs with Guides, Self Hosting, and Reference. Includes search, per-page OG images, `llms.txt`/`llms-full.txt`, and a sitemap; also fixes OG image rendering and social preview URL resolution.

- **New Features**
  - Mounted a docs route group using `fumadocs-mdx`; pages are statically rendered with last-modified timestamps and mapped to app theme tokens.
  - Added routes: docs catch-all page, `/api/search` (static index), `/docs-og/[...slug]` (per-page OG images), `/llms.txt` and `/llms-full.txt`, and `/sitemap`.
  - Configured sidebar tabs (Guides, Self Hosting, Reference) with edit-on-GitHub links and safe relative-link handling.
  - Initial content covers: Guides (Plaud account, AI providers, notifications, automation/webhooks, backup), Self Hosting (install, env vars, S3, SMTP, upgrading), Reference (architecture, public API, security model, encryption at rest).
  - Updated footer link to `/docs`; ignored generated `src/.source`; `postinstall` script builds the docs source.

- **Bug Fixes**
  - Per-page OG images now use hex colors instead of `oklch()` to avoid Satori parsing errors.
  - Set `metadataBase` from `APP_URL` so OG images resolve to the correct origin; sitemap is now force-dynamic and reads `APP_URL` at request time to avoid `localhost` or hardcoded hosts in self-host builds.
  - Corrected labels and copy in docs (UI paths, Vitest as the test runner, `/api/export` scope) and cleaned up stale comments.

<sup>Written for commit b15c5a9ff4a0a61b342f3ae107aef27dc36470b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

