### PR TITLE
fix(plaud): send a browser User-Agent on all Plaud API requests

### DIFF
--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -14,6 +14,7 @@
 
 import { AppError, ErrorCode } from "@/lib/errors";
 import { DEFAULT_PLAUD_API_BASE } from "./client";
+import { PLAUD_USER_AGENT } from "./servers";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -62,7 +63,10 @@ export async function plaudSendCode(
 }> {
     const res = await fetch(`${apiBase}/auth/otp-send-code`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+            "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
+        },
         body: JSON.stringify({ username: email }),
     });
 
@@ -105,7 +109,10 @@ export async function plaudVerifyOtp(
 }> {
     const res = await fetch(`${apiBase}/auth/otp-login`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+            "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
+        },
         body: JSON.stringify({ code, token: otpToken }),
     });
 
@@ -184,6 +191,7 @@ export async function fetchPlaudUserMeEmail(
             headers: {
                 Authorization: `Bearer ${accessToken}`,
                 "Content-Type": "application/json",
+                "User-Agent": PLAUD_USER_AGENT,
             },
         });
         if (!res.ok) return null;

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -5,7 +5,7 @@ import type {
     PlaudRecordingsResponse,
     PlaudTempUrlResponse,
 } from "@/types/plaud";
-import { DEFAULT_SERVER_KEY, PLAUD_SERVERS } from "./servers";
+import { DEFAULT_SERVER_KEY, PLAUD_SERVERS, PLAUD_USER_AGENT } from "./servers";
 import { resolveWorkspaceToken } from "./workspace";
 
 export interface PlaudUpdateFilenameResponse {
@@ -173,6 +173,7 @@ export class PlaudClient {
                     ...options?.headers,
                     Authorization: `Bearer ${bearer}`,
                     "Content-Type": "application/json",
+                    "User-Agent": PLAUD_USER_AGENT,
                 },
             });
 

--- a/src/lib/plaud/servers.ts
+++ b/src/lib/plaud/servers.ts
@@ -1,3 +1,14 @@
+/**
+ * User-Agent sent on every request to Plaud's API.
+ *
+ * Plaud's API endpoints sit behind Cloudflare's WAF, which 403s requests from
+ * Node's default fetch (undici sends no User-Agent or `node`). Self-host
+ * deploys behind datacenter IPs are particularly susceptible. A plain
+ * modern-Chrome UA is sufficient to clear the challenge.
+ */
+export const PLAUD_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
 export const PLAUD_SERVERS = {
     global: {
         label: "Global (api.plaud.ai)",

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -24,6 +24,7 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
+import { PLAUD_USER_AGENT } from "./servers";
 
 /**
  * SSRF barrier. `apiBase` is user-influenced (originally chosen at OTP-send
@@ -74,6 +75,7 @@ export async function listPlaudWorkspaces(
         headers: {
             Authorization: `Bearer ${userToken}`,
             "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
         },
     });
 
@@ -141,6 +143,7 @@ export async function mintPlaudWorkspaceToken(
         headers: {
             Authorization: `Bearer ${userToken}`,
             "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
         },
         body: "{}",
     });


### PR DESCRIPTION
## Summary

Fixes #132.

Plaud's API sits behind Cloudflare's WAF, which 403s requests from Node's default `fetch` (undici sends no `User-Agent`, or `node`/`undici`). On self-host deploys behind datacenter IPs, every Plaud API call gets an HTML challenge page instead of JSON. The error is invisible at the application layer: workspace-token mint catches it, falls back to UT, and the subsequent `/file/simple/web` call also 403s — which combines with the regional UT-silent-empty-list quirk (#66) to produce a healthy-looking sync run that picks up zero new recordings.

This adds a `PLAUD_USER_AGENT` constant (Chrome 120 on Win10 — sufficient to clear the WAF) and wires it into every fetch in `src/lib/plaud/`. The S3 presigned-URL download in `client.ts:downloadRecording` is unchanged: that hits AWS directly, not Cloudflare.

## Verified

Reproduced and verified on a personal fork against `api-apse1.plaud.ai`:

- **Before:** sync ran, `last_sync` advanced, 0 new recordings stored despite 14 new recordings visible on the Plaud server. Logs showed `[plaud] workspace token mint failed, falling back to user token: Failed to list Plaud workspaces`. Inside-container `fetch(...).text()` returned a Cloudflare challenge HTML with HTTP 403.
- **After:** same sync immediately picked up all 14 missing recordings. Same fetch returned JSON with HTTP 200. `pnpm test src/tests/plaud.test.ts` passes (21/21). `pnpm type-check` clean.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test src/tests/plaud.test.ts` (21/21 passing)
- [x] `pnpm biome check src/lib/plaud/{servers,client,workspace,auth}.ts` clean
- [x] End-to-end manual sync against APSE1: 9 → 23 stored recordings after fix


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a browser-like User-Agent on all Plaud API requests to bypass Cloudflare WAF 403s. This fixes silent syncs that advanced `last_sync` but fetched zero recordings on some self-hosted deploys.

- **Bug Fixes**
  - Add `PLAUD_USER_AGENT` (Chrome 120 UA) and send it in `src/lib/plaud/{auth,workspace,client}.ts`.
  - Prevent Cloudflare challenge pages on Plaud endpoints; S3 presigned download remains unchanged.

<sup>Written for commit dc4f73b3f7938908f3f7144139a72b8f26b84043. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

