### PR TITLE
fix(docker): run fumadocs-mdx codegen in builder stage, not via postinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,14 @@ FROM oven/bun:1 AS base
 WORKDIR /app
 
 # Install dependencies
+# `--ignore-scripts` skips the `fumadocs-mdx` postinstall (declared in
+# package.json by PR #131). That hook needs `source.config.ts` and
+# `content/docs/`, which aren't present in this hermetic deps stage --
+# only `package.json` + the lockfile are. We regenerate fumadocs sources
+# explicitly in the builder stage below, where the full tree is available.
 FROM base AS deps
 COPY package.json pnpm-lock.yaml ./
-RUN bun install --frozen-lockfile
+RUN bun install --frozen-lockfile --ignore-scripts
 
 # Build Next.js
 FROM base AS builder
@@ -16,6 +21,9 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
+# Compile MDX docs into `src/.source/` before `next build` -- this is what
+# the postinstall hook would have done on a non-Docker install.
+RUN bunx fumadocs-mdx source.config.ts src/.source
 RUN bun run build
 
 # Bundle idempotent migration script with all dependencies


### PR DESCRIPTION
## Description

PR #131 added a `postinstall` hook (`fumadocs-mdx source.config.ts src/.source`) that runs during `bun install`. The Dockerfile's `deps` stage only copies `package.json` and `pnpm-lock.yaml` before installing, so when the hook fires, `source.config.ts` and `content/docs/` are not yet in the image. esbuild then errors with `The entry point "source.config.ts" cannot be marked as external` and the Docker build fails.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Relates to #131

## Changes Made

- Install dependencies with `--ignore-scripts` in the `deps` stage so the fumadocs-mdx postinstall doesn't run against a tree that's missing `source.config.ts` / `content/docs/`.
- Generate fumadocs sources explicitly in the `builder` stage via `bunx fumadocs-mdx source.config.ts src/.source` after `COPY . .` and before `bun run build`.
- Comment both edits inline so the reason for diverging from a plain `bun install` is discoverable.

Local `bun install` on developer checkouts is unchanged — the postinstall still primes `src/.source/` for `next dev`.

## Testing

- Not run (Docker build not executed locally). The change is mechanical: the previously-failing postinstall step is replaced by an equivalent CLI invocation in the builder stage where the required files exist.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## For Reviewers

- Confirm the deps-layer cache key is still stable across docs edits (it should be — only `package.json` + lockfile are copied there).
- Sanity-check that `bunx fumadocs-mdx` resolves to the version installed under `node_modules` rather than fetching at build time (it does — `bunx` prefers local installs).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker builds by skipping the `fumadocs-mdx` postinstall in the deps stage and running codegen in the builder stage after sources are copied. Prevents missing-file errors and keeps local installs unchanged.

- **Bug Fixes**
  - Use `bun install --ignore-scripts` in deps so the `fumadocs-mdx` postinstall doesn’t run before sources exist.
  - Run `bunx fumadocs-mdx source.config.ts src/.source` in builder before `bun run build`.
  - Deps layer cache key remains based on `package.json` and the lockfile.

<sup>Written for commit 88e5b1f6a39e02537c98126bf05512f2db4b23b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

