### PR TITLE
fix(plaud): send browser User-Agent on all Plaud API requests + #132 regression test

### DIFF
--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -14,6 +14,7 @@
 
 import { AppError, ErrorCode } from "@/lib/errors";
 import { DEFAULT_PLAUD_API_BASE } from "./client";
+import { PLAUD_USER_AGENT } from "./servers";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -62,7 +63,10 @@ export async function plaudSendCode(
 }> {
     const res = await fetch(`${apiBase}/auth/otp-send-code`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+            "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
+        },
         body: JSON.stringify({ username: email }),
     });
 
@@ -105,7 +109,10 @@ export async function plaudVerifyOtp(
 }> {
     const res = await fetch(`${apiBase}/auth/otp-login`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+            "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
+        },
         body: JSON.stringify({ code, token: otpToken }),
     });
 
@@ -184,6 +191,7 @@ export async function fetchPlaudUserMeEmail(
             headers: {
                 Authorization: `Bearer ${accessToken}`,
                 "Content-Type": "application/json",
+                "User-Agent": PLAUD_USER_AGENT,
             },
         });
         if (!res.ok) return null;

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -5,7 +5,7 @@ import type {
     PlaudRecordingsResponse,
     PlaudTempUrlResponse,
 } from "@/types/plaud";
-import { DEFAULT_SERVER_KEY, PLAUD_SERVERS } from "./servers";
+import { DEFAULT_SERVER_KEY, PLAUD_SERVERS, PLAUD_USER_AGENT } from "./servers";
 import { resolveWorkspaceToken } from "./workspace";
 
 export interface PlaudUpdateFilenameResponse {
@@ -173,6 +173,7 @@ export class PlaudClient {
                     ...options?.headers,
                     Authorization: `Bearer ${bearer}`,
                     "Content-Type": "application/json",
+                    "User-Agent": PLAUD_USER_AGENT,
                 },
             });
 

--- a/src/lib/plaud/servers.ts
+++ b/src/lib/plaud/servers.ts
@@ -1,3 +1,14 @@
+/**
+ * User-Agent sent on every request to Plaud's API.
+ *
+ * Plaud's API endpoints sit behind Cloudflare's WAF, which 403s requests from
+ * Node's default fetch (undici sends no User-Agent or `node`). Self-host
+ * deploys behind datacenter IPs are particularly susceptible. A plain
+ * modern-Chrome UA is sufficient to clear the challenge.
+ */
+export const PLAUD_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
 export const PLAUD_SERVERS = {
     global: {
         label: "Global (api.plaud.ai)",

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -24,6 +24,7 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
+import { PLAUD_USER_AGENT } from "./servers";
 
 /**
  * SSRF barrier. `apiBase` is user-influenced (originally chosen at OTP-send
@@ -74,6 +75,7 @@ export async function listPlaudWorkspaces(
         headers: {
             Authorization: `Bearer ${userToken}`,
             "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
         },
     });
 
@@ -141,6 +143,7 @@ export async function mintPlaudWorkspaceToken(
         headers: {
             Authorization: `Bearer ${userToken}`,
             "Content-Type": "application/json",
+            "User-Agent": PLAUD_USER_AGENT,
         },
         body: "{}",
     });

--- a/src/tests/regressions/132-plaud-user-agent.test.ts
+++ b/src/tests/regressions/132-plaud-user-agent.test.ts
@@ -186,11 +186,12 @@ describe("issue #132: every Plaud API fetch sends User-Agent", () => {
     });
 
     it("client.ts: PlaudClient.request sends UA on recording endpoints", async () => {
-        // Two-step flow: workspace token mint (WT not needed for this
-        // assertion — we just need the request to reach /file/simple/web),
-        // then the actual recording fetch. We force the UT-fallback path
-        // by failing the mint, which keeps the test focused on the second
-        // fetch (the one inside PlaudClient.request).
+        // Two-step flow. With no cached workspaceId, the client first calls
+        // /team-app/workspaces/list (covered above); we 500 that call to
+        // force the UT-fallback path so the second fetch is the recordings
+        // call itself — which is what this test asserts against.
+        // (Mint is never attempted on this path because the list step
+        // throws before resolveWorkspaceToken reaches mintPlaudWorkspaceToken.)
         mockFetch
             .mockResolvedValueOnce(
                 mockJson({ status: 500 }, { ok: false, status: 500 }),

--- a/src/tests/regressions/132-plaud-user-agent.test.ts
+++ b/src/tests/regressions/132-plaud-user-agent.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Regression test for issue #132:
+ *   "Cloudflare 403s Node fetch with no User-Agent; sync silently returns
+ *   no recordings on datacenter IPs"
+ *
+ * Plaud's API sits behind Cloudflare's WAF, which 403s requests from Node's
+ * default fetch (undici sends no User-Agent header). On datacenter IPs this
+ * is essentially guaranteed; on residential IPs it's environment-dependent.
+ *
+ * The fix sets a browser-like User-Agent on every fetch in `src/lib/plaud/`.
+ * The presigned-S3 download in `client.ts:downloadRecording` is intentionally
+ * left alone because it hits AWS directly, not Cloudflare.
+ *
+ * These tests assert the User-Agent header is sent on each of the six
+ * affected call sites. They do NOT validate the exact UA string; that would
+ * couple the test to a value the maintainers may rotate when Cloudflare
+ * heuristics change. The contract is: "we send a non-empty browser-shaped
+ * UA, not node/undici/empty".
+ *
+ * Six call sites covered:
+ *   1. PlaudClient.request               (client.ts)
+ *   2. listPlaudWorkspaces               (workspace.ts)
+ *   3. mintPlaudWorkspaceToken           (workspace.ts)
+ *   4. plaudSendCode                     (auth.ts)
+ *   5. plaudVerifyOtp                    (auth.ts)
+ *   6. fetchPlaudUserMeEmail             (auth.ts)
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+import {
+    fetchPlaudUserMeEmail,
+    plaudSendCode,
+    plaudVerifyOtp,
+} from "@/lib/plaud/auth";
+import { PlaudClient } from "@/lib/plaud/client";
+import { PLAUD_USER_AGENT } from "@/lib/plaud/servers";
+import {
+    listPlaudWorkspaces,
+    mintPlaudWorkspaceToken,
+} from "@/lib/plaud/workspace";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+beforeAll(() => {
+    mockFetch = vi.fn() as Mock;
+    global.fetch = mockFetch as typeof global.fetch;
+});
+
+afterAll(() => {
+    global.fetch = originalFetch;
+});
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+const UT = "ut.user.token";
+const API_BASE = "https://api-apse1.plaud.ai";
+
+function mockJson(body: unknown, init?: { ok?: boolean; status?: number }) {
+    const ok = init?.ok ?? true;
+    return {
+        ok,
+        status: init?.status ?? (ok ? 200 : 400),
+        statusText: ok ? "OK" : "Error",
+        headers: { get: () => null },
+        json: () => Promise.resolve(body),
+    };
+}
+
+/**
+ * Pull the User-Agent header off a mockFetch call. Headers can be supplied
+ * as a Record<string, string> (every call site in src/lib/plaud/ uses this
+ * shape today). Returns undefined if absent so test assertions can be
+ * exact rather than loose.
+ */
+function userAgentFromCall(call: unknown[]): string | undefined {
+    const init = call[1] as RequestInit | undefined;
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    return headers["User-Agent"];
+}
+
+describe("issue #132: PLAUD_USER_AGENT constant", () => {
+    it("is a non-empty browser-shaped UA (not node/undici/empty)", () => {
+        expect(PLAUD_USER_AGENT).toBeTruthy();
+        expect(PLAUD_USER_AGENT.length).toBeGreaterThan(20);
+        // Cloudflare WAF flags these as obvious automation. Negative
+        // assertions guard against an accidental rollback to the default
+        // undici UA or a copy-paste of "node-fetch" / similar.
+        expect(PLAUD_USER_AGENT.toLowerCase()).not.toContain("undici");
+        expect(PLAUD_USER_AGENT.toLowerCase()).not.toContain("node-fetch");
+        // Browser-shaped: starts with "Mozilla/5.0". This is the same
+        // convention every real browser uses and what Plaud's own web
+        // client sends; matching it keeps us indistinguishable from
+        // normal user traffic on a WAF level.
+        expect(PLAUD_USER_AGENT).toMatch(/^Mozilla\/5\.0/);
+    });
+});
+
+describe("issue #132: every Plaud API fetch sends User-Agent", () => {
+    it("auth.ts: plaudSendCode sends UA", async () => {
+        mockFetch.mockResolvedValueOnce(
+            mockJson({ status: 0, token: "otp.session.token" }),
+        );
+        await plaudSendCode("user@example.com", API_BASE);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(userAgentFromCall(mockFetch.mock.calls[0])).toBe(
+            PLAUD_USER_AGENT,
+        );
+    });
+
+    it("auth.ts: plaudVerifyOtp sends UA", async () => {
+        mockFetch.mockResolvedValueOnce(
+            mockJson({ status: 0, access_token: "at.token" }),
+        );
+        await plaudVerifyOtp("123456", "otp.session.token", API_BASE);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(userAgentFromCall(mockFetch.mock.calls[0])).toBe(
+            PLAUD_USER_AGENT,
+        );
+    });
+
+    it("auth.ts: fetchPlaudUserMeEmail sends UA", async () => {
+        mockFetch.mockResolvedValueOnce(
+            mockJson({ status: 0, data: { email: "user@example.com" } }),
+        );
+        await fetchPlaudUserMeEmail("at.token", API_BASE);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(userAgentFromCall(mockFetch.mock.calls[0])).toBe(
+            PLAUD_USER_AGENT,
+        );
+    });
+
+    it("workspace.ts: listPlaudWorkspaces sends UA", async () => {
+        mockFetch.mockResolvedValueOnce(
+            mockJson({
+                status: 0,
+                data: {
+                    workspaces: [
+                        {
+                            workspace_id: "ws_1",
+                            member_id: "mem_1",
+                            name: "Personal",
+                            role: "admin",
+                            status: "active",
+                            workspace_type: "0",
+                        },
+                    ],
+                },
+            }),
+        );
+        await listPlaudWorkspaces(UT, API_BASE);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(userAgentFromCall(mockFetch.mock.calls[0])).toBe(
+            PLAUD_USER_AGENT,
+        );
+    });
+
+    it("workspace.ts: mintPlaudWorkspaceToken sends UA", async () => {
+        mockFetch.mockResolvedValueOnce(
+            mockJson({
+                status: 0,
+                data: { workspace_token: "wt.token" },
+            }),
+        );
+        await mintPlaudWorkspaceToken(UT, "ws_1", API_BASE);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(userAgentFromCall(mockFetch.mock.calls[0])).toBe(
+            PLAUD_USER_AGENT,
+        );
+    });
+
+    it("client.ts: PlaudClient.request sends UA on recording endpoints", async () => {
+        // Two-step flow: workspace token mint (WT not needed for this
+        // assertion — we just need the request to reach /file/simple/web),
+        // then the actual recording fetch. We force the UT-fallback path
+        // by failing the mint, which keeps the test focused on the second
+        // fetch (the one inside PlaudClient.request).
+        mockFetch
+            .mockResolvedValueOnce(
+                mockJson({ status: 500 }, { ok: false, status: 500 }),
+            )
+            .mockResolvedValueOnce(
+                mockJson({
+                    status: 0,
+                    msg: "success",
+                    data_file_total: 0,
+                    data_file_list: [],
+                }),
+            );
+
+        const client = new PlaudClient(UT, API_BASE);
+        await client.getRecordings(0, 10);
+
+        // We assert UA on the second call (the one PlaudClient.request
+        // makes). The first call goes through workspace.ts which is
+        // covered above; here we want the client.ts contract.
+        expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+        const recordingCall = mockFetch.mock.calls[1];
+        expect(String(recordingCall[0])).toContain("/file/simple/web");
+        expect(userAgentFromCall(recordingCall)).toBe(PLAUD_USER_AGENT);
+    });
+});


### PR DESCRIPTION
## Description

Re-applies #133 (User-Agent on Plaud API fetches) and adds a regression test asserting every Plaud API call site sends the expected `User-Agent` header. Closes the loop on #132 with coverage so this can't silently regress.

The fix itself is unchanged from #133 by @brendanerofeev — a single `PLAUD_USER_AGENT` constant wired into the six fetch sites under `src/lib/plaud/`. Cloudflare's WAF 403s Node's default fetch (no `User-Agent`) from datacenter IPs, which combined with the regional UT-silent-empty-list quirk (#66) produced healthy-looking syncs that picked up zero recordings. See #132 for the full repro.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #132
Relates to #66, supersedes #133

## Changes Made

- `src/lib/plaud/servers.ts` — add `PLAUD_USER_AGENT` constant (Chrome 120 UA) with a comment explaining the WAF context (from #133).
- `src/lib/plaud/{auth,workspace,client}.ts` — send `User-Agent` on all six fetches: `plaudSendCode`, `plaudVerifyOtp`, `fetchPlaudUserMeEmail`, `listPlaudWorkspaces`, `mintPlaudWorkspaceToken`, `PlaudClient.request`. Presigned-S3 download in `client.ts:downloadRecording` intentionally left alone — it hits AWS, not Cloudflare (from #133).
- `src/tests/regressions/132-plaud-user-agent.test.ts` — new. 7 tests asserting (a) the constant is a non-empty browser-shaped UA (not `undici`/`node-fetch`) and (b) every one of the six call sites emits the header. Verified the tests actually fail when the fix is reverted: swapped `auth.ts` back to the pre-fix version → 3 failures (the three auth sites) → restored → all 7 pass.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0

### Test Steps
1. `pnpm install`
2. `pnpm test src/tests/regressions/132-plaud-user-agent.test.ts` → 7/7 pass
3. `pnpm test src/tests/plaud.test.ts src/tests/regressions/66-eu-otp-permissions.test.ts` → 27/27 pass (no collateral on the existing #66 suite)
4. `pnpm type-check` → clean
5. `pnpm format-and-lint:fix` → no fixes applied to touched files
6. End-to-end manual sync against APSE1 reported in #133 by @brendanerofeev: 9 → 23 stored recordings after fix

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. No schema, env var, or `docker-compose.yml` change. Both self-host and hosted modes benefit equally — datacenter egress is essentially guaranteed to trip the WAF today.

## Additional Notes

- Credit for the fix belongs to @brendanerofeev (#133). This PR adds the regression coverage on top so #133 can be closed in favor of this one, or alternatively this can be cherry-picked onto their branch — maintainer's call.
- The test uses top-level imports throughout, per `AGENTS.md`'s "NEVER use inline imports" rule. The existing `66-eu-otp-permissions.test.ts` has one `await import(...)` that violates this; not fixed here, flagged for a separate cleanup.

## For Reviewers

- Confirm the UA string choice (`Mozilla/5.0 ... Chrome/120.0.0.0`) is acceptable long-term, or whether you'd rather rotate to a different/newer fingerprint. The regression test deliberately does NOT assert the exact string — only that it's non-empty and browser-shaped — so the maintainer can rotate the constant without touching tests.
- The S3 presigned-download fetch in `client.ts:downloadRecording` is intentionally untouched. If you'd prefer to send a UA there too for consistency, it's a one-line change but adds no value against AWS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends a browser-like User-Agent on all Plaud API requests to avoid Cloudflare WAF 403s that caused silent empty syncs. Adds regression coverage for #132 to ensure every Plaud call site sets the header.

- **Bug Fixes**
  - Added `PLAUD_USER_AGENT` and applied it to six fetches in `plaud/{auth,workspace,client}.ts`.
  - Left the S3 presigned download fetch unchanged (hits AWS, not Cloudflare).
  - Added `src/tests/regressions/132-plaud-user-agent.test.ts` to verify a browser-shaped UA on all six call sites; corrected the 500-fallback test comment.

<sup>Written for commit 192315995dc942ccbbca44c633a77071327892f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

