### PR TITLE
refactor: react-doctor cleanup pass (lint, copy, async, hydration, component splits)

### DIFF
--- a/.pi/extensions/prompt-url-widget.ts
+++ b/.pi/extensions/prompt-url-widget.ts
@@ -115,12 +115,9 @@ export default function promptUrlWidgetExtension(pi: ExtensionAPI) {
 	const getUserText = (content: string | { type: string; text?: string }[] | undefined): string => {
 		if (!content) return "";
 		if (typeof content === "string") return content;
-		return (
-			content
-				.filter((block): block is { type: "text"; text: string } => block.type === "text")
-				.map((block) => block.text)
-				.join("\n") ?? ""
-		);
+		return content
+			.flatMap((block) => (block.type === "text" && typeof block.text === "string" ? [block.text] : []))
+			.join("\n");
 	};
 
 	const rebuildFromSession = (ctx: ExtensionContext) => {

--- a/src/app/(admin)/admin/(gated)/_components/metrics.tsx
+++ b/src/app/(admin)/admin/(gated)/_components/metrics.tsx
@@ -118,8 +118,10 @@ export function formatBytes(b: number): string {
     return `${(b / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
+const NUMBER_FORMAT = new Intl.NumberFormat("en-US");
+
 export function formatNumber(n: number): string {
-    return new Intl.NumberFormat("en-US").format(n);
+    return NUMBER_FORMAT.format(n);
 }
 
 export function formatHours(ms: number): string {

--- a/src/app/(admin)/admin/(gated)/users/[id]/page.tsx
+++ b/src/app/(admin)/admin/(gated)/users/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function AdminUserDetailPage({
                     </div>
                     {user.suspendedAt ? (
                         <div className="mt-2 text-sm border border-red-500/30 bg-red-500/10 text-red-700 rounded px-3 py-2">
-                            Suspended {formatRelative(user.suspendedAt)} —{" "}
+                            Suspended {formatRelative(user.suspendedAt)}:{" "}
                             {user.suspendedReason ?? "no reason recorded"}
                         </div>
                     ) : null}

--- a/src/app/(admin)/admin/(gated)/users/[id]/recording-delete-button.tsx
+++ b/src/app/(admin)/admin/(gated)/users/[id]/recording-delete-button.tsx
@@ -16,7 +16,7 @@ export function RecordingDeleteButton({
 }: {
     recordingId: string;
 }) {
-    const router = useRouter();
+    const { refresh, replace } = useRouter();
     const confirm = useConfirm();
     const [busy, setBusy] = useState(false);
 
@@ -55,7 +55,7 @@ export function RecordingDeleteButton({
                         toast.error(
                             "Admin session expired. Reauth and try again.",
                         );
-                        router.replace(
+                        replace(
                             `/admin/reauth?next=${window.location.pathname}`,
                         );
                         return;
@@ -65,7 +65,7 @@ export function RecordingDeleteButton({
                         throw new Error(j.error ?? `Failed (${res.status})`);
                     }
                     toast.success("Recording soft-deleted");
-                    router.refresh();
+                    refresh();
                 } finally {
                     setBusy(false);
                 }

--- a/src/app/(admin)/admin/(gated)/users/[id]/user-actions.tsx
+++ b/src/app/(admin)/admin/(gated)/users/[id]/user-actions.tsx
@@ -20,7 +20,7 @@ export function UserActions({
     suspended: boolean;
     plaudConnected: boolean;
 }) {
-    const router = useRouter();
+    const { refresh, replace } = useRouter();
     const [busy, setBusy] = useState<string | null>(null);
 
     async function run(
@@ -42,7 +42,7 @@ export function UserActions({
             });
             if (res.status === 404) {
                 toast.error("Admin session expired. Reauth and try again.");
-                router.replace(`/admin/reauth?next=/admin/users/${userId}`);
+                replace(`/admin/reauth?next=/admin/users/${userId}`);
                 return;
             }
             if (!res.ok) {
@@ -51,7 +51,7 @@ export function UserActions({
                 return;
             }
             toast.success(`${label} done`);
-            router.refresh();
+            refresh();
         } finally {
             setBusy(null);
         }

--- a/src/app/(admin)/admin/(gated)/users/page.tsx
+++ b/src/app/(admin)/admin/(gated)/users/page.tsx
@@ -46,7 +46,7 @@ export default async function AdminUsersPage({
                 <div>
                     <h1 className="text-xl font-semibold">Users</h1>
                     <p className="text-sm text-muted-foreground">
-                        Cost-attribution view. PII surface — emails visible.
+                        Cost-attribution view. PII surface: emails visible.
                     </p>
                 </div>
                 <div className="text-sm text-muted-foreground">

--- a/src/app/(admin)/admin/(gated)/users/page.tsx
+++ b/src/app/(admin)/admin/(gated)/users/page.tsx
@@ -65,7 +65,7 @@ export default async function AdminUsersPage({
                 <select
                     name="sort"
                     defaultValue={sort}
-                    className="border rounded px-2 py-2 text-sm bg-background"
+                    className="border rounded p-2 text-sm bg-background"
                 >
                     {SORTS.map((s) => (
                         <option key={s.key} value={s.key}>

--- a/src/app/(admin)/admin/reauth/reauth-form.tsx
+++ b/src/app/(admin)/admin/reauth/reauth-form.tsx
@@ -55,6 +55,7 @@ export function ReauthForm({ email, next }: { email: string; next: string }) {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
+                // oxlint-disable-next-line jsx-a11y/no-autofocus -- intentional -- admin re-auth modal is gated; the whole point of this page is to type a password
                 autoFocus
             />
             {error ? <div className="text-sm text-red-600">{error}</div> : null}

--- a/src/app/(admin)/admin/reauth/reauth-form.tsx
+++ b/src/app/(admin)/admin/reauth/reauth-form.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 export function ReauthForm({ email, next }: { email: string; next: string }) {
-    const router = useRouter();
+    const { refresh, replace } = useRouter();
     const [password, setPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -24,7 +24,7 @@ export function ReauthForm({ email, next }: { email: string; next: string }) {
             if (res.status === 404) {
                 // Gate tripped (lost admin status, IP changed, etc.) -- bounce
                 // to the user dashboard rather than reveal the route.
-                router.replace("/dashboard");
+                replace("/dashboard");
                 return;
             }
             if (!res.ok) {
@@ -32,8 +32,8 @@ export function ReauthForm({ email, next }: { email: string; next: string }) {
                 setSubmitting(false);
                 return;
             }
-            router.replace(next);
-            router.refresh();
+            replace(next);
+            refresh();
         } catch {
             setError("Something went wrong");
             setSubmitting(false);

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -28,7 +28,7 @@ function RegistrationDisabled() {
             <div className="flex items-center gap-3">
                 <Logo className="size-10 shrink-0" />
                 <div>
-                    <h1 className="text-2xl font-bold tracking-tight">
+                    <h1 className="text-2xl font-semibold tracking-tight">
                         Registration Disabled
                     </h1>
                     <p className="text-sm text-muted-foreground">

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -27,14 +27,14 @@ export default function PrivacyPage() {
         <>
             <h1>Privacy Policy</h1>
             <p>
-                <em>Last updated: TBD — this page is a placeholder.</em>
+                <em>Last updated: TBD. This page is a placeholder.</em>
             </p>
             <p>
                 OpenPlaud is open-source software you can run yourself (under
                 AGPL-3.0) or use through the hosted service at openplaud.com.
                 This page describes how the hosted service handles your data. If
                 you self-host, your data never touches our infrastructure and
-                this policy does not apply to you — see the{" "}
+                this policy does not apply to you. See the{" "}
                 <Link href="https://github.com/openplaud/openplaud#readme">
                     project README
                 </Link>{" "}

--- a/src/app/(legal)/terms/page.tsx
+++ b/src/app/(legal)/terms/page.tsx
@@ -29,7 +29,7 @@ export default function TermsPage() {
         <>
             <h1>Terms of Service</h1>
             <p>
-                <em>Last updated: TBD — this page is a placeholder.</em>
+                <em>Last updated: TBD. This page is a placeholder.</em>
             </p>
             <p>
                 These terms govern your use of the hosted OpenPlaud service at

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -99,9 +99,9 @@ export const GET = apiHandler(async (request: Request) => {
         case "srt":
             // SRT format for subtitles
             exportData = decryptedRecordings
-                .map((recording, index) => {
+                .flatMap((recording, index) => {
                     const transcription = transcriptionMap.get(recording.id);
-                    if (!transcription?.text) return "";
+                    if (!transcription?.text) return [];
                     const startTime = new Date(recording.startTime);
                     const endTime = new Date(
                         startTime.getTime() + recording.duration,
@@ -125,9 +125,10 @@ export const GET = apiHandler(async (request: Request) => {
                             .padStart(3, "0");
                         return `${hours}:${minutes}:${seconds},${ms}`;
                     };
-                    return `${index + 1}\n${formatSRTTime(startTime)} --> ${formatSRTTime(endTime)}\n${transcription.text}\n\n`;
+                    return [
+                        `${index + 1}\n${formatSRTTime(startTime)} --> ${formatSRTTime(endTime)}\n${transcription.text}\n\n`,
+                    ];
                 })
-                .filter(Boolean)
                 .join("");
             contentType = "text/plain";
             filename = `recordings-${new Date().toISOString().split("T")[0]}.srt`;
@@ -136,9 +137,9 @@ export const GET = apiHandler(async (request: Request) => {
         case "vtt":
             // WebVTT format
             exportData = `WEBVTT\n\n${decryptedRecordings
-                .map((recording) => {
+                .flatMap((recording) => {
                     const transcription = transcriptionMap.get(recording.id);
-                    if (!transcription?.text) return "";
+                    if (!transcription?.text) return [];
                     const startTime = new Date(recording.startTime);
                     const endTime = new Date(
                         startTime.getTime() + recording.duration,
@@ -162,9 +163,10 @@ export const GET = apiHandler(async (request: Request) => {
                             .padStart(3, "0");
                         return `${hours}:${minutes}:${seconds}.${ms}`;
                     };
-                    return `${formatVTTTime(startTime)} --> ${formatVTTTime(endTime)}\n${transcription.text}\n\n`;
+                    return [
+                        `${formatVTTTime(startTime)} --> ${formatVTTTime(endTime)}\n${transcription.text}\n\n`,
+                    ];
                 })
-                .filter(Boolean)
                 .join("")}`;
             contentType = "text/vtt";
             filename = `recordings-${new Date().toISOString().split("T")[0]}.vtt`;

--- a/src/app/api/settings/ai/providers/models/route.ts
+++ b/src/app/api/settings/ai/providers/models/route.ts
@@ -103,6 +103,10 @@ async function fetchOpenRouterAudioModels(
         response = await fetch(url, {
             headers: { Authorization: `Bearer ${apiKey}` },
             signal: controller.signal,
+            // Model catalog is fetched on demand; never cache between
+            // requests. Provider catalogs (esp. OpenRouter) change daily and
+            // Next.js's default fetch cache would silently serve stale data.
+            cache: "no-store",
         });
     } catch (err) {
         if ((err as Error).name === "AbortError") {
@@ -142,10 +146,11 @@ async function fetchOpenRouterAudioModels(
     const list = Array.isArray(payload?.data) ? payload.data : [];
 
     const models: ModelOption[] = list
-        .filter((m) =>
-            (m.architecture?.input_modalities ?? []).includes("audio"),
+        .flatMap((m) =>
+            (m.architecture?.input_modalities ?? []).includes("audio")
+                ? [{ id: m.id, name: m.name || m.id }]
+                : [],
         )
-        .map((m) => ({ id: m.id, name: m.name || m.id }))
         // Stable alphabetical order so the dropdown doesn't reshuffle on
         // every refresh as OpenRouter's catalog re-orders.
         .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/app/api/settings/user/route.ts
+++ b/src/app/api/settings/user/route.ts
@@ -22,6 +22,13 @@ const ENUM_FIELDS = {
     defaultExportFormat: ["json", "csv", "zip"],
 } as const satisfies Record<string, readonly string[]>;
 
+// O(1) membership lookup tables built once at module load. The per-request
+// validator iterates many fields; .includes() over short tuples is fine but
+// converting to Sets makes intent explicit and removes the lint nag.
+const ENUM_FIELD_SETS: Record<string, ReadonlySet<string>> = Object.fromEntries(
+    Object.entries(ENUM_FIELDS).map(([k, v]) => [k, new Set(v)]),
+);
+
 // Default settings values
 const DEFAULT_SETTINGS = {
     autoTranscribe: false,
@@ -175,9 +182,7 @@ export const PUT = apiHandler(async (request: Request) => {
             field in ENUM_FIELDS &&
             value !== undefined &&
             value !== null &&
-            !(ENUM_FIELDS as Record<string, readonly string[]>)[field].includes(
-                value as string,
-            )
+            !ENUM_FIELD_SETS[field].has(value as string)
         ) {
             throw new AppError(
                 ErrorCode.INVALID_INPUT,

--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -72,7 +72,7 @@ export default function InstallPage() {
                         <div className="inline-flex items-center rounded-full border border-border bg-muted px-3 py-1 text-xs font-medium text-muted-foreground mb-6 font-mono">
                             Self-host
                         </div>
-                        <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-6">
+                        <h1 className="text-4xl md:text-5xl font-semibold tracking-tight mb-6">
                             Install OpenPlaud
                         </h1>
                         <p className="text-lg text-muted-foreground leading-relaxed">
@@ -209,7 +209,7 @@ export default function InstallPage() {
                             >
                                 self-host instructions
                             </Link>{" "}
-                            in the README. The whole project is AGPL-3.0 —
+                            in the README. The whole project is AGPL-3.0,
                             inspect everything before you run it.
                         </p>
                     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { Deploy } from "@/components/landing/deploy";
 import { FAQ } from "@/components/landing/faq";
@@ -12,6 +13,12 @@ import { TheMath } from "@/components/landing/the-math";
 import { LandingFooter } from "@/components/landing-footer";
 import { getSession } from "@/lib/auth-server";
 import { env } from "@/lib/env";
+
+export const metadata: Metadata = {
+    title: "OpenPlaud — open-source companion app for Plaud devices",
+    description:
+        "Free, self-hostable web app for Plaud Note, Note Pro, and NotePin. Bring your own AI provider, keep your data, skip the subscription.",
+};
 
 export default async function HomePage() {
     const session = await getSession();

--- a/src/app/suspended/page.tsx
+++ b/src/app/suspended/page.tsx
@@ -1,8 +1,14 @@
 import { eq } from "drizzle-orm";
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { getSession } from "@/lib/auth-server";
+
+export const metadata: Metadata = {
+    title: "Account suspended — OpenPlaud",
+    robots: { index: false, follow: false },
+};
 
 /**
  * Page shown to suspended users. We deliberately tell them their account is

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -58,7 +58,7 @@ export function ForgotPasswordForm({
             <div className="flex items-center gap-3">
                 <Logo className="size-10 shrink-0" />
                 <div>
-                    <h1 className="text-2xl font-bold tracking-tight">
+                    <h1 className="text-2xl font-semibold tracking-tight">
                         Reset password
                     </h1>
                     <p className="text-sm text-muted-foreground">

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -38,7 +38,7 @@ export function LoginForm({
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [isLoading, setIsLoading] = useState(false);
-    const router = useRouter();
+    const { push, refresh } = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -58,8 +58,8 @@ export function LoginForm({
             }
 
             toast.success("Logged in successfully");
-            router.push("/dashboard");
-            router.refresh();
+            push("/dashboard");
+            refresh();
         } catch (error) {
             const message =
                 error instanceof Error

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -76,7 +76,7 @@ export function LoginForm({
             <div className="flex items-center gap-3">
                 <Logo className="size-10 shrink-0" />
                 <div>
-                    <h1 className="text-2xl font-bold tracking-tight">
+                    <h1 className="text-2xl font-semibold tracking-tight">
                         OpenPlaud
                     </h1>
                     <p className="text-sm text-muted-foreground">

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -17,7 +17,7 @@ export function RegisterForm() {
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [isLoading, setIsLoading] = useState(false);
-    const router = useRouter();
+    const { push, refresh } = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -47,8 +47,8 @@ export function RegisterForm() {
             }
 
             toast.success("Account created successfully");
-            router.push("/onboarding");
-            router.refresh();
+            push("/onboarding");
+            refresh();
         } catch (error) {
             const message =
                 error instanceof Error

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -65,7 +65,7 @@ export function RegisterForm() {
             <div className="flex items-center gap-3">
                 <Logo className="size-10 shrink-0" />
                 <div>
-                    <h1 className="text-2xl font-bold tracking-tight">
+                    <h1 className="text-2xl font-semibold tracking-tight">
                         Create Account
                     </h1>
                     <p className="text-sm text-muted-foreground">

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -39,7 +39,7 @@ export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
                 <div className="flex items-center gap-3">
                     <Logo className="size-10 shrink-0" />
                     <div>
-                        <h1 className="text-2xl font-bold tracking-tight">
+                        <h1 className="text-2xl font-semibold tracking-tight">
                             Invalid reset link
                         </h1>
                         <p className="text-sm text-muted-foreground">
@@ -122,7 +122,7 @@ export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
             <div className="flex items-center gap-3">
                 <Logo className="size-10 shrink-0" />
                 <div>
-                    <h1 className="text-2xl font-bold tracking-tight">
+                    <h1 className="text-2xl font-semibold tracking-tight">
                         Set a new password
                     </h1>
                     <p className="text-sm text-muted-foreground">

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -27,7 +27,7 @@ export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [isLoading, setIsLoading] = useState(false);
-    const router = useRouter();
+    const { push, refresh } = useRouter();
 
     // No token in URL, or better-auth signaled an error on the callback --
     // either the user navigated here directly, the token expired, or the
@@ -104,8 +104,8 @@ export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
             }
 
             toast.success("Password reset. You can sign in now.");
-            router.push("/login");
-            router.refresh();
+            push("/login");
+            refresh();
         } catch (err) {
             const message =
                 err instanceof Error

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-    createContext,
-    type ReactNode,
-    useContext,
-    useRef,
-    useState,
-} from "react";
+import { createContext, type ReactNode, use, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
     AlertDialog,
@@ -73,7 +67,7 @@ type ConfirmFn = (opts: ConfirmOptions) => Promise<boolean>;
 const ConfirmContext = createContext<ConfirmFn | null>(null);
 
 export function useConfirm(): ConfirmFn {
-    const fn = useContext(ConfirmContext);
+    const fn = use(ConfirmContext);
     if (!fn) {
         throw new Error(
             "useConfirm() must be used inside <ConfirmDialogProvider>",

--- a/src/components/dashboard/command-palette-parts.tsx
+++ b/src/components/dashboard/command-palette-parts.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+/**
+ * Shared building blocks for the command palette. Lives next to
+ * `command-palette.tsx` so all the groups (Recordings/Actions/Theme)
+ * and the footer can share the same Row/Kbd primitives without
+ * either component re-exporting things from the other.
+ */
+
+import { Command } from "cmdk";
+import {
+    FileText,
+    Keyboard,
+    Loader2,
+    Mic,
+    Monitor,
+    Moon,
+    RefreshCw,
+    Settings,
+    Sparkles,
+    Sun,
+    Upload,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { type DateTimeFormat, formatDateTime } from "@/lib/format-date";
+import { formatDurationMs } from "@/lib/format-duration";
+import type { Recording } from "@/types/recording";
+
+export const RECORDING_CAP = 200;
+
+interface TranscriptionData {
+    text?: string;
+    language?: string;
+}
+
+/**
+ * Strip transcript noise (timecodes, speaker labels, redundant
+ * whitespace) into a single-line snippet usable as both a row
+ * subtitle and a fuzzy-search target. Kept in sync with the helper
+ * of the same name in `recording-list.tsx`; we duplicate rather
+ * than import-cross because the list's helper is module-local
+ * there and we don't want to widen its surface for one caller.
+ */
+export function transcriptSnippet(
+    text: string | undefined,
+    maxChars = 140,
+): string | null {
+    if (!text) return null;
+    const stripped = text
+        .replace(/\[[^\]]+\]/g, " ")
+        .replace(/\b\d{1,2}:\d{2}(:\d{2})?\b/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+    if (!stripped) return null;
+    if (stripped.length <= maxChars) return stripped;
+    return `${stripped.slice(0, maxChars - 1).trimEnd()}…`;
+}
+
+/**
+ * Generic two-line row used by every cmdk item in the palette so
+ * icon weight, alignment, and accessory placement stay consistent
+ * across groups (recordings, actions, theme).
+ */
+export function Row({
+    icon,
+    title,
+    subtitle,
+    accessory,
+}: {
+    icon: ReactNode;
+    title: ReactNode;
+    subtitle?: ReactNode;
+    accessory?: ReactNode;
+}) {
+    return (
+        <>
+            <span aria-hidden="true" className="shrink-0">
+                {icon}
+            </span>
+            <span className="cmd-body">
+                <span className="cmd-title">{title}</span>
+                {subtitle ? (
+                    <span className="cmd-subtitle">{subtitle}</span>
+                ) : null}
+            </span>
+            {accessory ? (
+                <span className="cmd-accessory">{accessory}</span>
+            ) : null}
+        </>
+    );
+}
+
+export function Kbd({ children }: { children: ReactNode }) {
+    return <kbd className="cmd-kbd">{children}</kbd>;
+}
+
+/**
+ * Recordings group. Renders the recent list with state-aware leading
+ * icons, transcript-snippet subtitles, and an inline Transcribe quick
+ * action on rows without a transcript. The Transcribe button calls
+ * onTranscribe (not onSelect) so it doesn't change the active row.
+ */
+export function RecordingsGroup({
+    recordings,
+    transcriptions,
+    currentRecording,
+    inFlightActions,
+    dateTimeFormat,
+    onSelectRecording,
+    onTranscribeRecording,
+    runAction,
+}: {
+    recordings: Recording[];
+    transcriptions: Map<string, TranscriptionData>;
+    currentRecording: Recording | null;
+    inFlightActions: Map<string, "transcribing" | "summarizing">;
+    dateTimeFormat: DateTimeFormat;
+    onSelectRecording: (r: Recording) => void;
+    onTranscribeRecording: (id: string) => void;
+    runAction: (fn: () => void) => () => void;
+}) {
+    if (recordings.length === 0) return null;
+    const overflowCount = Math.max(0, recordings.length - RECORDING_CAP);
+
+    return (
+        <Command.Group heading="Recent">
+            {recordings.map((r) => {
+                const snippet = transcriptSnippet(
+                    transcriptions.get(r.id)?.text,
+                );
+                const inFlight = inFlightActions.get(r.id);
+                const isCurrent = currentRecording?.id === r.id;
+
+                // Leading icon doubles as a state indicator so the user
+                // can scan and immediately tell which recordings are
+                // audio-only, transcribed, or fully processed. In-flight
+                // wins because it's the most actionable state ("don't
+                // trigger this again").
+                let stateIcon: ReactNode;
+                let stateLabel: string;
+                if (inFlight) {
+                    stateIcon = (
+                        <Loader2 className="size-4 animate-spin text-primary" />
+                    );
+                    stateLabel =
+                        inFlight === "transcribing"
+                            ? "Transcribing"
+                            : "Summarizing";
+                } else if (!r.hasTranscript) {
+                    stateIcon = (
+                        <Mic className="size-4 text-muted-foreground" />
+                    );
+                    stateLabel = "Audio only";
+                } else if (!r.hasSummary) {
+                    stateIcon = (
+                        <FileText className="size-4 text-foreground/70" />
+                    );
+                    stateLabel = "Transcribed";
+                } else {
+                    stateIcon = <Sparkles className="size-4 text-primary" />;
+                    stateLabel = "Transcribed & summarized";
+                }
+
+                // Null/undefined check -- a 0 ms duration is real (treat
+                // as "0:00") and should still render.
+                const durationText =
+                    r.duration != null ? formatDurationMs(r.duration) : null;
+                const timeText = formatDateTime(r.startTime, dateTimeFormat);
+                const subtitle: ReactNode = snippet
+                    ? snippet
+                    : durationText
+                      ? `${durationText} · ${timeText}`
+                      : timeText;
+
+                // Search value bakes in transcript text so cmdk's fuzzy
+                // matcher finds recordings by content, not just filename.
+                const searchValue = [r.filename, r.id, snippet ?? ""].join(" ");
+
+                let accessory: ReactNode = null;
+                if (inFlight === "transcribing") {
+                    accessory = (
+                        <span className="cmd-pill">
+                            <Loader2 className="size-3 animate-spin" />
+                            Transcribing
+                        </span>
+                    );
+                } else if (inFlight === "summarizing") {
+                    accessory = (
+                        <span className="cmd-pill">
+                            <Loader2 className="size-3 animate-spin" />
+                            Summarizing
+                        </span>
+                    );
+                } else if (!r.hasTranscript) {
+                    // Inline quick action: kicks off transcription
+                    // without changing the current selection.
+                    // stopPropagation on both pointerdown and click is
+                    // intentional -- cmdk treats a pointerdown anywhere
+                    // inside an item as selection intent, which would
+                    // fire the row's "open recording" handler too.
+                    // We don't close the palette after click so the user
+                    // can queue several transcribes in succession; the
+                    // row's accessory flips to "Transcribing" the moment
+                    // markAction lands.
+                    accessory = (
+                        <button
+                            type="button"
+                            className="cmd-row-action"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onTranscribeRecording(r.id);
+                            }}
+                            aria-label={`Transcribe ${r.filename}`}
+                        >
+                            <Sparkles className="size-3" aria-hidden="true" />
+                            Transcribe
+                        </button>
+                    );
+                } else if (isCurrent) {
+                    accessory = (
+                        <span className="cmd-pill">
+                            <span
+                                aria-hidden="true"
+                                className="inline-block size-1.5 rounded-full bg-primary"
+                            />
+                            Selected
+                        </span>
+                    );
+                }
+                // No fallback accessory -- "healthy rows are silent."
+
+                return (
+                    <Command.Item
+                        key={r.id}
+                        value={searchValue}
+                        onSelect={runAction(() => onSelectRecording(r))}
+                    >
+                        <Row
+                            icon={
+                                <span title={stateLabel} aria-hidden="true">
+                                    {stateIcon}
+                                </span>
+                            }
+                            title={r.filename}
+                            subtitle={subtitle}
+                            accessory={accessory}
+                        />
+                    </Command.Item>
+                );
+            })}
+            {overflowCount > 0 && (
+                <div className="cmd-more-hint">
+                    +{overflowCount} more · refine your search to narrow the
+                    list
+                </div>
+            )}
+        </Command.Group>
+    );
+}
+
+/**
+ * Static actions group (sync / upload / settings / shortcuts).
+ * runAction wraps each handler so the palette closes before the
+ * action runs.
+ */
+export function ActionsGroup({
+    onSync,
+    onUpload,
+    onOpenSettings,
+    onOpenShortcuts,
+    runAction,
+}: {
+    onSync: () => void;
+    onUpload: () => void;
+    onOpenSettings: () => void;
+    onOpenShortcuts: () => void;
+    runAction: (fn: () => void) => () => void;
+}) {
+    return (
+        <Command.Group heading="Actions">
+            <Command.Item onSelect={runAction(onSync)}>
+                <Row
+                    icon={
+                        <RefreshCw className="size-4 text-muted-foreground" />
+                    }
+                    title="Sync device"
+                />
+            </Command.Item>
+            <Command.Item onSelect={runAction(onUpload)}>
+                <Row
+                    icon={<Upload className="size-4 text-muted-foreground" />}
+                    title="Upload audio"
+                />
+            </Command.Item>
+            <Command.Item onSelect={runAction(onOpenSettings)}>
+                <Row
+                    icon={<Settings className="size-4 text-muted-foreground" />}
+                    title="Open settings"
+                    accessory={<Kbd>,</Kbd>}
+                />
+            </Command.Item>
+            <Command.Item onSelect={runAction(onOpenShortcuts)}>
+                <Row
+                    icon={<Keyboard className="size-4 text-muted-foreground" />}
+                    title="Keyboard shortcuts"
+                    accessory={<Kbd>?</Kbd>}
+                />
+            </Command.Item>
+        </Command.Group>
+    );
+}
+
+/**
+ * Theme picker group. Active theme is shown via an "Active" accessory
+ * pill, matching the rest of the palette's selected-state convention.
+ */
+export function ThemeGroup({
+    currentTheme,
+    onSetTheme,
+    runAction,
+}: {
+    currentTheme: "light" | "dark" | "system";
+    onSetTheme: (t: "light" | "dark" | "system") => void;
+    runAction: (fn: () => void) => () => void;
+}) {
+    return (
+        <Command.Group heading="Theme">
+            <Command.Item onSelect={runAction(() => onSetTheme("light"))}>
+                <Row
+                    icon={<Sun className="size-4 text-muted-foreground" />}
+                    title="Light"
+                    accessory={
+                        currentTheme === "light" ? (
+                            <span className="cmd-pill">Active</span>
+                        ) : null
+                    }
+                />
+            </Command.Item>
+            <Command.Item onSelect={runAction(() => onSetTheme("dark"))}>
+                <Row
+                    icon={<Moon className="size-4 text-muted-foreground" />}
+                    title="Dark"
+                    accessory={
+                        currentTheme === "dark" ? (
+                            <span className="cmd-pill">Active</span>
+                        ) : null
+                    }
+                />
+            </Command.Item>
+            <Command.Item onSelect={runAction(() => onSetTheme("system"))}>
+                <Row
+                    icon={<Monitor className="size-4 text-muted-foreground" />}
+                    title="Auto"
+                    accessory={
+                        currentTheme === "system" ? (
+                            <span className="cmd-pill">Active</span>
+                        ) : null
+                    }
+                />
+            </Command.Item>
+        </Command.Group>
+    );
+}
+
+/**
+ * Footer keyboard hints. Only renders the transcribe hint when at
+ * least one row in the palette would respond to it -- otherwise it's
+ * noise.
+ */
+export function PaletteFooter({
+    showTranscribeHint,
+}: {
+    showTranscribeHint: boolean;
+}) {
+    return (
+        <div className="cmd-footer">
+            <div className="cmd-footer-group">
+                <span className="cmd-footer-hint">
+                    <Kbd>↑</Kbd>
+                    <Kbd>↓</Kbd>
+                    navigate
+                </span>
+                <span className="cmd-footer-hint">
+                    <Kbd>↵</Kbd>
+                    select
+                </span>
+                <span className="cmd-footer-hint">
+                    <Kbd>esc</Kbd>
+                    close
+                </span>
+                {showTranscribeHint && (
+                    <span className="cmd-footer-hint">
+                        <Kbd>⌘</Kbd>
+                        <Kbd>↵</Kbd>
+                        transcribe
+                    </span>
+                )}
+            </div>
+            <span className="cmd-footer-hint">
+                <Kbd>⌘K</Kbd>
+                toggle
+            </span>
+        </div>
+    );
+}

--- a/src/components/dashboard/command-palette.tsx
+++ b/src/components/dashboard/command-palette.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import { Command } from "cmdk";
+import { Search } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 import {
-    FileText,
-    Keyboard,
-    Loader2,
-    Mic,
-    Monitor,
-    Moon,
-    RefreshCw,
-    Search,
-    Settings,
-    Sparkles,
-    Sun,
-    Upload,
-} from "lucide-react";
-import { type ReactNode, useMemo, useRef, useState } from "react";
+    ActionsGroup,
+    Kbd,
+    PaletteFooter,
+    RECORDING_CAP,
+    RecordingsGroup,
+    ThemeGroup,
+    transcriptSnippet,
+} from "@/components/dashboard/command-palette-parts";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { type DateTimeFormat, formatDateTime } from "@/lib/format-date";
-import { formatDurationMs } from "@/lib/format-duration";
+import type { DateTimeFormat } from "@/lib/format-date";
 import type { Recording } from "@/types/recording";
 import "@/components/dashboard/command-palette.css";
 
@@ -45,69 +40,6 @@ interface CommandPaletteProps {
     onTranscribeRecording: (id: string) => void;
 }
 
-const RECORDING_CAP = 200;
-
-/**
- * Strip transcript noise (timecodes, speaker labels, redundant
- * whitespace) into a single-line snippet usable as both a row
- * subtitle and a fuzzy-search target. Kept in sync with the helper
- * of the same name in `recording-list.tsx`; we duplicate rather
- * than import-cross because the list's helper is module-local
- * there and we don't want to widen its surface for one caller.
- */
-function transcriptSnippet(
-    text: string | undefined,
-    maxChars = 140,
-): string | null {
-    if (!text) return null;
-    const stripped = text
-        .replace(/\[[^\]]+\]/g, " ")
-        .replace(/\b\d{1,2}:\d{2}(:\d{2})?\b/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-    if (!stripped) return null;
-    if (stripped.length <= maxChars) return stripped;
-    return `${stripped.slice(0, maxChars - 1).trimEnd()}\u2026`;
-}
-
-/**
- * Generic two-line row used by every cmdk item in the palette so
- * icon weight, alignment, and accessory placement stay consistent
- * across groups (recordings, actions, theme).
- */
-function Row({
-    icon,
-    title,
-    subtitle,
-    accessory,
-}: {
-    icon: ReactNode;
-    title: ReactNode;
-    subtitle?: ReactNode;
-    accessory?: ReactNode;
-}) {
-    return (
-        <>
-            <span aria-hidden="true" className="shrink-0">
-                {icon}
-            </span>
-            <span className="cmd-body">
-                <span className="cmd-title">{title}</span>
-                {subtitle ? (
-                    <span className="cmd-subtitle">{subtitle}</span>
-                ) : null}
-            </span>
-            {accessory ? (
-                <span className="cmd-accessory">{accessory}</span>
-            ) : null}
-        </>
-    );
-}
-
-function Kbd({ children }: { children: ReactNode }) {
-    return <kbd className="cmd-kbd">{children}</kbd>;
-}
-
 export function CommandPalette({
     open,
     onOpenChange,
@@ -129,13 +61,12 @@ export function CommandPalette({
     // action runs on the next tick. Without the defer, dialogs the
     // action opens (settings, shortcuts) race the palette's own
     // close transition and end up stacked or fail to mount.
-    const run = (fn: () => void) => () => {
+    const runAction = (fn: () => void) => () => {
         onOpenChange(false);
         setTimeout(fn, 0);
     };
 
     const visibleRecordings = recordings.slice(0, RECORDING_CAP);
-    const overflowCount = Math.max(0, recordings.length - RECORDING_CAP);
 
     // Controlled `value` on the cmdk root lets us look up the
     // currently-highlighted item when the user fires a global
@@ -205,7 +136,6 @@ export function CommandPalette({
                     onValueChange={setActiveValue}
                     onKeyDownCapture={handleKeyDownCapture}
                 >
-                    {/* Input row */}
                     <div className="cmd-input-row">
                         <Search
                             className="cmd-input-icon size-4"
@@ -223,356 +153,35 @@ export function CommandPalette({
                             </div>
                         </Command.Empty>
 
-                        {/* Recordings */}
-                        {visibleRecordings.length > 0 && (
-                            <Command.Group heading="Recent">
-                                {visibleRecordings.map((r) => {
-                                    const snippet = transcriptSnippet(
-                                        transcriptions.get(r.id)?.text,
-                                    );
-                                    const inFlight = inFlightActions.get(r.id);
-                                    const isCurrent =
-                                        currentRecording?.id === r.id;
+                        <RecordingsGroup
+                            recordings={visibleRecordings}
+                            transcriptions={transcriptions}
+                            currentRecording={currentRecording}
+                            inFlightActions={inFlightActions}
+                            dateTimeFormat={dateTimeFormat}
+                            onSelectRecording={onSelectRecording}
+                            onTranscribeRecording={onTranscribeRecording}
+                            runAction={runAction}
+                        />
 
-                                    // Leading icon doubles as a state
-                                    // indicator so the user can scan the
-                                    // list and immediately tell which
-                                    // recordings are audio-only, which
-                                    // have a transcript, and which are
-                                    // fully processed (transcript +
-                                    // summary). In-flight wins because
-                                    // it's the most actionable state
-                                    // ("don't trigger this again").
-                                    let stateIcon: ReactNode;
-                                    let stateLabel: string;
-                                    if (inFlight) {
-                                        stateIcon = (
-                                            <Loader2 className="size-4 animate-spin text-primary" />
-                                        );
-                                        stateLabel =
-                                            inFlight === "transcribing"
-                                                ? "Transcribing"
-                                                : "Summarizing";
-                                    } else if (!r.hasTranscript) {
-                                        stateIcon = (
-                                            <Mic className="size-4 text-muted-foreground" />
-                                        );
-                                        stateLabel = "Audio only";
-                                    } else if (!r.hasSummary) {
-                                        stateIcon = (
-                                            <FileText className="size-4 text-foreground/70" />
-                                        );
-                                        stateLabel = "Transcribed";
-                                    } else {
-                                        stateIcon = (
-                                            <Sparkles className="size-4 text-primary" />
-                                        );
-                                        stateLabel = "Transcribed & summarized";
-                                    }
+                        <ActionsGroup
+                            onSync={onSync}
+                            onUpload={onUpload}
+                            onOpenSettings={onOpenSettings}
+                            onOpenShortcuts={onOpenShortcuts}
+                            runAction={runAction}
+                        />
 
-                                    // Subtitle mirrors the recording
-                                    // list's second-line treatment so the
-                                    // two surfaces feel like the same
-                                    // app: transcript snippet when one
-                                    // exists, else `duration · time` using
-                                    // the user's selected date format.
-                                    // The state (audio-only / transcribed
-                                    // / processed) is conveyed by the
-                                    // leading icon — no text duplication.
-                                    // Null/undefined check — a 0 ms
-                                    // duration is a real value (treat as
-                                    // "0:00") and should still render so
-                                    // the user can see the recording is
-                                    // tracked even if it failed to record.
-                                    const durationText =
-                                        r.duration != null
-                                            ? formatDurationMs(r.duration)
-                                            : null;
-                                    const timeText = formatDateTime(
-                                        r.startTime,
-                                        dateTimeFormat,
-                                    );
-                                    // Subtitle is rendered raw — the CSS shrink chain
-                                    // (cmdk-item / .cmd-body / .cmd-subtitle, all with
-                                    // `min-width: 0`) plus `text-overflow: ellipsis`
-                                    // truncates to whatever the row can fit, regardless
-                                    // of viewport width or string length.
-                                    const subtitle: ReactNode = snippet
-                                        ? snippet
-                                        : durationText
-                                          ? `${durationText} · ${timeText}`
-                                          : timeText;
-
-                                    // Search value bakes in transcript text
-                                    // so cmdk's fuzzy matcher finds
-                                    // recordings by their content, not just
-                                    // their filename.
-                                    const searchValue = [
-                                        r.filename,
-                                        r.id,
-                                        snippet ?? "",
-                                    ].join(" ");
-
-                                    let accessory: ReactNode = null;
-                                    if (inFlight === "transcribing") {
-                                        accessory = (
-                                            <span className="cmd-pill">
-                                                <Loader2 className="size-3 animate-spin" />
-                                                Transcribing
-                                            </span>
-                                        );
-                                    } else if (inFlight === "summarizing") {
-                                        accessory = (
-                                            <span className="cmd-pill">
-                                                <Loader2 className="size-3 animate-spin" />
-                                                Summarizing
-                                            </span>
-                                        );
-                                    } else if (!r.hasTranscript) {
-                                        // Inline quick action: kicks off
-                                        // transcription without changing
-                                        // the current selection. The
-                                        // `stopPropagation` calls on both
-                                        // pointerdown and click are
-                                        // intentional — cmdk treats a
-                                        // pointerdown anywhere inside an
-                                        // item as selection intent, which
-                                        // would otherwise fire the row's
-                                        // "open recording" handler in
-                                        // addition to (or before) the
-                                        // button's own onClick.
-                                        // Quick action: fires the
-                                        // transcribe request without
-                                        // closing the palette. The user
-                                        // typically wants to queue several
-                                        // in a row; closing the palette
-                                        // after each click would force a
-                                        // ⌘K reopen between actions. The
-                                        // row's accessory flips to a
-                                        // "Transcribing" pill once
-                                        // markAction lands, so the user
-                                        // gets immediate feedback without
-                                        // a visual mode switch.
-                                        accessory = (
-                                            <button
-                                                type="button"
-                                                className="cmd-row-action"
-                                                onPointerDown={(e) =>
-                                                    e.stopPropagation()
-                                                }
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    onTranscribeRecording(r.id);
-                                                }}
-                                                aria-label={`Transcribe ${r.filename}`}
-                                            >
-                                                <Sparkles
-                                                    className="size-3"
-                                                    aria-hidden="true"
-                                                />
-                                                Transcribe
-                                            </button>
-                                        );
-                                    } else if (isCurrent) {
-                                        // Lower priority than the
-                                        // Transcribe quick-action: a
-                                        // recording without a transcript
-                                        // still benefits from the button
-                                        // even when it happens to be the
-                                        // currently selected row. cmdk's
-                                        // own `data-selected` highlight
-                                        // already conveys "this is the
-                                        // active row" visually.
-                                        accessory = (
-                                            <span className="cmd-pill">
-                                                <span
-                                                    aria-hidden="true"
-                                                    className="inline-block size-1.5 rounded-full bg-primary"
-                                                />
-                                                Selected
-                                            </span>
-                                        );
-                                    }
-                                    // No fallback accessory — the list's
-                                    // "healthy rows are silent" convention
-                                    // applies here too. Duration already
-                                    // lives in the subtitle now, so a
-                                    // duration accessory would duplicate.
-
-                                    return (
-                                        <Command.Item
-                                            key={r.id}
-                                            value={searchValue}
-                                            onSelect={run(() =>
-                                                onSelectRecording(r),
-                                            )}
-                                        >
-                                            <Row
-                                                /* Truncated for layout
-                                                   safety; the full
-                                                   filename is still in
-                                                   `searchValue` so cmdk's
-                                                   fuzzy matcher hits it. */
-                                                icon={
-                                                    // Icon is decorative;
-                                                    // the state is also in
-                                                    // the subtitle ("Audio
-                                                    // only · …") so screen
-                                                    // readers don't miss it.
-                                                    // `title` gives sighted
-                                                    // users a hover tooltip.
-                                                    <span
-                                                        title={stateLabel}
-                                                        aria-hidden="true"
-                                                    >
-                                                        {stateIcon}
-                                                    </span>
-                                                }
-                                                title={r.filename}
-                                                subtitle={subtitle}
-                                                accessory={accessory}
-                                            />
-                                        </Command.Item>
-                                    );
-                                })}
-                                {overflowCount > 0 && (
-                                    <div className="cmd-more-hint">
-                                        +{overflowCount} more · refine your
-                                        search to narrow the list
-                                    </div>
-                                )}
-                            </Command.Group>
-                        )}
-
-                        {/* Actions */}
-                        <Command.Group heading="Actions">
-                            <Command.Item onSelect={run(onSync)}>
-                                <Row
-                                    icon={
-                                        <RefreshCw className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Sync device"
-                                />
-                            </Command.Item>
-                            <Command.Item onSelect={run(onUpload)}>
-                                <Row
-                                    icon={
-                                        <Upload className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Upload audio"
-                                />
-                            </Command.Item>
-                            <Command.Item onSelect={run(onOpenSettings)}>
-                                <Row
-                                    icon={
-                                        <Settings className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Open settings"
-                                    accessory={<Kbd>,</Kbd>}
-                                />
-                            </Command.Item>
-                            <Command.Item onSelect={run(onOpenShortcuts)}>
-                                <Row
-                                    icon={
-                                        <Keyboard className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Keyboard shortcuts"
-                                    accessory={<Kbd>?</Kbd>}
-                                />
-                            </Command.Item>
-                        </Command.Group>
-
-                        {/* Theme */}
-                        <Command.Group heading="Theme">
-                            <Command.Item
-                                onSelect={run(() => onSetTheme("light"))}
-                            >
-                                <Row
-                                    icon={
-                                        <Sun className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Light"
-                                    accessory={
-                                        currentTheme === "light" ? (
-                                            <span className="cmd-pill">
-                                                Active
-                                            </span>
-                                        ) : null
-                                    }
-                                />
-                            </Command.Item>
-                            <Command.Item
-                                onSelect={run(() => onSetTheme("dark"))}
-                            >
-                                <Row
-                                    icon={
-                                        <Moon className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Dark"
-                                    accessory={
-                                        currentTheme === "dark" ? (
-                                            <span className="cmd-pill">
-                                                Active
-                                            </span>
-                                        ) : null
-                                    }
-                                />
-                            </Command.Item>
-                            <Command.Item
-                                onSelect={run(() => onSetTheme("system"))}
-                            >
-                                <Row
-                                    icon={
-                                        <Monitor className="size-4 text-muted-foreground" />
-                                    }
-                                    title="Auto"
-                                    accessory={
-                                        currentTheme === "system" ? (
-                                            <span className="cmd-pill">
-                                                Active
-                                            </span>
-                                        ) : null
-                                    }
-                                />
-                            </Command.Item>
-                        </Command.Group>
+                        <ThemeGroup
+                            currentTheme={currentTheme}
+                            onSetTheme={onSetTheme}
+                            runAction={runAction}
+                        />
                     </Command.List>
 
-                    {/* Footer hints */}
-                    <div className="cmd-footer">
-                        <div className="cmd-footer-group">
-                            <span className="cmd-footer-hint">
-                                <Kbd>↑</Kbd>
-                                <Kbd>↓</Kbd>
-                                navigate
-                            </span>
-                            <span className="cmd-footer-hint">
-                                <Kbd>↵</Kbd>
-                                select
-                            </span>
-                            <span className="cmd-footer-hint">
-                                <Kbd>esc</Kbd>
-                                close
-                            </span>
-                            {/*
-                              Only surface the ⌘↵ hint when there's at
-                              least one row that would respond to it.
-                              Otherwise it's noise: users see a keyboard
-                              promise the palette can't keep on this view.
-                            */}
-                            {transcribeTargets.size > 0 && (
-                                <span className="cmd-footer-hint">
-                                    <Kbd>⌘</Kbd>
-                                    <Kbd>↵</Kbd>
-                                    transcribe
-                                </span>
-                            )}
-                        </div>
-                        <span className="cmd-footer-hint">
-                            <Kbd>⌘K</Kbd>
-                            toggle
-                        </span>
-                    </div>
+                    <PaletteFooter
+                        showTranscribeHint={transcribeTargets.size > 0}
+                    />
                 </Command>
             </DialogContent>
         </Dialog>

--- a/src/components/dashboard/recording-list.tsx
+++ b/src/components/dashboard/recording-list.tsx
@@ -11,8 +11,8 @@ import {
     Trash2,
     X,
 } from "lucide-react";
+import type * as React from "react";
 import {
-    forwardRef,
     useCallback,
     useEffect,
     useImperativeHandle,
@@ -116,25 +116,20 @@ function transcriptSnippet(
     return `${stripped.slice(0, maxChars - 1).trimEnd()}\u2026`;
 }
 
-export const RecordingList = forwardRef<
-    RecordingListHandle,
-    RecordingListProps
->(function RecordingList(
-    {
-        recordings,
-        transcriptions,
-        currentRecording,
-        pendingUploads,
-        inFlightActions,
-        onSelect,
-        onDelete,
-        initialDateTimeFormat,
-        initialSortOrder,
-        initialDensity,
-        initialChunkSize,
-    },
+export function RecordingList({
+    recordings,
+    transcriptions,
+    currentRecording,
+    pendingUploads,
+    inFlightActions,
+    onSelect,
+    onDelete,
+    initialDateTimeFormat,
+    initialSortOrder,
+    initialDensity,
+    initialChunkSize,
     ref,
-) {
+}: RecordingListProps & { ref?: React.Ref<RecordingListHandle> }) {
     const [dateTimeFormat] = useState<DateTimeFormat>(initialDateTimeFormat);
     const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder);
     const [density, setDensity] = useState<ListDensity>(initialDensity);
@@ -727,4 +722,4 @@ export const RecordingList = forwardRef<
             </CardContent>
         </Card>
     );
-});
+}

--- a/src/components/dashboard/recording-player-controls.tsx
+++ b/src/components/dashboard/recording-player-controls.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { Pause, Play, Volume2, VolumeX } from "lucide-react";
+import { Waveform } from "@/components/dashboard/waveform";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { PLAYBACK_SPEED_OPTIONS } from "@/hooks/use-playback-engine";
+import { formatTimeLike } from "@/lib/format-duration";
+
+interface Props {
+    isPlaying: boolean;
+    onTogglePlay: () => void;
+    currentTime: number;
+    duration: number;
+    onSeekRatio: (ratio: number) => void;
+    playbackSpeed: number;
+    onCycleSpeed: () => void;
+    volume: number;
+    onVolumeChange: (volume: number) => void;
+    onToggleMute: () => void;
+    scrubberStyle: "waveform" | "slider";
+    waveformPeaks: number[] | null;
+}
+
+/**
+ * Controls row for the recording player: play/pause, time label,
+ * scrubber (waveform when peaks are decoded, slider otherwise), speed
+ * cycle button, and volume slider with a mute toggle.
+ *
+ * Pure presentation -- all state lives in usePlaybackEngine, and the
+ * parent wires this component's callbacks to that hook's handlers.
+ */
+export function RecordingPlayerControls({
+    isPlaying,
+    onTogglePlay,
+    currentTime,
+    duration,
+    onSeekRatio,
+    playbackSpeed,
+    onCycleSpeed,
+    volume,
+    onVolumeChange,
+    onToggleMute,
+    scrubberStyle,
+    waveformPeaks,
+}: Props) {
+    const seekDisabled = !duration || duration === 0;
+    const seekRatio = duration > 0 ? currentTime / duration : 0;
+    const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+    const speedLabel =
+        PLAYBACK_SPEED_OPTIONS.find((opt) => opt.value === playbackSpeed)
+            ?.label || "1x";
+    const speakerIcon =
+        volume === 0 ? (
+            <VolumeX className="size-4" />
+        ) : (
+            <Volume2 className="size-4" />
+        );
+
+    return (
+        <div className="flex items-center gap-4">
+            <Button
+                onClick={onTogglePlay}
+                size="lg"
+                aria-label={isPlaying ? "Pause" : "Play"}
+                className="size-12 shrink-0 rounded-full"
+            >
+                {isPlaying ? (
+                    <Pause className="size-5" />
+                ) : (
+                    <Play className="size-5" />
+                )}
+            </Button>
+
+            {/*
+              Fixed-width time label, monospace + tabular-nums so digit
+              width is stable, and `formatTimeLike` pads currentTime to
+              match duration's segment structure so the whole
+              `M:SS / H:MM:SS` line never resizes mid-playback. Sits
+              next to play so the eye can pair them without scanning.
+            */}
+            <span
+                className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground"
+                aria-live="off"
+            >
+                <span className="text-foreground">
+                    {formatTimeLike(currentTime, duration)}
+                </span>
+                <span className="mx-1 opacity-40">/</span>
+                <span>{formatTimeLike(duration, duration)}</span>
+            </span>
+
+            {/*
+              Waveform takes whatever's left, with min-w-0 so flex
+              doesn't expand the parent when bars are dense.
+            */}
+            <div className="min-w-0 flex-1">
+                {scrubberStyle === "waveform" && waveformPeaks ? (
+                    <Waveform
+                        peaks={waveformPeaks}
+                        progress={seekRatio}
+                        durationSeconds={duration}
+                        onSeek={onSeekRatio}
+                        disabled={seekDisabled}
+                        height={56}
+                    />
+                ) : (
+                    <Slider
+                        value={[progress]}
+                        onValueChange={(value) =>
+                            onSeekRatio((value[0] ?? 0) / 100)
+                        }
+                        onValueCommit={(value) =>
+                            onSeekRatio((value[0] ?? 0) / 100)
+                        }
+                        max={100}
+                        step={0.1}
+                        className="w-full"
+                        disabled={seekDisabled}
+                    />
+                )}
+            </div>
+
+            <Button
+                onClick={onCycleSpeed}
+                variant="outline"
+                size="sm"
+                className="h-8 w-12 shrink-0 px-0 font-mono text-xs tabular-nums"
+                title="Click to cycle playback speed"
+                aria-label={`Playback speed ${speedLabel}. Click to change.`}
+            >
+                {speedLabel}
+            </Button>
+
+            <div className="flex shrink-0 items-center gap-2">
+                <button
+                    type="button"
+                    onClick={onToggleMute}
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label={volume === 0 ? "Unmute" : "Mute"}
+                    title={volume === 0 ? "Unmute" : "Mute"}
+                >
+                    {speakerIcon}
+                </button>
+                <Slider
+                    value={[volume]}
+                    onValueChange={(value) => onVolumeChange(value[0] ?? 75)}
+                    max={100}
+                    className="w-20"
+                    aria-label="Volume"
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/recording-player-header.tsx
+++ b/src/components/dashboard/recording-player-header.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { AudioWaveform, Loader2 } from "lucide-react";
+import { CardHeader, CardTitle } from "@/components/ui/card";
+import { formatBytes } from "@/lib/format-bytes";
+import { formatDateTime } from "@/lib/format-date";
+import { formatDuration } from "@/lib/format-duration";
+import type { Recording } from "@/types/recording";
+
+interface Props {
+    recording: Recording;
+    /** Resolved playback duration in seconds (0 when not yet loaded). */
+    duration: number;
+    scrubberStyle: "waveform" | "slider";
+    waveformStatus: "idle" | "ready" | "decoding" | "skipped" | "error";
+    onDecodeWaveform: () => void;
+}
+
+/**
+ * Title + compact metadata row + waveform-status footer for the
+ * RecordingPlayer card. Lifted out so the parent's render reads as
+ * "header + controls + audio element" instead of a 100-line JSX block.
+ *
+ * The metadata order is information-density-first: when (relative
+ * date), then how long (duration), then how big (file size). Falls
+ * back to recording.duration / 1000 before the audio element reports
+ * a real duration so the line doesn't flicker on first paint.
+ */
+export function RecordingPlayerHeader({
+    recording,
+    duration,
+    scrubberStyle,
+    waveformStatus,
+    onDecodeWaveform,
+}: Props) {
+    const metaParts: string[] = [
+        formatDateTime(recording.startTime, "relative"),
+        formatDuration(duration || recording.duration / 1000),
+        formatBytes(recording.filesize),
+    ];
+
+    return (
+        <CardHeader className="gap-1">
+            <CardTitle className="truncate text-lg">
+                {recording.filename}
+            </CardTitle>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                {metaParts.map((part, i) => (
+                    <span key={part} className="inline-flex items-center gap-2">
+                        {i > 0 && (
+                            <span aria-hidden="true" className="opacity-40">
+                                ·
+                            </span>
+                        )}
+                        <span>{part}</span>
+                    </span>
+                ))}
+                {scrubberStyle === "waveform" &&
+                    waveformStatus === "decoding" && (
+                        <span className="inline-flex items-center gap-1">
+                            <span aria-hidden="true" className="opacity-40">
+                                ·
+                            </span>
+                            <Loader2 className="size-3 animate-spin" />
+                            Analyzing audio…
+                        </span>
+                    )}
+                {scrubberStyle === "waveform" &&
+                    waveformStatus === "skipped" && (
+                        <button
+                            type="button"
+                            onClick={onDecodeWaveform}
+                            className="inline-flex items-center gap-1 underline-offset-2 hover:text-foreground hover:underline"
+                            title="Decode waveform in your browser (may take a few seconds)"
+                        >
+                            <span aria-hidden="true" className="opacity-40">
+                                ·
+                            </span>
+                            <AudioWaveform className="size-3" />
+                            Generate waveform
+                        </button>
+                    )}
+                {scrubberStyle === "waveform" && waveformStatus === "error" && (
+                    <button
+                        type="button"
+                        onClick={onDecodeWaveform}
+                        className="inline-flex items-center gap-1 text-destructive underline-offset-2 hover:underline"
+                    >
+                        <span aria-hidden="true" className="opacity-40">
+                            ·
+                        </span>
+                        <AudioWaveform className="size-3" />
+                        Retry waveform
+                    </button>
+                )}
+            </div>
+        </CardHeader>
+    );
+}

--- a/src/components/dashboard/recording-player.tsx
+++ b/src/components/dashboard/recording-player.tsx
@@ -385,7 +385,7 @@ export function RecordingPlayer({
                         onClick={togglePlayPause}
                         size="lg"
                         aria-label={isPlaying ? "Pause" : "Play"}
-                        className="h-12 w-12 shrink-0 rounded-full"
+                        className="size-12 shrink-0 rounded-full"
                     >
                         {isPlaying ? (
                             <Pause className="size-5" />

--- a/src/components/dashboard/recording-player.tsx
+++ b/src/components/dashboard/recording-player.tsx
@@ -1,23 +1,11 @@
 "use client";
 
-import {
-    AudioWaveform,
-    Loader2,
-    Pause,
-    Play,
-    Volume2,
-    VolumeX,
-} from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import { Waveform } from "@/components/dashboard/waveform";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Slider } from "@/components/ui/slider";
+import { RecordingPlayerControls } from "@/components/dashboard/recording-player-controls";
+import { RecordingPlayerHeader } from "@/components/dashboard/recording-player-header";
+import { Card, CardContent } from "@/components/ui/card";
+import { usePlaybackEngine } from "@/hooks/use-playback-engine";
+import { usePlaybackKeyboard } from "@/hooks/use-playback-keyboard";
 import { useWaveform } from "@/hooks/use-waveform";
-import { formatBytes } from "@/lib/format-bytes";
-import { formatDateTime } from "@/lib/format-date";
-import { formatDuration, formatTimeLike } from "@/lib/format-duration";
 import type { Recording } from "@/types/recording";
 
 interface RecordingPlayerProps {
@@ -35,15 +23,13 @@ interface RecordingPlayerProps {
     scrubberStyle?: "waveform" | "slider";
 }
 
-const playbackSpeedOptions = [
-    { label: "0.5x", value: 0.5 },
-    { label: "0.75x", value: 0.75 },
-    { label: "1x", value: 1.0 },
-    { label: "1.25x", value: 1.25 },
-    { label: "1.5x", value: 1.5 },
-    { label: "2x", value: 2.0 },
-];
-
+/**
+ * Audio playback card for a single recording. State is owned by
+ * usePlaybackEngine (audio element + transport state); keyboard
+ * shortcuts by usePlaybackKeyboard; waveform peaks by useWaveform.
+ * This component is the composition root + the hidden <audio>
+ * element that the engine writes to.
+ */
 export function RecordingPlayer({
     recording,
     onEnded,
@@ -52,191 +38,39 @@ export function RecordingPlayer({
     initialAutoPlayNext = false,
     scrubberStyle = "waveform",
 }: RecordingPlayerProps) {
-    const [isPlaying, setIsPlaying] = useState(false);
-    const [currentTime, setCurrentTime] = useState(0);
-    const [duration, setDuration] = useState(0);
-    const [volume, setVolume] = useState(initialVolume);
-    const [playbackSpeed, setPlaybackSpeed] = useState(initialPlaybackSpeed);
-    const [autoPlayNext] = useState(initialAutoPlayNext);
-    const audioRef = useRef<HTMLAudioElement>(null);
-    const isSeekingRef = useRef(false);
+    const {
+        audioRef,
+        isPlaying,
+        currentTime,
+        duration,
+        volume,
+        setVolume,
+        playbackSpeed,
+        togglePlayPause,
+        seekToRatio,
+        seekRelative,
+        cycleSpeed,
+        toggleMute,
+    } = usePlaybackEngine({
+        recording,
+        onEnded,
+        initialPlaybackSpeed,
+        initialVolume,
+        initialAutoPlayNext,
+    });
 
-    useEffect(() => {
-        const recordingId = recording.id; // Explicitly use recording to satisfy linter
-        setCurrentTime(0);
-        setDuration(0);
-        setIsPlaying(false);
-        if (audioRef.current) {
-            audioRef.current.currentTime = 0;
-        }
-        if (audioRef.current) {
-            audioRef.current.src = `/api/recordings/${recordingId}/audio`;
-            audioRef.current.load();
-        }
-    }, [recording]);
+    usePlaybackKeyboard({
+        onToggle: togglePlayPause,
+        onSeekRelative: seekRelative,
+        onVolumeDelta: (delta) =>
+            setVolume((prev) => Math.max(0, Math.min(100, prev + delta))),
+    });
 
-    useEffect(() => {
-        if (audioRef.current) {
-            audioRef.current.volume = volume / 100;
-        }
-    }, [volume]);
-
-    useEffect(() => {
-        if (audioRef.current) {
-            audioRef.current.playbackRate = playbackSpeed;
-        }
-    }, [playbackSpeed]);
-
-    useEffect(() => {
-        if (!audioRef.current) return;
-
-        const audio = audioRef.current;
-        const recordingId = recording.id; // Explicitly use recording to satisfy linter
-
-        const updateTime = () => {
-            if (!isSeekingRef.current) {
-                setCurrentTime(audio.currentTime);
-            }
-        };
-        const updateDuration = () => {
-            if (audio.duration && !Number.isNaN(audio.duration)) {
-                setDuration(audio.duration);
-            }
-        };
-        const handleEnded = () => {
-            setIsPlaying(false);
-            if (autoPlayNext && onEnded) {
-                onEnded();
-            }
-        };
-        const handleSeeked = () => {
-            isSeekingRef.current = false;
-            setCurrentTime(audio.currentTime);
-        };
-
-        if (audio.src !== `/api/recordings/${recordingId}/audio`) {
-            audio.src = `/api/recordings/${recordingId}/audio`;
-            audio.load();
-        }
-
-        audio.addEventListener("timeupdate", updateTime);
-        audio.addEventListener("loadedmetadata", updateDuration);
-        audio.addEventListener("durationchange", updateDuration);
-        audio.addEventListener("ended", handleEnded);
-        audio.addEventListener("seeked", handleSeeked);
-
-        if (audio.duration && !Number.isNaN(audio.duration)) {
-            setDuration(audio.duration);
-        }
-
-        return () => {
-            audio.removeEventListener("timeupdate", updateTime);
-            audio.removeEventListener("loadedmetadata", updateDuration);
-            audio.removeEventListener("durationchange", updateDuration);
-            audio.removeEventListener("ended", handleEnded);
-            audio.removeEventListener("seeked", handleSeeked);
-        };
-    }, [recording, autoPlayNext, onEnded]);
-
-    const togglePlayPause = useCallback(() => {
-        if (!audioRef.current) return;
-
-        if (isPlaying) {
-            audioRef.current.pause();
-        } else {
-            audioRef.current.playbackRate = playbackSpeed;
-            audioRef.current.play().catch((error) => {
-                console.error("Error playing audio:", error);
-                toast.error("Failed to play audio");
-            });
-        }
-        setIsPlaying(!isPlaying);
-    }, [isPlaying, playbackSpeed]);
-
-    const handleSeek = (value: number[]) => {
-        const audio = audioRef.current;
-        if (!audio) return;
-
-        const percentage = value[0];
-
-        const audioDuration = audio.duration;
-        if (!audioDuration || Number.isNaN(audioDuration)) {
-            audio.load();
-            return;
-        }
-
-        const newTime = (percentage / 100) * audioDuration;
-
-        isSeekingRef.current = true;
-
-        audio.currentTime = newTime;
-
-        setCurrentTime(newTime);
-    };
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            const target = e.target as HTMLElement;
-            if (
-                target.tagName === "INPUT" ||
-                target.tagName === "TEXTAREA" ||
-                target.isContentEditable
-            ) {
-                return;
-            }
-
-            switch (e.key) {
-                case " ": {
-                    e.preventDefault();
-                    togglePlayPause();
-                    break;
-                }
-                case "ArrowLeft": {
-                    e.preventDefault();
-                    if (audioRef.current && duration > 0) {
-                        const newTime = Math.max(0, currentTime - 5);
-                        audioRef.current.currentTime = newTime;
-                        setCurrentTime(newTime);
-                    }
-                    break;
-                }
-                case "ArrowRight": {
-                    e.preventDefault();
-                    if (audioRef.current && duration > 0) {
-                        const newTime = Math.min(duration, currentTime + 5);
-                        audioRef.current.currentTime = newTime;
-                        setCurrentTime(newTime);
-                    }
-                    break;
-                }
-                case "ArrowUp": {
-                    e.preventDefault();
-                    setVolume((prev) => Math.min(100, prev + 5));
-                    break;
-                }
-                case "ArrowDown": {
-                    e.preventDefault();
-                    setVolume((prev) => Math.max(0, prev - 5));
-                    break;
-                }
-            }
-        };
-
-        window.addEventListener("keydown", handleKeyDown);
-        return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [currentTime, duration, togglePlayPause]);
-
-    // Local alias kept so existing JSX reads naturally; the helper
-    // itself lives in @/lib/format-duration and handles the H:MM:SS
-    // switch for recordings longer than an hour.
-    const formatTime = formatDuration;
-
-    const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
-
-    // Waveform peaks: cached server-side if present, decoded client-side
-    // on first listen for recordings under AUTO_DECODE_MAX_MS. Long
-    // recordings show a manual "Generate waveform" button instead so we
-    // don't surprise the user with a multi-hundred-MB decode.
+    // Waveform peaks: cached server-side if present, decoded
+    // client-side on first listen for recordings under
+    // AUTO_DECODE_MAX_MS. Long recordings show a manual "Generate
+    // waveform" button instead so we don't surprise the user with a
+    // multi-hundred-MB decode.
     const {
         peaks: waveformPeaks,
         status: waveformStatus,
@@ -246,226 +80,35 @@ export function RecordingPlayer({
         durationMs: recording.duration,
         initialPeaks: recording.waveformPeaks ?? null,
         // Skip auto-decode entirely when the user has opted out of the
-        // waveform UI — there's no point spending CPU on peaks the
+        // waveform UI -- there's no point spending CPU on peaks the
         // player will never display.
         autoStart: scrubberStyle === "waveform",
     });
 
-    // Seek by waveform click. Receives a [0, 1] ratio; converts to the
-    // same audio.currentTime path as the slider so seeking semantics are
-    // identical regardless of which control the user touches.
-    const handleWaveformSeek = useCallback((ratio: number) => {
-        const audio = audioRef.current;
-        if (!audio) return;
-        const audioDuration = audio.duration;
-        if (!audioDuration || Number.isNaN(audioDuration)) {
-            audio.load();
-            return;
-        }
-        const newTime = Math.max(
-            0,
-            Math.min(audioDuration, ratio * audioDuration),
-        );
-        isSeekingRef.current = true;
-        audio.currentTime = newTime;
-        setCurrentTime(newTime);
-    }, []);
-
-    // Speed cycling: factored out so it can be reused (button + future
-    // command palette action).
-    const cycleSpeed = useCallback(() => {
-        const currentIndex = playbackSpeedOptions.findIndex(
-            (opt) => opt.value === playbackSpeed,
-        );
-        const nextIndex = (currentIndex + 1) % playbackSpeedOptions.length;
-        const nextSpeed = playbackSpeedOptions[nextIndex].value;
-        setPlaybackSpeed(nextSpeed);
-        if (audioRef.current) {
-            audioRef.current.playbackRate = nextSpeed;
-        }
-    }, [playbackSpeed]);
-
-    // Click-to-mute: stash the previous volume so unmute restores it.
-    // A pure 0/75 toggle would be surprising for users who set their
-    // own preferred level.
-    const previousVolumeRef = useRef<number>(volume > 0 ? volume : 75);
-    useEffect(() => {
-        if (volume > 0) previousVolumeRef.current = volume;
-    }, [volume]);
-    const toggleMute = useCallback(() => {
-        setVolume((v) => (v > 0 ? 0 : previousVolumeRef.current || 75));
-    }, []);
-
-    const speedLabel =
-        playbackSpeedOptions.find((opt) => opt.value === playbackSpeed)
-            ?.label || "1x";
-    const speakerIcon =
-        volume === 0 ? (
-            <VolumeX className="size-4" />
-        ) : (
-            <Volume2 className="size-4" />
-        );
-
-    const seekDisabled = !duration || duration === 0;
-    const seekRatio = duration > 0 ? currentTime / duration : 0;
-
-    // Compact metadata line under the title — replaces the redundant
-    // toLocaleString() subtitle. Order is information-density-first:
-    // when (relative), then how long (duration), then how big (size).
-    const metaParts: string[] = [
-        formatDateTime(recording.startTime, "relative"),
-        formatTime(duration || recording.duration / 1000),
-        formatBytes(recording.filesize),
-    ];
-
     return (
         <Card>
-            <CardHeader className="gap-1">
-                <CardTitle className="truncate text-lg">
-                    {recording.filename}
-                </CardTitle>
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                    {metaParts.map((part, i) => (
-                        <span
-                            key={part}
-                            className="inline-flex items-center gap-2"
-                        >
-                            {i > 0 && (
-                                <span aria-hidden="true" className="opacity-40">
-                                    ·
-                                </span>
-                            )}
-                            <span>{part}</span>
-                        </span>
-                    ))}
-                    {scrubberStyle === "waveform" &&
-                        waveformStatus === "decoding" && (
-                            <span className="inline-flex items-center gap-1">
-                                <span aria-hidden="true" className="opacity-40">
-                                    ·
-                                </span>
-                                <Loader2 className="size-3 animate-spin" />
-                                Analyzing audio…
-                            </span>
-                        )}
-                    {scrubberStyle === "waveform" &&
-                        waveformStatus === "skipped" && (
-                            <button
-                                type="button"
-                                onClick={triggerWaveformDecode}
-                                className="inline-flex items-center gap-1 underline-offset-2 hover:text-foreground hover:underline"
-                                title="Decode waveform in your browser (may take a few seconds)"
-                            >
-                                <span aria-hidden="true" className="opacity-40">
-                                    ·
-                                </span>
-                                <AudioWaveform className="size-3" />
-                                Generate waveform
-                            </button>
-                        )}
-                    {scrubberStyle === "waveform" &&
-                        waveformStatus === "error" && (
-                            <button
-                                type="button"
-                                onClick={triggerWaveformDecode}
-                                className="inline-flex items-center gap-1 text-destructive underline-offset-2 hover:underline"
-                            >
-                                <span aria-hidden="true" className="opacity-40">
-                                    ·
-                                </span>
-                                <AudioWaveform className="size-3" />
-                                Retry waveform
-                            </button>
-                        )}
-                </div>
-            </CardHeader>
+            <RecordingPlayerHeader
+                recording={recording}
+                duration={duration}
+                scrubberStyle={scrubberStyle}
+                waveformStatus={waveformStatus}
+                onDecodeWaveform={triggerWaveformDecode}
+            />
             <CardContent>
-                <div className="flex items-center gap-4">
-                    <Button
-                        onClick={togglePlayPause}
-                        size="lg"
-                        aria-label={isPlaying ? "Pause" : "Play"}
-                        className="size-12 shrink-0 rounded-full"
-                    >
-                        {isPlaying ? (
-                            <Pause className="size-5" />
-                        ) : (
-                            <Play className="size-5" />
-                        )}
-                    </Button>
-
-                    {/* Fixed-width time label, monospace + tabular-nums
-                        so digit width is stable, and `formatTimeLike`
-                        pads currentTime to match duration's segment
-                        structure so the whole `M:SS / H:MM:SS` line
-                        never resizes mid-playback. Sits next to play so
-                        the eye can pair them without scanning. */}
-                    <span
-                        className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground"
-                        aria-live="off"
-                    >
-                        <span className="text-foreground">
-                            {formatTimeLike(currentTime, duration)}
-                        </span>
-                        <span className="mx-1 opacity-40">/</span>
-                        <span>{formatTimeLike(duration, duration)}</span>
-                    </span>
-
-                    {/* Waveform takes whatever's left, with min-w-0 so
-                        flex doesn't expand the parent when bars are dense. */}
-                    <div className="min-w-0 flex-1">
-                        {scrubberStyle === "waveform" && waveformPeaks ? (
-                            <Waveform
-                                peaks={waveformPeaks}
-                                progress={seekRatio}
-                                durationSeconds={duration}
-                                onSeek={handleWaveformSeek}
-                                disabled={seekDisabled}
-                                height={56}
-                            />
-                        ) : (
-                            <Slider
-                                value={[progress]}
-                                onValueChange={handleSeek}
-                                onValueCommit={handleSeek}
-                                max={100}
-                                step={0.1}
-                                className="w-full"
-                                disabled={seekDisabled}
-                            />
-                        )}
-                    </div>
-
-                    <Button
-                        onClick={cycleSpeed}
-                        variant="outline"
-                        size="sm"
-                        className="h-8 w-12 shrink-0 px-0 font-mono text-xs tabular-nums"
-                        title="Click to cycle playback speed"
-                        aria-label={`Playback speed ${speedLabel}. Click to change.`}
-                    >
-                        {speedLabel}
-                    </Button>
-
-                    <div className="flex shrink-0 items-center gap-2">
-                        <button
-                            type="button"
-                            onClick={toggleMute}
-                            className="text-muted-foreground transition-colors hover:text-foreground"
-                            aria-label={volume === 0 ? "Unmute" : "Mute"}
-                            title={volume === 0 ? "Unmute" : "Mute"}
-                        >
-                            {speakerIcon}
-                        </button>
-                        <Slider
-                            value={[volume]}
-                            onValueChange={(value) => setVolume(value[0] ?? 75)}
-                            max={100}
-                            className="w-20"
-                            aria-label="Volume"
-                        />
-                    </div>
-                </div>
+                <RecordingPlayerControls
+                    isPlaying={isPlaying}
+                    onTogglePlay={togglePlayPause}
+                    currentTime={currentTime}
+                    duration={duration}
+                    onSeekRatio={seekToRatio}
+                    playbackSpeed={playbackSpeed}
+                    onCycleSpeed={cycleSpeed}
+                    volume={volume}
+                    onVolumeChange={setVolume}
+                    onToggleMute={toggleMute}
+                    scrubberStyle={scrubberStyle}
+                    waveformPeaks={waveformPeaks}
+                />
 
                 <audio
                     ref={audioRef}

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -145,7 +145,7 @@ export function TranscriptionPanel({
                 <CardHeader>
                     <div className="flex items-center justify-between">
                         <CardTitle className="flex items-center gap-2">
-                            <FileText className="w-5 h-5" />
+                            <FileText className="size-5" />
                             Transcription
                         </CardTitle>
                         <div className="flex items-center gap-2">
@@ -156,7 +156,7 @@ export function TranscriptionPanel({
                                     variant="outline"
                                     disabled={isTranscribing}
                                 >
-                                    <RefreshCw className="w-4 h-4 mr-2" />
+                                    <RefreshCw className="size-4 mr-2" />
                                     Re-transcribe
                                 </Button>
                             )}
@@ -166,7 +166,7 @@ export function TranscriptionPanel({
                                     size="sm"
                                     disabled={isTranscribing}
                                 >
-                                    <Sparkles className="w-4 h-4 mr-2" />
+                                    <Sparkles className="size-4 mr-2" />
                                     Transcribe
                                 </Button>
                             )}
@@ -176,9 +176,9 @@ export function TranscriptionPanel({
                 <CardContent>
                     {isTranscribing ? (
                         <div className="flex flex-col items-center justify-center py-12">
-                            <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full mb-4" />
+                            <div className="animate-spin size-8 border-2 border-primary border-t-transparent rounded-full mb-4" />
                             <p className="text-sm text-muted-foreground">
-                                Transcribing audio...
+                                Transcribing audio…
                             </p>
                         </div>
                     ) : transcription?.text ? (
@@ -191,7 +191,7 @@ export function TranscriptionPanel({
                             <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
                                 {transcription.language && (
                                     <div className="flex items-center gap-1">
-                                        <Languages className="w-3 h-3" />
+                                        <Languages className="size-3" />
                                         <span>
                                             Language: {transcription.language}
                                         </span>
@@ -211,7 +211,7 @@ export function TranscriptionPanel({
                         </div>
                     ) : (
                         <div className="flex flex-col items-center justify-center py-10 text-center">
-                            <FileText className="w-10 h-10 text-muted-foreground mb-3" />
+                            <FileText className="size-10 text-muted-foreground mb-3" />
                             <p className="text-sm text-muted-foreground">
                                 No transcription yet — use the Transcribe button
                                 above.
@@ -227,7 +227,7 @@ export function TranscriptionPanel({
                     <CardHeader>
                         <div className="flex items-center justify-between">
                             <CardTitle className="flex items-center gap-2">
-                                <ListChecks className="w-5 h-5" />
+                                <ListChecks className="size-5" />
                                 Summary
                             </CardTitle>
                             <div className="flex items-center gap-2">
@@ -263,17 +263,17 @@ export function TranscriptionPanel({
                                 >
                                     {isSummarizing ? (
                                         <>
-                                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                                            Generating...
+                                            <Loader2 className="size-4 mr-2 animate-spin" />
+                                            Generating…
                                         </>
                                     ) : summaryData ? (
                                         <>
-                                            <RefreshCw className="w-4 h-4 mr-2" />
+                                            <RefreshCw className="size-4 mr-2" />
                                             Re-generate
                                         </>
                                     ) : (
                                         <>
-                                            <Sparkles className="w-4 h-4 mr-2" />
+                                            <Sparkles className="size-4 mr-2" />
                                             Summarize
                                         </>
                                     )}
@@ -284,9 +284,9 @@ export function TranscriptionPanel({
                     <CardContent>
                         {isSummarizing ? (
                             <div className="flex flex-col items-center justify-center py-8">
-                                <Loader2 className="w-8 h-8 animate-spin text-primary mb-4" />
+                                <Loader2 className="size-8 animate-spin text-primary mb-4" />
                                 <p className="text-sm text-muted-foreground">
-                                    Generating summary...
+                                    Generating summary…
                                 </p>
                             </div>
                         ) : summaryData?.summary ? (
@@ -299,9 +299,9 @@ export function TranscriptionPanel({
                                     className="flex items-center gap-1 text-sm font-medium hover:text-primary transition-colors"
                                 >
                                     {summaryExpanded ? (
-                                        <ChevronUp className="w-4 h-4" />
+                                        <ChevronUp className="size-4" />
                                     ) : (
-                                        <ChevronDown className="w-4 h-4" />
+                                        <ChevronDown className="size-4" />
                                     )}
                                     {summaryExpanded
                                         ? "Collapse"
@@ -336,7 +336,7 @@ export function TranscriptionPanel({
                                                                         }
                                                                         className="text-sm text-muted-foreground flex items-start gap-2"
                                                                     >
-                                                                        <span className="text-primary mt-1.5 w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
+                                                                        <span className="text-primary mt-1.5 size-1.5 rounded-full bg-primary shrink-0" />
                                                                         {point}
                                                                     </li>
                                                                 );
@@ -365,7 +365,7 @@ export function TranscriptionPanel({
                                                                         }
                                                                         className="text-sm text-muted-foreground flex items-start gap-2"
                                                                     >
-                                                                        <ListChecks className="w-3.5 h-3.5 mt-0.5 text-primary shrink-0" />
+                                                                        <ListChecks className="size-3.5 mt-0.5 text-primary shrink-0" />
                                                                         {item}
                                                                     </li>
                                                                 );
@@ -395,7 +395,7 @@ export function TranscriptionPanel({
                                                 variant="ghost"
                                                 className="text-destructive hover:text-destructive"
                                             >
-                                                <Trash2 className="w-4 h-4 mr-1" />
+                                                <Trash2 className="size-4 mr-1" />
                                                 Delete
                                             </Button>
                                         </div>
@@ -404,7 +404,7 @@ export function TranscriptionPanel({
                             </div>
                         ) : (
                             <div className="flex flex-col items-center justify-center py-8 text-center">
-                                <ListChecks className="w-10 h-10 text-muted-foreground mb-3" />
+                                <ListChecks className="size-10 text-muted-foreground mb-3" />
                                 <p className="text-sm text-muted-foreground">
                                     No summary yet. Click "Summarize" to
                                     generate one.

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -213,7 +213,7 @@ export function TranscriptionPanel({
                         <div className="flex flex-col items-center justify-center py-10 text-center">
                             <FileText className="size-10 text-muted-foreground mb-3" />
                             <p className="text-sm text-muted-foreground">
-                                No transcription yet — use the Transcribe button
+                                No transcription yet. Use the Transcribe button
                                 above.
                             </p>
                         </div>

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -11,8 +11,6 @@ import {
     Sparkles,
     Trash2,
 } from "lucide-react";
-import React, { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -22,20 +20,13 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { useTranscriptionSummary } from "@/hooks/use-transcription-summary";
 import { SUMMARY_PRESETS } from "@/lib/ai/summary-presets";
 import type { Recording } from "@/types/recording";
 
 interface Transcription {
     text?: string;
     language?: string;
-}
-
-interface SummaryData {
-    summary: string | null;
-    keyPoints: string[] | null;
-    actionItems: string[] | null;
-    provider?: string;
-    model?: string;
 }
 
 interface TranscriptionPanelProps {
@@ -51,92 +42,19 @@ export function TranscriptionPanel({
     isTranscribing,
     onTranscribe,
 }: TranscriptionPanelProps) {
-    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-    const [isSummarizing, setIsSummarizing] = useState(false);
-    const [summaryExpanded, setSummaryExpanded] = useState(true);
-    const [summaryPreset, setSummaryPreset] = useState("general");
-    // Key to force re-fetch summary (e.g. after transcription text changes)
-    const [summaryFetchKey, setSummaryFetchKey] = useState(0);
-    const transcriptionTextRef = React.useRef(transcription?.text);
-
-    // Detect when transcription text actually changes → invalidate summary
-    if (transcription?.text !== transcriptionTextRef.current) {
-        transcriptionTextRef.current = transcription?.text;
-        // will trigger the useEffect below on next render
-        setSummaryFetchKey((k) => k + 1);
-        setSummaryData(null);
-    }
-
-    // Fetch existing summary when recording changes
-    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch signal
-    useEffect(() => {
-        setSummaryData(null);
-        if (!recording?.id) return;
-
-        const controller = new AbortController();
-        fetch(`/api/recordings/${recording.id}/summary`, {
-            signal: controller.signal,
-        })
-            .then((res) => res.json())
-            .then((data) => {
-                if (data.summary) {
-                    setSummaryData(data);
-                }
-            })
-            .catch(() => {});
-
-        return () => controller.abort();
-    }, [recording?.id, summaryFetchKey]);
-
-    const handleSummarize = useCallback(async () => {
-        setIsSummarizing(true);
-        try {
-            const response = await fetch(
-                `/api/recordings/${recording.id}/summary`,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ preset: summaryPreset }),
-                },
-            );
-
-            if (response.ok) {
-                const data = await response.json();
-                setSummaryData(data);
-                toast.success("Summary generated");
-            } else {
-                const error = await response.json();
-                toast.error(error.error || "Summary generation failed");
-            }
-        } catch {
-            toast.error("Failed to generate summary");
-        } finally {
-            setIsSummarizing(false);
-        }
-    }, [recording.id, summaryPreset]);
-
-    const handleDeleteSummary = useCallback(async () => {
-        // Optimistic delete
-        const previous = summaryData;
-        setSummaryData(null);
-
-        try {
-            const response = await fetch(
-                `/api/recordings/${recording.id}/summary`,
-                { method: "DELETE" },
-            );
-
-            if (response.ok) {
-                toast.success("Summary deleted");
-            } else {
-                setSummaryData(previous);
-                toast.error("Failed to delete summary");
-            }
-        } catch {
-            setSummaryData(previous);
-            toast.error("Failed to delete summary");
-        }
-    }, [recording.id, summaryData]);
+    const {
+        summaryData,
+        isSummarizing,
+        summaryExpanded,
+        setSummaryExpanded,
+        summaryPreset,
+        setSummaryPreset,
+        handleSummarize,
+        handleDeleteSummary,
+    } = useTranscriptionSummary({
+        recordingId: recording?.id,
+        transcriptionText: transcription?.text,
+    });
 
     return (
         <div className="space-y-4">
@@ -221,7 +139,7 @@ export function TranscriptionPanel({
                 </CardContent>
             </Card>
 
-            {/* Summary Card — only show when transcription exists */}
+            {/* Summary Card -- only show when transcription exists */}
             {transcription?.text && (
                 <Card>
                     <CardHeader>

--- a/src/components/dashboard/user-menu.tsx
+++ b/src/components/dashboard/user-menu.tsx
@@ -59,7 +59,7 @@ export function UserMenu({
     onOpenSettings,
     onOpenShortcuts,
 }: UserMenuProps) {
-    const router = useRouter();
+    const { push, refresh } = useRouter();
     const { theme, setTheme } = useTheme(initialTheme);
 
     const themeOptions = [
@@ -112,9 +112,7 @@ export function UserMenu({
                         <Kbd>?</Kbd>
                     </DropdownMenuItem>
                     {isAdmin && (
-                        <DropdownMenuItem
-                            onSelect={() => router.push("/admin")}
-                        >
+                        <DropdownMenuItem onSelect={() => push("/admin")}>
                             <Shield />
                             <span className="flex-1">Admin dashboard</span>
                         </DropdownMenuItem>
@@ -173,8 +171,8 @@ export function UserMenu({
                         variant="destructive"
                         onSelect={async () => {
                             await signOut();
-                            router.push("/");
-                            router.refresh();
+                            push("/");
+                            refresh();
                         }}
                     >
                         <LogOut />

--- a/src/components/dashboard/user-menu.tsx
+++ b/src/components/dashboard/user-menu.tsx
@@ -82,7 +82,7 @@ export function UserMenu({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-72 p-0">
                 {/* Identity block */}
-                <div className="flex items-center gap-3 border-b px-3 py-3">
+                <div className="flex items-center gap-3 border-b p-3">
                     <div
                         className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary"
                         aria-hidden="true"

--- a/src/components/dashboard/workstation-detail-pane.tsx
+++ b/src/components/dashboard/workstation-detail-pane.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { RecordingPlayer } from "@/components/dashboard/recording-player";
+import { TranscriptionPanel } from "@/components/dashboard/transcription-panel";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { Recording } from "@/types/recording";
+
+interface TranscriptionData {
+    text?: string;
+    language?: string;
+}
+
+interface Props {
+    currentRecording: Recording | null;
+    currentTranscription: TranscriptionData | undefined;
+    isCurrentTranscribing: boolean;
+    visibleRecordings: Recording[];
+    onTranscribe: () => void;
+    onSelectRecording: (r: Recording) => void;
+    onBackToList: () => void;
+    /** When true, the pane is hidden (mobile list view active). */
+    hiddenOnMobile: boolean;
+    initialPlaybackSpeed: number | undefined;
+    initialVolume: number | undefined;
+    initialAutoPlayNext: boolean | undefined;
+    scrubberStyle: "waveform" | "slider" | undefined;
+}
+
+/**
+ * Right-hand detail pane: player + transcription. On lg+ this is a
+ * sticky column next to the recording list; on <lg the list and
+ * detail toggle via `mobileView` -- both stay mounted so scroll
+ * position / search query / selection survive a back-navigation.
+ *
+ * Auto-advance on player ended (when `autoPlayNext` is on) moves to
+ * the next recording in `visibleRecordings`; the back-affordance is
+ * mobile-only because desktop has both panes visible at once.
+ */
+export function WorkstationDetailPane({
+    currentRecording,
+    currentTranscription,
+    isCurrentTranscribing,
+    visibleRecordings,
+    onTranscribe,
+    onSelectRecording,
+    onBackToList,
+    hiddenOnMobile,
+    initialPlaybackSpeed,
+    initialVolume,
+    initialAutoPlayNext,
+    scrubberStyle,
+}: Props) {
+    return (
+        <div
+            className={cn(
+                "space-y-6 lg:sticky lg:top-[4.5rem] lg:col-span-2 lg:block lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-y-auto lg:pr-1",
+                hiddenOnMobile && "hidden",
+            )}
+        >
+            {/*
+              Mobile back affordance. Returns to the list view without
+              dropping the selected recording -- reopening shows the
+              same detail. Hidden on lg+ where both panes are visible
+              at once.
+            */}
+            <Button
+                variant="ghost"
+                size="sm"
+                onClick={onBackToList}
+                className="-ml-2 h-9 gap-1 px-2 lg:hidden"
+            >
+                <ArrowLeft className="size-4" />
+                Back to recordings
+            </Button>
+            {currentRecording ? (
+                <>
+                    <RecordingPlayer
+                        recording={currentRecording}
+                        initialPlaybackSpeed={initialPlaybackSpeed}
+                        initialVolume={initialVolume}
+                        initialAutoPlayNext={initialAutoPlayNext}
+                        scrubberStyle={scrubberStyle}
+                        onEnded={() => {
+                            const currentIndex = visibleRecordings.findIndex(
+                                (r) => r.id === currentRecording.id,
+                            );
+                            if (
+                                currentIndex >= 0 &&
+                                currentIndex < visibleRecordings.length - 1
+                            ) {
+                                onSelectRecording(
+                                    visibleRecordings[currentIndex + 1],
+                                );
+                            }
+                        }}
+                    />
+                    <TranscriptionPanel
+                        recording={currentRecording}
+                        transcription={currentTranscription}
+                        isTranscribing={isCurrentTranscribing}
+                        onTranscribe={onTranscribe}
+                    />
+                </>
+            ) : (
+                <Card>
+                    <CardContent className="py-16 text-center">
+                        <p className="text-muted-foreground">
+                            Select a recording to view details and transcription
+                        </p>
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+}

--- a/src/components/dashboard/workstation-empty-state.tsx
+++ b/src/components/dashboard/workstation-empty-state.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Mic, RefreshCw, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface Props {
+    isSyncing: boolean;
+    onSync: () => void;
+    onUpload: () => void;
+}
+
+/**
+ * Shown when the user has no recordings yet (and no in-flight upload).
+ * Offers the two paths into having content: sync from a Plaud device
+ * (the common case) or upload an audio file from disk.
+ */
+export function WorkstationEmptyState({ isSyncing, onSync, onUpload }: Props) {
+    return (
+        <Card>
+            <CardContent className="flex flex-col items-center justify-center py-16">
+                <Mic className="mb-4 size-16 text-muted-foreground" />
+                <h3 className="mb-2 text-lg font-semibold">
+                    No recordings yet
+                </h3>
+                <p className="mb-6 max-w-md text-center text-sm text-muted-foreground">
+                    Sync your Plaud device to import your recordings and start
+                    transcribing them.
+                </p>
+                <div className="flex gap-2">
+                    <Button onClick={onSync} disabled={isSyncing}>
+                        {isSyncing ? (
+                            <>
+                                <RefreshCw className="mr-2 size-4 animate-spin" />
+                                Syncing…
+                            </>
+                        ) : (
+                            <>
+                                <RefreshCw className="mr-2 size-4" />
+                                Sync Device
+                            </>
+                        )}
+                    </Button>
+                    <Button variant="outline" onClick={onUpload}>
+                        <Upload className="mr-2 size-4" />
+                        Upload Audio
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/dashboard/workstation-header.tsx
+++ b/src/components/dashboard/workstation-header.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Command, Upload } from "lucide-react";
+import { UserMenu } from "@/components/dashboard/user-menu";
+import { SyncButton } from "@/components/sync-button";
+import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface Props {
+    isAdmin: boolean;
+    userEmail: string | null;
+    initialTheme: "light" | "dark" | "system";
+    lastSyncTime: Date | null;
+    nextSyncTime: Date | null;
+    isAutoSyncing: boolean;
+    lastSyncResult: {
+        success: boolean;
+        newRecordings?: number;
+        error?: string;
+    } | null;
+    onSync: () => void;
+    isUploading: boolean;
+    isProcessing: boolean;
+    uploadInputRef: React.RefObject<HTMLInputElement | null>;
+    onTriggerUpload: () => void;
+    onUploadInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onOpenPalette: () => void;
+    onOpenSettings: () => void;
+    onOpenShortcuts: () => void;
+}
+
+/**
+ * Sticky page header for the dashboard workstation.
+ *
+ * Title left, actions right, always one row. On mobile the buttons
+ * collapse to icon-only (per-button `sm:` overrides) so the whole bar
+ * fits in ~360px. `min-w-0` on the title block lets it truncate before
+ * pushing buttons off-screen.
+ *
+ * Action order is intentional: search palette (most general), sync
+ * (most frequent), upload (alternate ingest path), user menu (escape
+ * hatch to settings + identity). The sync button is status-aware --
+ * its label includes "Synced 2m ago" / "Retry sync" / "Syncing..."
+ * so a separate status block isn't needed.
+ */
+export function WorkstationHeader({
+    isAdmin,
+    userEmail,
+    initialTheme,
+    lastSyncTime,
+    nextSyncTime,
+    isAutoSyncing,
+    lastSyncResult,
+    onSync,
+    isUploading,
+    isProcessing,
+    uploadInputRef,
+    onTriggerUpload,
+    onUploadInputChange,
+    onOpenPalette,
+    onOpenSettings,
+    onOpenShortcuts,
+}: Props) {
+    return (
+        <div className="sticky top-0 z-30 -mx-4 mb-6 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+            <div className="flex min-w-0 items-baseline gap-3">
+                <h1 className="truncate text-xl font-semibold leading-tight sm:text-2xl md:text-3xl">
+                    Recordings
+                </h1>
+                {/*
+                  Recording count lives in the list pane's own meta row
+                  ("N of N recordings") -- showing it again in the page
+                  header is duplicative on every breakpoint, so the
+                  count is gone here.
+                */}
+            </div>
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            onClick={onOpenPalette}
+                            variant="outline"
+                            size="sm"
+                            className="hidden h-9 md:inline-flex"
+                            aria-label="Open command palette"
+                        >
+                            <Command className="mr-2 size-4" />
+                            <span>Search</span>
+                            <kbd className="ml-2 hidden rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground lg:inline">
+                                ⌘K
+                            </kbd>
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                        Search recordings, transcripts, and actions
+                    </TooltipContent>
+                </Tooltip>
+                <SyncButton
+                    lastSyncTime={lastSyncTime}
+                    nextSyncTime={nextSyncTime}
+                    isAutoSyncing={isAutoSyncing}
+                    lastSyncResult={lastSyncResult}
+                    onSync={onSync}
+                />
+                <input
+                    ref={uploadInputRef}
+                    type="file"
+                    accept="audio/*"
+                    className="hidden"
+                    onChange={onUploadInputChange}
+                />
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            onClick={onTriggerUpload}
+                            disabled={isProcessing}
+                            variant="outline"
+                            size="sm"
+                            className="h-9"
+                            aria-label={
+                                isUploading ? "Uploading audio" : "Upload audio"
+                            }
+                        >
+                            <Upload className="size-4 sm:mr-2" />
+                            <span className="hidden sm:inline">
+                                {isUploading ? "Uploading…" : "Upload Audio"}
+                            </span>
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                        Upload an audio file from your computer
+                    </TooltipContent>
+                </Tooltip>
+                <UserMenu
+                    isAdmin={isAdmin}
+                    initialTheme={initialTheme}
+                    userEmail={userEmail}
+                    onOpenSettings={onOpenSettings}
+                    onOpenShortcuts={onOpenShortcuts}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -384,7 +384,7 @@ export function Workstation({
                     */}
                     <div className="sticky top-0 z-30 -mx-4 mb-6 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/70">
                         <div className="flex min-w-0 items-baseline gap-3">
-                            <h1 className="truncate text-xl font-bold leading-tight sm:text-2xl md:text-3xl">
+                            <h1 className="truncate text-xl font-semibold leading-tight sm:text-2xl md:text-3xl">
                                 Recordings
                             </h1>
                             {/*

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -81,7 +81,7 @@ export function Workstation({
     initialSettings,
     isHosted,
 }: WorkstationProps) {
-    const router = useRouter();
+    const { refresh } = useRouter();
     const [currentRecording, setCurrentRecording] = useState<Recording | null>(
         recordings.length > 0 ? recordings[0] : null,
     );
@@ -144,7 +144,7 @@ export function Workstation({
     const isProcessing = anyTranscribing || isUploading;
 
     // Keep currentRecording in sync with the recordings prop (updated
-    // after router.refresh()). If the previously-selected recording is no
+    // after refresh()). If the previously-selected recording is no
     // longer present (e.g. just deleted), clear the selection.
     useEffect(() => {
         setCurrentRecording((prev) => {
@@ -246,7 +246,7 @@ export function Workstation({
                 );
                 if (response.ok) {
                     toast.success("Transcription complete");
-                    router.refresh();
+                    refresh();
                 } else {
                     const error = await response.json();
                     toast.error(error.error || "Transcription failed");
@@ -261,7 +261,7 @@ export function Workstation({
                 markAction(id, null);
             }
         },
-        [router, markAction],
+        [refresh, markAction],
     );
 
     const handleTranscribe = useCallback(async () => {
@@ -299,7 +299,7 @@ export function Workstation({
                 if (response.ok) {
                     const data = await response.json();
                     toast.success(`"${data.filename}" uploaded`);
-                    router.refresh();
+                    refresh();
                 } else {
                     const error = await response.json();
                     toast.error(error.error || "Upload failed");
@@ -313,7 +313,7 @@ export function Workstation({
                 );
             }
         },
-        [router],
+        [refresh],
     );
 
     const handleDelete = useCallback(
@@ -336,7 +336,7 @@ export function Workstation({
                 });
                 if (!res.ok) throw new Error("Delete failed");
                 toast.success("Recording deleted");
-                router.refresh();
+                refresh();
             } catch (err) {
                 // Rollback
                 setHiddenIds((prev) => {
@@ -348,7 +348,7 @@ export function Workstation({
                 throw err;
             }
         },
-        [currentRecording, visibleRecordings, router],
+        [currentRecording, visibleRecordings, refresh],
     );
 
     const triggerUpload = useCallback(() => {
@@ -698,7 +698,7 @@ export function Workstation({
                 onOpenChange={setOnboardingOpen}
                 onComplete={() => {
                     setOnboardingOpen(false);
-                    router.refresh();
+                    refresh();
                 }}
             />
         </>

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -419,7 +419,7 @@ export function Workstation({
                               Sync button is status-aware: its label is
                               the last-sync relative time, so the user
                               sees "Synced 2m ago" / "Retry sync" /
-                              "Syncing..." without a separate status
+                              "Syncing…" without a separate status
                               block. Tooltip carries next-sync ETA and
                               error detail.
                             */}
@@ -454,7 +454,7 @@ export function Workstation({
                                         <Upload className="size-4 sm:mr-2" />
                                         <span className="hidden sm:inline">
                                             {isUploading
-                                                ? "Uploading..."
+                                                ? "Uploading…"
                                                 : "Upload Audio"}
                                         </span>
                                     </Button>
@@ -493,7 +493,7 @@ export function Workstation({
                                         {isAutoSyncing ? (
                                             <>
                                                 <RefreshCw className="mr-2 size-4 animate-spin" />
-                                                Syncing...
+                                                Syncing…
                                             </>
                                         ) : (
                                             <>

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -1,32 +1,24 @@
 "use client";
 
-import { ArrowLeft, Command, Mic, RefreshCw, Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CommandPalette } from "@/components/dashboard/command-palette";
 import {
-    type PendingUpload,
     RecordingList,
     type RecordingListHandle,
 } from "@/components/dashboard/recording-list";
-import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import { ShortcutsDialog } from "@/components/dashboard/shortcuts-dialog";
-import { TranscriptionPanel } from "@/components/dashboard/transcription-panel";
-import { UserMenu } from "@/components/dashboard/user-menu";
+import { WorkstationDetailPane } from "@/components/dashboard/workstation-detail-pane";
+import { WorkstationEmptyState } from "@/components/dashboard/workstation-empty-state";
+import { WorkstationHeader } from "@/components/dashboard/workstation-header";
 import { OnboardingDialog } from "@/components/onboarding-dialog";
 import { SettingsDialog } from "@/components/settings-dialog";
-import { SyncButton } from "@/components/sync-button";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useAutoSync } from "@/hooks/use-auto-sync";
 import { useListKeyboardNav } from "@/hooks/use-list-keyboard-nav";
 import { useTheme } from "@/hooks/use-theme";
+import { useTranscribeQueue } from "@/hooks/use-transcribe-queue";
+import { useUploadQueue } from "@/hooks/use-upload-queue";
 import {
     requestNotificationPermission,
     showNewRecordingNotification,
@@ -42,37 +34,61 @@ interface TranscriptionData {
     language?: string;
 }
 
-// InitialSettings + its defaults live in
-// `src/lib/settings/initial-settings.ts` so server pages and the
-// client component agree on shape and fallback values.
+interface Provider {
+    id: string;
+    provider: string;
+    baseUrl: string | null;
+    defaultModel: string | null;
+    isDefaultTranscription: boolean;
+    isDefaultEnhancement: boolean;
+    createdAt: Date;
+}
+
+const EMPTY_PROVIDERS: Provider[] = [];
 
 interface WorkstationProps {
     recordings: Recording[];
     transcriptions: Map<string, TranscriptionData>;
     /**
-     * When true, an admin shortcut appears in the avatar menu. Set by the
-     * server-rendered page based on env.ADMIN_EMAILS membership; never
-     * trusted client-side — the actual /admin gate runs server-side.
+     * When true, an admin shortcut appears in the avatar menu. Set by
+     * the server-rendered page based on env.ADMIN_EMAILS membership;
+     * never trusted client-side -- the actual /admin gate runs
+     * server-side.
      */
     isAdmin?: boolean;
     /**
      * Logged-in user's email. Passed down to the avatar menu for the
-     * identity block. Server-supplied — never derive from any client
+     * identity block. Server-supplied -- never derive from any client
      * state, which would risk a stale or attacker-influenced value.
      */
     userEmail?: string | null;
     initialSettings: InitialSettings;
     /**
      * True when running in OpenPlaud's hosted mode (`IS_HOSTED=true`).
-     * Forwarded into SettingsDialog so hosted-only UI gating (e.g. the
-     * self-host-only storage backend card) reflects the deployment mode.
-     * Server-supplied; never derive client-side. Required (no default)
-     * so a future caller can't silently regress hosted-mode behavior
-     * by forgetting to thread the value through.
+     * Forwarded into SettingsDialog so hosted-only UI gating reflects
+     * the deployment mode. Server-supplied; never derive client-side.
+     * Required (no default) so a future caller can't silently regress
+     * hosted-mode behavior by forgetting to thread the value through.
      */
     isHosted: boolean;
 }
 
+/**
+ * Top-level dashboard component. Composition root for the recording
+ * list, the detail pane (player + transcription), and the four
+ * modals (CommandPalette, ShortcutsDialog, SettingsDialog,
+ * OnboardingDialog).
+ *
+ * State ownership is split:
+ *  - selection / mobile master-detail toggle live here
+ *  - uploads -> useUploadQueue
+ *  - transcribes -> useTranscribeQueue
+ *  - sync loop -> useAutoSync
+ *  - theme -> useTheme
+ *  - keyboard nav -> useListKeyboardNav
+ *  - deletes stay here because they need access to currentRecording
+ *    / visibleRecordings to pick the next selection.
+ */
 export function Workstation({
     recordings,
     transcriptions,
@@ -85,40 +101,18 @@ export function Workstation({
     const [currentRecording, setCurrentRecording] = useState<Recording | null>(
         recordings.length > 0 ? recordings[0] : null,
     );
-    // No standalone `isTranscribing` boolean: that races when two
-    // transcribes run concurrently (each request's `finally` would
-    // flip it back to false while another was still pending). The
-    // per-id `inFlightActions` map below is the source of truth;
-    // `isCurrentTranscribing` / `anyTranscribing` are derived from it.
-    const [isUploading, setIsUploading] = useState(false);
-    const uploadInputRef = useRef<HTMLInputElement>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [onboardingOpen, setOnboardingOpen] = useState(false);
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
-    const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
-    const [inFlightActions, setInFlightActions] = useState<
-        Map<string, "transcribing" | "summarizing">
-    >(new Map());
     const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
-    // On <lg viewports the list and detail panes can't coexist — we
+    // On <lg viewports the list and detail panes can't coexist -- we
     // toggle between them instead of stacking. Desktop ignores this
     // state entirely (both panes render via the grid).
     const [mobileView, setMobileView] = useState<"list" | "detail">("list");
-    const [providers, setProviders] = useState<
-        Array<{
-            id: string;
-            provider: string;
-            baseUrl: string | null;
-            defaultModel: string | null;
-            isDefaultTranscription: boolean;
-            isDefaultEnhancement: boolean;
-            createdAt: Date;
-        }>
-    >([]);
+    const [providers, setProviders] = useState<Provider[]>(EMPTY_PROVIDERS);
 
     const { theme, setTheme } = useTheme(initialSettings.theme);
-
     const listRef = useRef<RecordingListHandle>(null);
 
     // Filter out optimistically-hidden (deleted) rows.
@@ -130,18 +124,6 @@ export function Workstation({
     const currentTranscription = currentRecording
         ? transcriptions.get(currentRecording.id)
         : undefined;
-
-    // Any transcribe in flight (across all recordings) blocks new
-    // uploads. The previous `isTranscribing` boolean conflated "this
-    // recording is being transcribed" with "some transcribe is
-    // happening"; splitting them out fixes the concurrency bug.
-    const anyTranscribing = Array.from(inFlightActions.values()).some(
-        (kind) => kind === "transcribing",
-    );
-    const isCurrentTranscribing =
-        currentRecording !== null &&
-        inFlightActions.get(currentRecording.id) === "transcribing";
-    const isProcessing = anyTranscribing || isUploading;
 
     // Keep currentRecording in sync with the recordings prop (updated
     // after refresh()). If the previously-selected recording is no
@@ -159,7 +141,7 @@ export function Workstation({
             const next = new Set<string>();
             const ids = new Set(recordings.map((r) => r.id));
             for (const id of prev) {
-                if (ids.has(id)) next.add(id); // still present → keep hidden until confirmed
+                if (ids.has(id)) next.add(id); // still present -> keep hidden until confirmed
             }
             return next.size === prev.size ? prev : next;
         });
@@ -208,6 +190,9 @@ export function Workstation({
         await manualSync();
     }, [manualSync]);
 
+    // Settings dialog needs the provider list at open-time so the
+    // Providers section seeds correctly. Fetching on open (rather
+    // than on mount) avoids loading a list the user may never see.
     useEffect(() => {
         if (settingsOpen) {
             fetch("/api/settings/ai/providers")
@@ -217,104 +202,35 @@ export function Workstation({
         }
     }, [settingsOpen]);
 
-    const markAction = useCallback(
-        (id: string, kind: "transcribing" | "summarizing" | null) => {
-            setInFlightActions((prev) => {
-                const next = new Map(prev);
-                if (kind === null) next.delete(id);
-                else next.set(id, kind);
-                return next;
-            });
-        },
-        [],
-    );
+    const {
+        isUploading,
+        pendingUploads,
+        uploadInputRef,
+        handleUpload,
+        triggerUpload,
+    } = useUploadQueue({ onUploadComplete: refresh });
 
-    // Trigger transcription for a specific recording id. Used by:
-    //   - the per-recording "Transcribe" button in TranscriptionPanel
-    //     (via `handleTranscribe`, which always targets the currently
-    //     selected recording for backwards compatibility), and
-    //   - the command palette's per-row "Transcribe X" quick actions,
-    //     which need to dispatch against an arbitrary recording without
-    //     having to first change the selection.
-    const transcribeById = useCallback(
-        async (id: string) => {
-            markAction(id, "transcribing");
-            try {
-                const response = await fetch(
-                    `/api/recordings/${id}/transcribe`,
-                    { method: "POST" },
-                );
-                if (response.ok) {
-                    toast.success("Transcription complete");
-                    refresh();
-                } else {
-                    const error = await response.json();
-                    toast.error(error.error || "Transcription failed");
-                }
-            } catch {
-                toast.error("Failed to transcribe recording");
-            } finally {
-                // Per-id clear only — don't touch any global "is
-                // transcribing" flag (there isn't one), so a concurrent
-                // transcribe on a different recording keeps its own
-                // marker intact.
-                markAction(id, null);
-            }
-        },
-        [refresh, markAction],
+    const { inFlightActions, transcribeById } = useTranscribeQueue({
+        onTranscribeComplete: refresh,
+    });
+
+    // Any transcribe in flight (across all recordings) blocks new
+    // uploads. The previous `isTranscribing` boolean conflated "this
+    // recording is being transcribed" with "some transcribe is
+    // happening"; splitting them fixes a concurrency bug where two
+    // pending transcribes would race each other's finally clauses.
+    const anyTranscribing = Array.from(inFlightActions.values()).some(
+        (kind) => kind === "transcribing",
     );
+    const isCurrentTranscribing =
+        currentRecording !== null &&
+        inFlightActions.get(currentRecording.id) === "transcribing";
+    const isProcessing = anyTranscribing || isUploading;
 
     const handleTranscribe = useCallback(async () => {
         if (!currentRecording) return;
         await transcribeById(currentRecording.id);
     }, [currentRecording, transcribeById]);
-
-    const handleUpload = useCallback(
-        async (e: React.ChangeEvent<HTMLInputElement>) => {
-            const file = e.target.files?.[0];
-            if (!file) return;
-            e.target.value = "";
-
-            // Optimistic placeholder in the list.
-            const placeholderId = `pending:${Date.now()}:${Math.random()
-                .toString(36)
-                .slice(2)}`;
-            setPendingUploads((prev) => [
-                ...prev,
-                {
-                    id: placeholderId,
-                    filename: file.name,
-                    filesize: file.size,
-                },
-            ]);
-
-            setIsUploading(true);
-            try {
-                const formData = new FormData();
-                formData.append("file", file);
-                const response = await fetch("/api/recordings/upload", {
-                    method: "POST",
-                    body: formData,
-                });
-                if (response.ok) {
-                    const data = await response.json();
-                    toast.success(`"${data.filename}" uploaded`);
-                    refresh();
-                } else {
-                    const error = await response.json();
-                    toast.error(error.error || "Upload failed");
-                }
-            } catch {
-                toast.error("Failed to upload recording");
-            } finally {
-                setIsUploading(false);
-                setPendingUploads((prev) =>
-                    prev.filter((p) => p.id !== placeholderId),
-                );
-            }
-        },
-        [refresh],
-    );
 
     const handleDelete = useCallback(
         async (recording: Recording) => {
@@ -351,11 +267,9 @@ export function Workstation({
         [currentRecording, visibleRecordings, refresh],
     );
 
-    const triggerUpload = useCallback(() => {
-        uploadInputRef.current?.click();
-    }, []);
-
-    // Keyboard shortcuts (global).
+    // Keyboard shortcuts (global). Disabled while any modal is open
+    // so the modal owns keyboard focus exclusively. The shortcuts
+    // dialog itself uses these very keys to navigate its rows.
     useListKeyboardNav({
         onNext: () => listRef.current?.next(),
         onPrev: () => listRef.current?.prev(),
@@ -363,9 +277,6 @@ export function Workstation({
         onOpenPalette: () => setPaletteOpen(true),
         onOpenShortcuts: () => setShortcutsOpen(true),
         onOpenSettings: () => setSettingsOpen(true),
-        // Disable global j/k/?/,/Enter etc. while any modal is open
-        // so the modal owns keyboard focus exclusively. The shortcuts
-        // dialog itself uses these very keys to navigate its rows.
         enabled:
             !settingsOpen && !onboardingOpen && !paletteOpen && !shortcutsOpen,
     });
@@ -374,155 +285,43 @@ export function Workstation({
         <>
             <div className="bg-background">
                 <div className="container mx-auto max-w-7xl px-4 py-6">
-                    {/*
-                      Header: title on the left, actions on the right,
-                      always one row. On mobile the title shrinks and the
-                      buttons collapse to icon-only (see the per-button
-                      `sm:` overrides below), so the whole bar fits in
-                      ~360px. `min-w-0` on the title block lets it
-                      truncate before pushing buttons off-screen.
-                    */}
-                    <div className="sticky top-0 z-30 -mx-4 mb-6 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-                        <div className="flex min-w-0 items-baseline gap-3">
-                            <h1 className="truncate text-xl font-semibold leading-tight sm:text-2xl md:text-3xl">
-                                Recordings
-                            </h1>
-                            {/*
-                              Recording count lives in the list pane's own
-                              meta row ("N of N recordings") — showing it
-                              again in the page header is duplicative on
-                              every breakpoint, so the count is gone here.
-                            */}
-                        </div>
-                        <div className="ml-auto flex shrink-0 items-center gap-2">
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button
-                                        onClick={() => setPaletteOpen(true)}
-                                        variant="outline"
-                                        size="sm"
-                                        className="hidden h-9 md:inline-flex"
-                                        aria-label="Open command palette"
-                                    >
-                                        <Command className="mr-2 size-4" />
-                                        <span>Search</span>
-                                        <kbd className="ml-2 hidden rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground lg:inline">
-                                            ⌘K
-                                        </kbd>
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">
-                                    Search recordings, transcripts, and actions
-                                </TooltipContent>
-                            </Tooltip>
-                            {/*
-                              Sync button is status-aware: its label is
-                              the last-sync relative time, so the user
-                              sees "Synced 2m ago" / "Retry sync" /
-                              "Syncing…" without a separate status
-                              block. Tooltip carries next-sync ETA and
-                              error detail.
-                            */}
-                            <SyncButton
-                                lastSyncTime={lastSyncTime}
-                                nextSyncTime={nextSyncTime}
-                                isAutoSyncing={isAutoSyncing}
-                                lastSyncResult={lastSyncResult}
-                                onSync={handleSync}
-                            />
-                            <input
-                                ref={uploadInputRef}
-                                type="file"
-                                accept="audio/*"
-                                className="hidden"
-                                onChange={handleUpload}
-                            />
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button
-                                        onClick={triggerUpload}
-                                        disabled={isProcessing}
-                                        variant="outline"
-                                        size="sm"
-                                        className="h-9"
-                                        aria-label={
-                                            isUploading
-                                                ? "Uploading audio"
-                                                : "Upload audio"
-                                        }
-                                    >
-                                        <Upload className="size-4 sm:mr-2" />
-                                        <span className="hidden sm:inline">
-                                            {isUploading
-                                                ? "Uploading…"
-                                                : "Upload Audio"}
-                                        </span>
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">
-                                    Upload an audio file from your computer
-                                </TooltipContent>
-                            </Tooltip>
-                            <UserMenu
-                                isAdmin={isAdmin}
-                                initialTheme={initialSettings.theme}
-                                userEmail={userEmail}
-                                onOpenSettings={() => setSettingsOpen(true)}
-                                onOpenShortcuts={() => setShortcutsOpen(true)}
-                            />
-                        </div>
-                    </div>
+                    <WorkstationHeader
+                        isAdmin={isAdmin}
+                        userEmail={userEmail}
+                        initialTheme={initialSettings.theme}
+                        lastSyncTime={lastSyncTime}
+                        nextSyncTime={nextSyncTime}
+                        isAutoSyncing={isAutoSyncing}
+                        lastSyncResult={lastSyncResult}
+                        onSync={handleSync}
+                        isUploading={isUploading}
+                        isProcessing={isProcessing}
+                        uploadInputRef={uploadInputRef}
+                        onTriggerUpload={triggerUpload}
+                        onUploadInputChange={handleUpload}
+                        onOpenPalette={() => setPaletteOpen(true)}
+                        onOpenSettings={() => setSettingsOpen(true)}
+                        onOpenShortcuts={() => setShortcutsOpen(true)}
+                    />
 
                     {visibleRecordings.length === 0 &&
                     pendingUploads.length === 0 ? (
-                        <Card>
-                            <CardContent className="flex flex-col items-center justify-center py-16">
-                                <Mic className="mb-4 size-16 text-muted-foreground" />
-                                <h3 className="mb-2 text-lg font-semibold">
-                                    No recordings yet
-                                </h3>
-                                <p className="mb-6 max-w-md text-center text-sm text-muted-foreground">
-                                    Sync your Plaud device to import your
-                                    recordings and start transcribing them.
-                                </p>
-                                <div className="flex gap-2">
-                                    <Button
-                                        onClick={handleSync}
-                                        disabled={isAutoSyncing}
-                                    >
-                                        {isAutoSyncing ? (
-                                            <>
-                                                <RefreshCw className="mr-2 size-4 animate-spin" />
-                                                Syncing…
-                                            </>
-                                        ) : (
-                                            <>
-                                                <RefreshCw className="mr-2 size-4" />
-                                                Sync Device
-                                            </>
-                                        )}
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        onClick={triggerUpload}
-                                    >
-                                        <Upload className="mr-2 size-4" />
-                                        Upload Audio
-                                    </Button>
-                                </div>
-                            </CardContent>
-                        </Card>
+                        <WorkstationEmptyState
+                            isSyncing={isAutoSyncing}
+                            onSync={handleSync}
+                            onUpload={triggerUpload}
+                        />
                     ) : (
                         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
                             {/*
-                              Mobile master/detail: on <lg, only one pane
-                              renders at a time. `mobileView === "detail"`
-                              hides the list (via `hidden`) while keeping
-                              its state mounted, so scroll position,
-                              search query, and selection survive the
-                              back-navigation. The `lg:block` override
-                              brings the list back on desktop where both
-                              panes coexist.
+                              Mobile master/detail: on <lg, only one
+                              pane renders at a time. `mobileView ===
+                              "detail"` hides the list (via `hidden`)
+                              while keeping its state mounted, so
+                              scroll position, search query, and
+                              selection survive the back-navigation.
+                              The `lg:block` override brings the list
+                              back on desktop where both panes coexist.
                             */}
                             <div
                                 className={cn(
@@ -539,9 +338,9 @@ export function Workstation({
                                     inFlightActions={inFlightActions}
                                     onSelect={(r) => {
                                         setCurrentRecording(r);
-                                        // Tapping a row on mobile reveals
-                                        // the detail pane. Desktop ignores
-                                        // this state.
+                                        // Tapping a row on mobile
+                                        // reveals the detail pane.
+                                        // Desktop ignores this state.
                                         setMobileView("detail");
                                     }}
                                     onDelete={handleDelete}
@@ -558,99 +357,24 @@ export function Workstation({
                                 />
                             </div>
 
-                            {/*
-                              On lg+: pin the detail pane just below the
-                              sticky page header so the list is the only
-                              thing that scrolls vertically. `self-start`
-                              opts the grid item out of the default
-                              `stretch` alignment that would otherwise
-                              defeat `position: sticky`. Max-height clamps
-                              the pane to the viewport minus the header
-                              + a little breathing room, and any content
-                              that overflows (e.g. long transcripts)
-                              scrolls internally instead of pushing the
-                              list down. Below lg the layout stacks, so
-                              the sticky behavior is intentionally off.
-                            */}
-                            <div
-                                className={cn(
-                                    "space-y-6 lg:sticky lg:top-[4.5rem] lg:col-span-2 lg:block lg:max-h-[calc(100vh-5rem)] lg:self-start lg:overflow-y-auto lg:pr-1",
-                                    mobileView === "list" && "hidden",
-                                )}
-                            >
-                                {/*
-                                  Mobile back affordance. Returns to the
-                                  list view without dropping the selected
-                                  recording — reopening shows the same
-                                  detail. Hidden on lg+ where both panes
-                                  are visible at once.
-                                */}
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => setMobileView("list")}
-                                    className="-ml-2 h-9 gap-1 px-2 lg:hidden"
-                                >
-                                    <ArrowLeft className="size-4" />
-                                    Back to recordings
-                                </Button>
-                                {currentRecording ? (
-                                    <>
-                                        <RecordingPlayer
-                                            recording={currentRecording}
-                                            initialPlaybackSpeed={
-                                                initialSettings.defaultPlaybackSpeed
-                                            }
-                                            initialVolume={
-                                                initialSettings.defaultVolume
-                                            }
-                                            initialAutoPlayNext={
-                                                initialSettings.autoPlayNext
-                                            }
-                                            scrubberStyle={
-                                                initialSettings.playerScrubber
-                                            }
-                                            onEnded={() => {
-                                                const currentIndex =
-                                                    visibleRecordings.findIndex(
-                                                        (r) =>
-                                                            r.id ===
-                                                            currentRecording.id,
-                                                    );
-                                                if (
-                                                    currentIndex >= 0 &&
-                                                    currentIndex <
-                                                        visibleRecordings.length -
-                                                            1
-                                                ) {
-                                                    setCurrentRecording(
-                                                        visibleRecordings[
-                                                            currentIndex + 1
-                                                        ],
-                                                    );
-                                                }
-                                            }}
-                                        />
-                                        <TranscriptionPanel
-                                            recording={currentRecording}
-                                            transcription={currentTranscription}
-                                            isTranscribing={
-                                                isCurrentTranscribing
-                                            }
-                                            onTranscribe={handleTranscribe}
-                                        />
-                                    </>
-                                ) : (
-                                    <Card>
-                                        <CardContent className="py-16 text-center">
-                                            <p className="text-muted-foreground">
-                                                Select a recording to view
-                                                details and transcription
-                                            </p>
-                                        </CardContent>
-                                    </Card>
-                                )}
-                            </div>
+                            <WorkstationDetailPane
+                                currentRecording={currentRecording}
+                                currentTranscription={currentTranscription}
+                                isCurrentTranscribing={isCurrentTranscribing}
+                                visibleRecordings={visibleRecordings}
+                                onTranscribe={handleTranscribe}
+                                onSelectRecording={setCurrentRecording}
+                                onBackToList={() => setMobileView("list")}
+                                hiddenOnMobile={mobileView === "list"}
+                                initialPlaybackSpeed={
+                                    initialSettings.defaultPlaybackSpeed
+                                }
+                                initialVolume={initialSettings.defaultVolume}
+                                initialAutoPlayNext={
+                                    initialSettings.autoPlayNext
+                                }
+                                scrubberStyle={initialSettings.playerScrubber}
+                            />
                         </div>
                     )}
                 </div>

--- a/src/components/landing/deploy.tsx
+++ b/src/components/landing/deploy.tsx
@@ -14,7 +14,7 @@ export function Deploy() {
                             <Terminal className="mr-2 size-3" />
                             Self-host, if you want to
                         </div>
-                        <h2 className="text-3xl md:text-4xl font-bold tracking-tight">
+                        <h2 className="text-3xl md:text-4xl font-semibold tracking-tight">
                             Three commands. One container. Yours forever.
                         </h2>
                         <p className="text-zinc-400 text-lg leading-relaxed">

--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -30,7 +30,7 @@ export function FAQ() {
         <section className="py-24 md:py-32 border-t border-border/40">
             <div className="container mx-auto px-4">
                 <div className="max-w-3xl mx-auto">
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-12">
+                    <h2 className="text-3xl md:text-4xl font-semibold tracking-tight mb-12">
                         Questions people actually ask.
                     </h2>
                     <dl className="space-y-10">

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -7,12 +7,12 @@ export function Features() {
         <section className="py-24">
             <div className="container mx-auto px-4">
                 <div className="max-w-3xl mb-16">
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">
+                    <h2 className="text-3xl md:text-4xl font-semibold tracking-tight mb-4">
                         What OpenPlaud does.
                     </h2>
                     <p className="text-muted-foreground text-lg leading-relaxed">
                         Four things, in order. Your Plaud Note keeps recording
-                        exactly as it does today — we replace everything that
+                        exactly as it does today; we replace everything that
                         happens after.
                     </p>
                 </div>

--- a/src/components/landing/final-cta.tsx
+++ b/src/components/landing/final-cta.tsx
@@ -6,12 +6,12 @@ export function FinalCTA() {
     return (
         <section className="container mx-auto px-4 py-24 md:py-32">
             <div className="max-w-3xl mx-auto text-center">
-                <h2 className="text-3xl md:text-5xl font-bold tracking-tight mb-6">
+                <h2 className="text-3xl md:text-5xl font-semibold tracking-tight mb-6">
                     Stop renting your own voice.
                 </h2>
                 <p className="text-muted-foreground text-lg leading-relaxed mb-10 max-w-xl mx-auto">
                     Your Plaud Note already works. OpenPlaud gives you the rest
-                    of it — transcription, search, export, and a choice about
+                    of it: transcription, search, export, and a choice about
                     where it all lives.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">

--- a/src/components/landing/for-professionals.tsx
+++ b/src/components/landing/for-professionals.tsx
@@ -8,13 +8,13 @@ export function ForProfessionals() {
                     <p className="text-sm font-mono text-muted-foreground uppercase tracking-wider mb-4">
                         For professionals
                     </p>
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-6">
+                    <h2 className="text-3xl md:text-4xl font-semibold tracking-tight mb-6">
                         If your conversations stay in the room, your recordings
                         should too.
                     </h2>
                     <p className="text-muted-foreground text-lg leading-relaxed mb-12">
-                        Lawyers, journalists, consultants, researchers —
-                        OpenPlaud gives you the parts that matter: your
+                        Lawyers, journalists, consultants, researchers:
+                        OpenPlaud gives you the parts that matter. Your
                         recordings on infrastructure you control, the ability to
                         audit every line of code yourself, and a real choice of
                         AI provider, including ones that never leave your
@@ -46,12 +46,12 @@ export function ForProfessionals() {
                         <p className="text-sm text-muted-foreground leading-relaxed">
                             Plaud self-attests HIPAA compliance and will sign a
                             BAA. OpenPlaud doesn't make a compliance claim of
-                            its own — the claim belongs to your AI provider, not
+                            its own; the claim belongs to your AI provider, not
                             to us. If you handle protected information (health,
                             privileged legal, regulated financial), the right
                             path is to self-host OpenPlaud with a provider that
                             signs a BAA you've reviewed (OpenAI Enterprise,
-                            Azure Speech, Deepgram) — or use a local Whisper
+                            Azure Speech, Deepgram), or use a local Whisper
                             model that never leaves your machine. We won't
                             promise compliance we don't control. We'll give you
                             the tools to achieve it yourself.

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
 
             <div className="container mx-auto px-4">
                 <div className="max-w-4xl mx-auto text-center">
-                    <h1 className="text-[clamp(2.5rem,6.5vw,5.5rem)] font-bold tracking-[-0.02em] leading-[1.02] mb-8 text-foreground">
+                    <h1 className="text-[clamp(2.5rem,6.5vw,5.5rem)] font-semibold tracking-[-0.02em] leading-[1.02] mb-8 text-foreground">
                         Plaud charges{" "}
                         <span className="text-muted-foreground/70 line-through decoration-[0.08em] decoration-muted-foreground/40">
                             $29.99
@@ -23,7 +23,7 @@ export function Hero() {
 
                     <p className="max-w-2xl mx-auto text-lg md:text-xl text-muted-foreground leading-relaxed mb-10">
                         OpenPlaud connects to your Plaud Note and transcribes
-                        with your own AI keys — pennies per hour, instead of a
+                        with your own AI keys. Pennies per hour, instead of a
                         subscription. Self-host free, or hosted from{" "}
                         <span className="text-foreground font-medium">
                             $0/mo

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -57,7 +57,7 @@ export function Pricing() {
         <section id="pricing" className="py-24 md:py-32">
             <div className="container mx-auto px-4">
                 <div className="max-w-3xl mx-auto text-center mb-16">
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">
+                    <h2 className="text-3xl md:text-4xl font-semibold tracking-tight mb-4">
                         Pick the version that fits you.
                     </h2>
                     <p className="text-muted-foreground text-lg leading-relaxed">

--- a/src/components/landing/reddit-quotes.tsx
+++ b/src/components/landing/reddit-quotes.tsx
@@ -44,7 +44,7 @@ export function RedditQuotes() {
                                     rel="noopener noreferrer"
                                     className="inline-block mt-4 text-sm text-muted-foreground hover:text-foreground transition-colors"
                                 >
-                                    — {q.sub}
+                                    from {q.sub}
                                 </a>
                             </li>
                         ))}

--- a/src/components/landing/reddit-quotes.tsx
+++ b/src/components/landing/reddit-quotes.tsx
@@ -44,7 +44,7 @@ export function RedditQuotes() {
                                     rel="noopener noreferrer"
                                     className="inline-block mt-4 text-sm text-muted-foreground hover:text-foreground transition-colors"
                                 >
-                                    from {q.sub}
+                                    – {q.sub}
                                 </a>
                             </li>
                         ))}

--- a/src/components/landing/the-math.tsx
+++ b/src/components/landing/the-math.tsx
@@ -3,11 +3,11 @@ export function TheMath() {
         <section className="py-24 border-y border-border/40 bg-secondary/10">
             <div className="container mx-auto px-4">
                 <div className="max-w-3xl mx-auto">
-                    <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-4">
+                    <h2 className="text-3xl md:text-4xl font-semibold tracking-tight mb-4">
                         Here's what you're actually paying for.
                     </h2>
                     <p className="text-muted-foreground text-lg leading-relaxed mb-12">
-                        Plaud doesn't transcribe your audio — OpenAI, Groq, and
+                        Plaud doesn't transcribe your audio. OpenAI, Groq, and
                         similar do. Plaud marks it up and wraps a subscription
                         around it. OpenPlaud lets you pay the provider directly.
                     </p>

--- a/src/components/led-indicator.tsx
+++ b/src/components/led-indicator.tsx
@@ -9,9 +9,9 @@ interface LEDIndicatorProps {
 }
 
 const sizeMap = {
-    sm: "w-2 h-2",
-    md: "w-3 h-3",
-    lg: "w-4 h-4",
+    sm: "size-2",
+    md: "size-3",
+    lg: "size-4",
 };
 
 export function LEDIndicator({

--- a/src/components/local-time.tsx
+++ b/src/components/local-time.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+    /** Date object or anything `new Date(...)` accepts (ISO string, ms). */
+    value: Date | string | number;
+    /**
+     * Variant: \`datetime\` -> toLocaleString(); \`date\` -> toLocaleDateString().
+     * Defaults to \`datetime\` which mirrors the prior `new Date(x).toLocaleString()`
+     * call sites.
+     */
+    variant?: "datetime" | "date";
+    className?: string;
+}
+
+/**
+ * Renders a timestamp using the user's locale, but only after the
+ * client takes over. SSR emits a stable, locale-neutral ISO form so
+ * the server and the first client render produce identical HTML --
+ * otherwise hydration mismatches surface as a visible flash plus a
+ * console warning (and, on strict React modes, a re-mount).
+ *
+ * Why not just `<time suppressHydrationWarning>`? Because we'd still
+ * have to pay the SSR -> CSR text swap; this is the same swap done
+ * deliberately and visibly only after we know the client locale.
+ */
+export function LocalTime({ value, variant = "datetime", className }: Props) {
+    const date = value instanceof Date ? value : new Date(value);
+    const iso = date.toISOString();
+    const [text, setText] = useState<string>(iso);
+
+    useEffect(() => {
+        setText(
+            variant === "date"
+                ? date.toLocaleDateString()
+                : date.toLocaleString(),
+        );
+    }, [date, variant]);
+
+    return (
+        <time dateTime={iso} className={className}>
+            {text}
+        </time>
+    );
+}

--- a/src/components/metal-button.tsx
+++ b/src/components/metal-button.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const metalButtonVariants = cva(
@@ -36,22 +36,25 @@ export interface MetalButtonProps
      * avoid nesting interactive elements (`<a><button>` is invalid markup).
      */
     asChild?: boolean;
+    ref?: React.Ref<HTMLButtonElement>;
 }
 
-const MetalButton = React.forwardRef<HTMLButtonElement, MetalButtonProps>(
-    ({ className, variant, size, asChild = false, ...props }, ref) => {
-        const Comp = asChild ? Slot : "button";
-        return (
-            <Comp
-                className={cn(
-                    metalButtonVariants({ variant, size, className }),
-                )}
-                ref={ref}
-                {...props}
-            />
-        );
-    },
-);
-MetalButton.displayName = "MetalButton";
+function MetalButton({
+    className,
+    variant,
+    size,
+    asChild = false,
+    ref,
+    ...props
+}: MetalButtonProps) {
+    const Comp = asChild ? Slot : "button";
+    return (
+        <Comp
+            className={cn(metalButtonVariants({ variant, size, className }))}
+            ref={ref}
+            {...props}
+        />
+    );
+}
 
 export { MetalButton, metalButtonVariants };

--- a/src/components/metal-button.tsx
+++ b/src/components/metal-button.tsx
@@ -17,7 +17,7 @@ const metalButtonVariants = cva(
                 default: "h-10 px-6 py-2",
                 sm: "h-8 px-4 text-xs",
                 lg: "h-12 px-8 text-base",
-                icon: "h-10 w-10",
+                icon: "size-10",
             },
         },
         defaultVariants: {

--- a/src/components/onboarding-dialog-base.tsx
+++ b/src/components/onboarding-dialog-base.tsx
@@ -40,7 +40,7 @@ const OnboardingDialogContent = React.forwardRef<
         >
             {children}
             <DialogPrimitive.Close className="group absolute right-3 top-3 flex size-7 items-center justify-center rounded-lg outline-offset-2 transition-colors focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none">
-                <X className="h-4 w-4 opacity-60 transition-opacity group-hover:opacity-100" />
+                <X className="size-4 opacity-60 transition-opacity group-hover:opacity-100" />
                 <span className="sr-only">Close</span>
             </DialogPrimitive.Close>
         </DialogPrimitive.Content>

--- a/src/components/onboarding-dialog-base.tsx
+++ b/src/components/onboarding-dialog-base.tsx
@@ -2,104 +2,122 @@
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const OnboardingDialogRoot = DialogPrimitive.Root;
 
 const OnboardingDialogPortal = DialogPrimitive.Portal;
 
-const OnboardingDialogOverlay = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Overlay>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-    <DialogPrimitive.Overlay
-        ref={ref}
-        className={cn(
-            "fixed inset-0 z-[101] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-200 data-[state=open]:duration-200",
-            className,
-        )}
-        {...props}
-    />
-));
-OnboardingDialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
-
-const OnboardingDialogContent = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-    <OnboardingDialogPortal>
-        <OnboardingDialogOverlay />
-        <DialogPrimitive.Content
+function OnboardingDialogOverlay({
+    className,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+    ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Overlay>>;
+}) {
+    return (
+        <DialogPrimitive.Overlay
             ref={ref}
             className={cn(
-                "fixed left-1/2 top-1/2 z-[101] grid max-h-[calc(100%-4rem)] w-full -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto border bg-background p-6 shadow-lg shadow-black/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:max-w-[600px] sm:rounded-xl",
+                "fixed inset-0 z-[101] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:duration-200 data-[state=open]:duration-200",
                 className,
             )}
             {...props}
-        >
-            {children}
-            <DialogPrimitive.Close className="group absolute right-3 top-3 flex size-7 items-center justify-center rounded-lg outline-offset-2 transition-colors focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none">
-                <X className="size-4 opacity-60 transition-opacity group-hover:opacity-100" />
-                <span className="sr-only">Close</span>
-            </DialogPrimitive.Close>
-        </DialogPrimitive.Content>
-    </OnboardingDialogPortal>
-));
-OnboardingDialogContent.displayName = DialogPrimitive.Content.displayName;
+        />
+    );
+}
 
-const OnboardingDialogHeader = ({
+function OnboardingDialogContent({
+    className,
+    children,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;
+}) {
+    return (
+        <OnboardingDialogPortal>
+            <OnboardingDialogOverlay />
+            <DialogPrimitive.Content
+                ref={ref}
+                className={cn(
+                    "fixed left-1/2 top-1/2 z-[101] grid max-h-[calc(100%-4rem)] w-full -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto border bg-background p-6 shadow-lg shadow-black/5 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:duration-200 data-[state=open]:duration-200 sm:max-w-[600px] sm:rounded-xl",
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <DialogPrimitive.Close className="group absolute right-3 top-3 flex size-7 items-center justify-center rounded-lg outline-offset-2 transition-colors focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none">
+                    <X className="size-4 opacity-60 transition-opacity group-hover:opacity-100" />
+                    <span className="sr-only">Close</span>
+                </DialogPrimitive.Close>
+            </DialogPrimitive.Content>
+        </OnboardingDialogPortal>
+    );
+}
+
+function OnboardingDialogHeader({
     className,
     ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-    <div
-        className={cn(
-            "flex flex-col space-y-1.5 text-center sm:text-left",
-            className,
-        )}
-        {...props}
-    />
-);
-OnboardingDialogHeader.displayName = "OnboardingDialogHeader";
+}: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn(
+                "flex flex-col space-y-1.5 text-center sm:text-left",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
 
-const OnboardingDialogFooter = ({
+function OnboardingDialogFooter({
     className,
     ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-    <div
-        className={cn(
-            "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3",
-            className,
-        )}
-        {...props}
-    />
-);
-OnboardingDialogFooter.displayName = "OnboardingDialogFooter";
+}: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn(
+                "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-3",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
 
-const OnboardingDialogTitle = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Title>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-    <DialogPrimitive.Title
-        ref={ref}
-        className={cn("text-lg font-semibold tracking-tight", className)}
-        {...props}
-    />
-));
-OnboardingDialogTitle.displayName = DialogPrimitive.Title.displayName;
+function OnboardingDialogTitle({
+    className,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
+    ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Title>>;
+}) {
+    return (
+        <DialogPrimitive.Title
+            ref={ref}
+            className={cn("text-lg font-semibold tracking-tight", className)}
+            {...props}
+        />
+    );
+}
 
-const OnboardingDialogDescription = React.forwardRef<
-    React.ElementRef<typeof DialogPrimitive.Description>,
-    React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-    <DialogPrimitive.Description
-        ref={ref}
-        className={cn("text-sm text-muted-foreground", className)}
-        {...props}
-    />
-));
-OnboardingDialogDescription.displayName =
-    DialogPrimitive.Description.displayName;
+function OnboardingDialogDescription({
+    className,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+    ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Description>>;
+}) {
+    return (
+        <DialogPrimitive.Description
+            ref={ref}
+            className={cn("text-sm text-muted-foreground", className)}
+            {...props}
+        />
+    );
+}
 
 export {
     OnboardingDialogRoot as Dialog,

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-    ArrowLeft,
-    ArrowRight,
-    Bot,
-    CheckCircle2,
-    Mic,
-    Sparkles,
-} from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -18,11 +11,22 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/onboarding-dialog-base";
-import { PlaudConnectTabs } from "@/components/plaud-connect-tabs";
+import {
+    OnboardingStepAiProvider,
+    OnboardingStepComplete,
+    OnboardingStepPlaud,
+    OnboardingStepWelcome,
+} from "@/components/onboarding-steps";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type OnboardingStep = "welcome" | "plaud" | "ai-provider" | "complete";
+
+const STEP_ORDER: OnboardingStep[] = [
+    "welcome",
+    "plaud",
+    "ai-provider",
+    "complete",
+];
 
 interface OnboardingDialogProps {
     open: boolean;
@@ -40,6 +44,11 @@ export function OnboardingDialog({
     const [hasPlaudConnection, setHasPlaudConnection] = useState(false);
     const [hasAiProvider, setHasAiProvider] = useState(false);
 
+    // Probe whether the user already finished the Plaud connection in
+    // a previous session, so re-entering the flow doesn't make them
+    // re-paste a token. Same for the AI provider step below. Each runs
+    // only while its step is active to avoid an unnecessary request on
+    // mount.
     useEffect(() => {
         if (open && step === "plaud") {
             fetch("/api/plaud/connection")
@@ -66,6 +75,8 @@ export function OnboardingDialog({
         }
     }, [open, step]);
 
+    // Reset on dialog close so re-opening starts at the welcome step
+    // and the cached "has X" flags get re-fetched.
     useEffect(() => {
         if (!open) {
             setStep("welcome");
@@ -74,13 +85,12 @@ export function OnboardingDialog({
         }
     }, [open]);
 
-    const handleSkipPlaud = () => {
-        setStep("ai-provider");
-    };
-
-    const handleSkipAiProvider = () => {
-        setStep("complete");
-    };
+    const stepIndex = STEP_ORDER.indexOf(step);
+    const prevStep: OnboardingStep | null =
+        stepIndex > 0 ? STEP_ORDER[stepIndex - 1] : null;
+    const nextStep: OnboardingStep | null =
+        stepIndex < STEP_ORDER.length - 1 ? STEP_ORDER[stepIndex + 1] : null;
+    const canSkip = step === "plaud" || step === "ai-provider";
 
     const handleComplete = async () => {
         try {
@@ -97,56 +107,6 @@ export function OnboardingDialog({
         }
     };
 
-    const getStepIndex = () => {
-        const steps: OnboardingStep[] = [
-            "welcome",
-            "plaud",
-            "ai-provider",
-            "complete",
-        ];
-        return steps.indexOf(step);
-    };
-
-    const isStepCompleted = (stepIndex: number) => {
-        const currentIndex = getStepIndex();
-        return stepIndex < currentIndex;
-    };
-
-    const isStepCurrent = (stepIndex: number) => {
-        const currentIndex = getStepIndex();
-        return stepIndex === currentIndex;
-    };
-
-    const canSkipStep = () => {
-        if (step === "plaud") return true;
-        if (step === "ai-provider") return true;
-        return false;
-    };
-
-    const getNextStep = (): OnboardingStep | null => {
-        if (step === "welcome") return "plaud";
-        if (step === "plaud") return "ai-provider";
-        if (step === "ai-provider") return "complete";
-        return null;
-    };
-
-    const getPrevStep = (): OnboardingStep | null => {
-        if (step === "plaud") return "welcome";
-        if (step === "ai-provider") return "plaud";
-        if (step === "complete") return "ai-provider";
-        return null;
-    };
-
-    const handleNext = () => {
-        const next = getNextStep();
-        if (next) setStep(next);
-    };
-
-    const handlePrev = () => {
-        const prev = getPrevStep();
-        if (prev) setStep(prev);
-    };
-
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
@@ -157,250 +117,33 @@ export function OnboardingDialog({
                 </DialogHeader>
 
                 <div className="space-y-6">
-                    {step === "welcome" && (
-                        <div className="space-y-6">
-                            <div className="text-center space-y-2">
-                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Mic className="size-8 text-primary" />
-                                </div>
-                                <h3 className="text-xl font-semibold">
-                                    Your AI-Powered Recording Hub
-                                </h3>
-                                <p className="text-muted-foreground">
-                                    OpenPlaud helps you manage, transcribe, and
-                                    enhance your Plaud recordings with AI. Let's
-                                    set up your account.
-                                </p>
-                            </div>
-
-                            <div className="grid gap-4">
-                                <Card className="gap-0 py-4">
-                                    <CardHeader>
-                                        <CardTitle className="text-base flex items-center gap-2">
-                                            <Mic className="size-4" />
-                                            Connect Your Account
-                                        </CardTitle>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <p className="text-sm text-muted-foreground">
-                                            Sign in with your Plaud email to
-                                            sync recordings automatically
-                                        </p>
-                                    </CardContent>
-                                </Card>
-
-                                <Card className="gap-0 py-4">
-                                    <CardHeader>
-                                        <CardTitle className="text-base flex items-center gap-2">
-                                            <Bot className="size-4" />
-                                            Set Up AI Provider
-                                        </CardTitle>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <p className="text-sm text-muted-foreground">
-                                            Configure an AI provider for
-                                            automatic transcriptions
-                                        </p>
-                                    </CardContent>
-                                </Card>
-
-                                <Card className="gap-0 py-4">
-                                    <CardHeader>
-                                        <CardTitle className="text-base flex items-center gap-2">
-                                            <Sparkles className="size-4" />
-                                            Start Recording
-                                        </CardTitle>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <p className="text-sm text-muted-foreground">
-                                            You're all set! Start recording and
-                                            let AI do the work
-                                        </p>
-                                    </CardContent>
-                                </Card>
-                            </div>
-                        </div>
-                    )}
-
+                    {step === "welcome" && <OnboardingStepWelcome />}
                     {step === "plaud" && (
-                        <div className="space-y-6">
-                            <div className="text-center space-y-2">
-                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Mic className="size-8 text-primary" />
-                                </div>
-                                <h3 className="text-xl font-semibold">
-                                    Connect Your Plaud Account
-                                </h3>
-                                <p className="text-muted-foreground">
-                                    Sign in with your Plaud email to sync
-                                    recordings automatically
-                                </p>
-                            </div>
-
-                            {hasPlaudConnection ? (
-                                <Card className="border-primary/50 bg-primary/5 py-3">
-                                    <CardContent className="px-4">
-                                        <div className="flex items-center gap-3">
-                                            <CheckCircle2 className="size-5 text-primary" />
-                                            <div className="flex-1">
-                                                <p className="font-medium">
-                                                    Device Connected
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    Your Plaud account is
-                                                    connected
-                                                </p>
-                                            </div>
-                                            <Button
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() =>
-                                                    setHasPlaudConnection(false)
-                                                }
-                                            >
-                                                Reconnect
-                                            </Button>
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            ) : (
-                                <Card className="gap-0 py-4">
-                                    <CardContent className="pt-6">
-                                        <PlaudConnectTabs
-                                            variant="dialog"
-                                            onConnected={() =>
-                                                setHasPlaudConnection(true)
-                                            }
-                                        />
-                                    </CardContent>
-                                </Card>
-                            )}
-                        </div>
+                        <OnboardingStepPlaud
+                            hasPlaudConnection={hasPlaudConnection}
+                            onReconnect={() => setHasPlaudConnection(false)}
+                            onConnected={() => setHasPlaudConnection(true)}
+                        />
                     )}
-
                     {step === "ai-provider" && (
-                        <div className="space-y-6">
-                            <div className="text-center space-y-2">
-                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Bot className="size-8 text-primary" />
-                                </div>
-                                <h3 className="text-xl font-semibold">
-                                    Set Up AI Provider
-                                </h3>
-                                <p className="text-muted-foreground">
-                                    Configure an AI provider to enable automatic
-                                    transcriptions
-                                </p>
-                            </div>
-
-                            {hasAiProvider ? (
-                                <Card className="border-primary/50 bg-primary/5 py-3">
-                                    <CardContent>
-                                        <div className="flex items-center gap-3">
-                                            <CheckCircle2 className="size-5 text-primary" />
-                                            <div className="flex-1">
-                                                <p className="font-medium">
-                                                    AI Provider Configured
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    You already have an AI
-                                                    provider set up
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            ) : (
-                                <Card className="gap-0 py-4">
-                                    <CardContent className="pt-6 space-y-4">
-                                        <p className="text-sm text-muted-foreground">
-                                            You can set up an AI provider later
-                                            in Settings. This enables automatic
-                                            transcription of your recordings.
-                                        </p>
-                                        <Button
-                                            onClick={() => {
-                                                onOpenChange(false);
-                                                window.location.href =
-                                                    "/dashboard?settings=providers";
-                                            }}
-                                            variant="outline"
-                                            className="w-full"
-                                        >
-                                            Go to Settings
-                                        </Button>
-                                    </CardContent>
-                                </Card>
-                            )}
-                        </div>
+                        <OnboardingStepAiProvider
+                            hasAiProvider={hasAiProvider}
+                            onGoToSettings={() => {
+                                onOpenChange(false);
+                                window.location.href =
+                                    "/dashboard?settings=providers";
+                            }}
+                        />
                     )}
-
-                    {step === "complete" && (
-                        <div className="space-y-6">
-                            <div className="text-center space-y-2">
-                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <CheckCircle2 className="size-8 text-primary" />
-                                </div>
-                                <h3 className="text-xl font-semibold">
-                                    You're All Set!
-                                </h3>
-                                <p className="text-muted-foreground">
-                                    Start recording and let OpenPlaud handle the
-                                    rest
-                                </p>
-                            </div>
-
-                            <Card className="gap-0 py-4">
-                                <CardContent>
-                                    <div className="space-y-3">
-                                        <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
-                                            <div>
-                                                <p className="font-medium">
-                                                    Recordings sync
-                                                    automatically
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    Your Plaud device will sync
-                                                    recordings in the background
-                                                </p>
-                                            </div>
-                                        </div>
-                                        <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
-                                            <div>
-                                                <p className="font-medium">
-                                                    AI-powered transcriptions
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    Set up an AI provider to
-                                                    transcribe recordings
-                                                    automatically
-                                                </p>
-                                            </div>
-                                        </div>
-                                        <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
-                                            <div>
-                                                <p className="font-medium">
-                                                    Customize your experience
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    Adjust settings anytime from
-                                                    the Settings menu
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        </div>
-                    )}
+                    {step === "complete" && <OnboardingStepComplete />}
 
                     <DialogFooter className="gap-2 sm:gap-3 relative">
                         <div className="flex gap-2 flex-1">
-                            {getPrevStep() && (
-                                <Button variant="outline" onClick={handlePrev}>
+                            {prevStep && (
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setStep(prevStep)}
+                                >
                                     <ArrowLeft className="size-4 mr-2" />
                                     Previous
                                 </Button>
@@ -408,33 +151,29 @@ export function OnboardingDialog({
                         </div>
 
                         <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-2 mt-0.5">
-                            {[1, 2, 3, 4].map((stepNum, index) => {
-                                const completed = isStepCompleted(index);
-                                const current = isStepCurrent(index);
+                            {STEP_ORDER.map((stepName, index) => {
+                                const completed = index < stepIndex;
+                                const current = index === stepIndex;
                                 return (
                                     <div
-                                        key={stepNum}
+                                        key={stepName}
                                         className={`size-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
                                             completed || current
                                                 ? "bg-primary text-primary-foreground"
                                                 : "border-2 border-muted-foreground/30 text-muted-foreground"
                                         }`}
                                     >
-                                        {stepNum}
+                                        {index + 1}
                                     </div>
                                 );
                             })}
                         </div>
 
                         <div className="flex gap-2 flex-1 justify-end">
-                            {canSkipStep() && step !== "complete" && (
+                            {canSkip && nextStep && (
                                 <Button
                                     variant="ghost"
-                                    onClick={() => {
-                                        if (step === "plaud") handleSkipPlaud();
-                                        if (step === "ai-provider")
-                                            handleSkipAiProvider();
-                                    }}
+                                    onClick={() => setStep(nextStep)}
                                 >
                                     Skip
                                 </Button>
@@ -445,8 +184,8 @@ export function OnboardingDialog({
                                     <ArrowRight className="size-4 ml-2" />
                                 </Button>
                             ) : (
-                                getNextStep() && (
-                                    <Button onClick={handleNext}>
+                                nextStep && (
+                                    <Button onClick={() => setStep(nextStep)}>
                                         Next
                                         <ArrowRight className="size-4 ml-2" />
                                     </Button>

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -35,7 +35,7 @@ export function OnboardingDialog({
     onOpenChange,
     onComplete,
 }: OnboardingDialogProps) {
-    const router = useRouter();
+    const { refresh } = useRouter();
     const [step, setStep] = useState<OnboardingStep>("welcome");
     const [hasPlaudConnection, setHasPlaudConnection] = useState(false);
     const [hasAiProvider, setHasAiProvider] = useState(false);
@@ -91,7 +91,7 @@ export function OnboardingDialog({
             });
             onComplete();
             onOpenChange(false);
-            router.refresh();
+            refresh();
         } catch {
             toast.error("Failed to complete onboarding");
         }

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -160,8 +160,8 @@ export function OnboardingDialog({
                     {step === "welcome" && (
                         <div className="space-y-6">
                             <div className="text-center space-y-2">
-                                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Mic className="w-8 h-8 text-primary" />
+                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                                    <Mic className="size-8 text-primary" />
                                 </div>
                                 <h3 className="text-xl font-semibold">
                                     Your AI-Powered Recording Hub
@@ -177,7 +177,7 @@ export function OnboardingDialog({
                                 <Card className="gap-0 py-4">
                                     <CardHeader>
                                         <CardTitle className="text-base flex items-center gap-2">
-                                            <Mic className="w-4 h-4" />
+                                            <Mic className="size-4" />
                                             Connect Your Account
                                         </CardTitle>
                                     </CardHeader>
@@ -192,7 +192,7 @@ export function OnboardingDialog({
                                 <Card className="gap-0 py-4">
                                     <CardHeader>
                                         <CardTitle className="text-base flex items-center gap-2">
-                                            <Bot className="w-4 h-4" />
+                                            <Bot className="size-4" />
                                             Set Up AI Provider
                                         </CardTitle>
                                     </CardHeader>
@@ -207,7 +207,7 @@ export function OnboardingDialog({
                                 <Card className="gap-0 py-4">
                                     <CardHeader>
                                         <CardTitle className="text-base flex items-center gap-2">
-                                            <Sparkles className="w-4 h-4" />
+                                            <Sparkles className="size-4" />
                                             Start Recording
                                         </CardTitle>
                                     </CardHeader>
@@ -225,8 +225,8 @@ export function OnboardingDialog({
                     {step === "plaud" && (
                         <div className="space-y-6">
                             <div className="text-center space-y-2">
-                                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Mic className="w-8 h-8 text-primary" />
+                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                                    <Mic className="size-8 text-primary" />
                                 </div>
                                 <h3 className="text-xl font-semibold">
                                     Connect Your Plaud Account
@@ -241,7 +241,7 @@ export function OnboardingDialog({
                                 <Card className="border-primary/50 bg-primary/5 py-3">
                                     <CardContent className="px-4">
                                         <div className="flex items-center gap-3">
-                                            <CheckCircle2 className="w-5 h-5 text-primary" />
+                                            <CheckCircle2 className="size-5 text-primary" />
                                             <div className="flex-1">
                                                 <p className="font-medium">
                                                     Device Connected
@@ -281,8 +281,8 @@ export function OnboardingDialog({
                     {step === "ai-provider" && (
                         <div className="space-y-6">
                             <div className="text-center space-y-2">
-                                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <Bot className="w-8 h-8 text-primary" />
+                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                                    <Bot className="size-8 text-primary" />
                                 </div>
                                 <h3 className="text-xl font-semibold">
                                     Set Up AI Provider
@@ -297,7 +297,7 @@ export function OnboardingDialog({
                                 <Card className="border-primary/50 bg-primary/5 py-3">
                                     <CardContent>
                                         <div className="flex items-center gap-3">
-                                            <CheckCircle2 className="w-5 h-5 text-primary" />
+                                            <CheckCircle2 className="size-5 text-primary" />
                                             <div className="flex-1">
                                                 <p className="font-medium">
                                                     AI Provider Configured
@@ -338,8 +338,8 @@ export function OnboardingDialog({
                     {step === "complete" && (
                         <div className="space-y-6">
                             <div className="text-center space-y-2">
-                                <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                                    <CheckCircle2 className="w-8 h-8 text-primary" />
+                                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                                    <CheckCircle2 className="size-8 text-primary" />
                                 </div>
                                 <h3 className="text-xl font-semibold">
                                     You're All Set!
@@ -354,7 +354,7 @@ export function OnboardingDialog({
                                 <CardContent>
                                     <div className="space-y-3">
                                         <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="w-5 h-5 text-primary mt-0.5" />
+                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
                                             <div>
                                                 <p className="font-medium">
                                                     Recordings sync
@@ -367,7 +367,7 @@ export function OnboardingDialog({
                                             </div>
                                         </div>
                                         <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="w-5 h-5 text-primary mt-0.5" />
+                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
                                             <div>
                                                 <p className="font-medium">
                                                     AI-powered transcriptions
@@ -380,7 +380,7 @@ export function OnboardingDialog({
                                             </div>
                                         </div>
                                         <div className="flex items-start gap-3">
-                                            <CheckCircle2 className="w-5 h-5 text-primary mt-0.5" />
+                                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
                                             <div>
                                                 <p className="font-medium">
                                                     Customize your experience
@@ -401,7 +401,7 @@ export function OnboardingDialog({
                         <div className="flex gap-2 flex-1">
                             {getPrevStep() && (
                                 <Button variant="outline" onClick={handlePrev}>
-                                    <ArrowLeft className="w-4 h-4 mr-2" />
+                                    <ArrowLeft className="size-4 mr-2" />
                                     Previous
                                 </Button>
                             )}
@@ -414,7 +414,7 @@ export function OnboardingDialog({
                                 return (
                                     <div
                                         key={stepNum}
-                                        className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
+                                        className={`size-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors ${
                                             completed || current
                                                 ? "bg-primary text-primary-foreground"
                                                 : "border-2 border-muted-foreground/30 text-muted-foreground"
@@ -442,13 +442,13 @@ export function OnboardingDialog({
                             {step === "complete" ? (
                                 <Button onClick={handleComplete}>
                                     Get Started
-                                    <ArrowRight className="w-4 h-4 ml-2" />
+                                    <ArrowRight className="size-4 ml-2" />
                                 </Button>
                             ) : (
                                 getNextStep() && (
                                     <Button onClick={handleNext}>
                                         Next
-                                        <ArrowRight className="w-4 h-4 ml-2" />
+                                        <ArrowRight className="size-4 ml-2" />
                                     </Button>
                                 )
                             )}

--- a/src/components/onboarding-steps.tsx
+++ b/src/components/onboarding-steps.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { Bot, CheckCircle2, Mic, Sparkles } from "lucide-react";
+import { PlaudConnectTabs } from "@/components/plaud-connect-tabs";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/**
+ * Step 1: welcome / overview. Pure presentation -- explains what the
+ * onboarding flow is about to ask the user to do.
+ */
+export function OnboardingStepWelcome() {
+    return (
+        <div className="space-y-6">
+            <div className="text-center space-y-2">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <Mic className="size-8 text-primary" />
+                </div>
+                <h3 className="text-xl font-semibold">
+                    Your AI-Powered Recording Hub
+                </h3>
+                <p className="text-muted-foreground">
+                    OpenPlaud helps you manage, transcribe, and enhance your
+                    Plaud recordings with AI. Let's set up your account.
+                </p>
+            </div>
+
+            <div className="grid gap-4">
+                <Card className="gap-0 py-4">
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2">
+                            <Mic className="size-4" />
+                            Connect Your Account
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-sm text-muted-foreground">
+                            Sign in with your Plaud email to sync recordings
+                            automatically
+                        </p>
+                    </CardContent>
+                </Card>
+
+                <Card className="gap-0 py-4">
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2">
+                            <Bot className="size-4" />
+                            Set Up AI Provider
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-sm text-muted-foreground">
+                            Configure an AI provider for automatic
+                            transcriptions
+                        </p>
+                    </CardContent>
+                </Card>
+
+                <Card className="gap-0 py-4">
+                    <CardHeader>
+                        <CardTitle className="text-base flex items-center gap-2">
+                            <Sparkles className="size-4" />
+                            Start Recording
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-sm text-muted-foreground">
+                            You're all set! Start recording and let AI do the
+                            work
+                        </p>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Step 2: Plaud account connection. When already connected, shows a
+ * confirmation card with a Reconnect button; otherwise embeds the
+ * shared PlaudConnectTabs (email OTP / paste-token / connector flows).
+ */
+export function OnboardingStepPlaud({
+    hasPlaudConnection,
+    onReconnect,
+    onConnected,
+}: {
+    hasPlaudConnection: boolean;
+    onReconnect: () => void;
+    onConnected: () => void;
+}) {
+    return (
+        <div className="space-y-6">
+            <div className="text-center space-y-2">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <Mic className="size-8 text-primary" />
+                </div>
+                <h3 className="text-xl font-semibold">
+                    Connect Your Plaud Account
+                </h3>
+                <p className="text-muted-foreground">
+                    Sign in with your Plaud email to sync recordings
+                    automatically
+                </p>
+            </div>
+
+            {hasPlaudConnection ? (
+                <Card className="border-primary/50 bg-primary/5 py-3">
+                    <CardContent className="px-4">
+                        <div className="flex items-center gap-3">
+                            <CheckCircle2 className="size-5 text-primary" />
+                            <div className="flex-1">
+                                <p className="font-medium">Device Connected</p>
+                                <p className="text-sm text-muted-foreground">
+                                    Your Plaud account is connected
+                                </p>
+                            </div>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={onReconnect}
+                            >
+                                Reconnect
+                            </Button>
+                        </div>
+                    </CardContent>
+                </Card>
+            ) : (
+                <Card className="gap-0 py-4">
+                    <CardContent className="pt-6">
+                        <PlaudConnectTabs
+                            variant="dialog"
+                            onConnected={onConnected}
+                        />
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Step 3: AI provider configuration. When already configured, just
+ * confirms. Otherwise punts to the Settings -> Providers section
+ * (the actual provider configuration lives there; embedding the full
+ * provider UI in the onboarding dialog would duplicate too much).
+ */
+export function OnboardingStepAiProvider({
+    hasAiProvider,
+    onGoToSettings,
+}: {
+    hasAiProvider: boolean;
+    onGoToSettings: () => void;
+}) {
+    return (
+        <div className="space-y-6">
+            <div className="text-center space-y-2">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <Bot className="size-8 text-primary" />
+                </div>
+                <h3 className="text-xl font-semibold">Set Up AI Provider</h3>
+                <p className="text-muted-foreground">
+                    Configure an AI provider to enable automatic transcriptions
+                </p>
+            </div>
+
+            {hasAiProvider ? (
+                <Card className="border-primary/50 bg-primary/5 py-3">
+                    <CardContent>
+                        <div className="flex items-center gap-3">
+                            <CheckCircle2 className="size-5 text-primary" />
+                            <div className="flex-1">
+                                <p className="font-medium">
+                                    AI Provider Configured
+                                </p>
+                                <p className="text-sm text-muted-foreground">
+                                    You already have an AI provider set up
+                                </p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            ) : (
+                <Card className="gap-0 py-4">
+                    <CardContent className="pt-6 space-y-4">
+                        <p className="text-sm text-muted-foreground">
+                            You can set up an AI provider later in Settings.
+                            This enables automatic transcription of your
+                            recordings.
+                        </p>
+                        <Button
+                            onClick={onGoToSettings}
+                            variant="outline"
+                            className="w-full"
+                        >
+                            Go to Settings
+                        </Button>
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Step 4: completion. Recaps what happens next so the user knows what
+ * to expect when they hit Get Started.
+ */
+export function OnboardingStepComplete() {
+    return (
+        <div className="space-y-6">
+            <div className="text-center space-y-2">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <CheckCircle2 className="size-8 text-primary" />
+                </div>
+                <h3 className="text-xl font-semibold">You're All Set!</h3>
+                <p className="text-muted-foreground">
+                    Start recording and let OpenPlaud handle the rest
+                </p>
+            </div>
+
+            <Card className="gap-0 py-4">
+                <CardContent>
+                    <div className="space-y-3">
+                        <div className="flex items-start gap-3">
+                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
+                            <div>
+                                <p className="font-medium">
+                                    Recordings sync automatically
+                                </p>
+                                <p className="text-sm text-muted-foreground">
+                                    Your Plaud device will sync recordings in
+                                    the background
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-start gap-3">
+                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
+                            <div>
+                                <p className="font-medium">
+                                    AI-powered transcriptions
+                                </p>
+                                <p className="text-sm text-muted-foreground">
+                                    Set up an AI provider to transcribe
+                                    recordings automatically
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-start gap-3">
+                            <CheckCircle2 className="size-5 text-primary mt-0.5" />
+                            <div>
+                                <p className="font-medium">
+                                    Customize your experience
+                                </p>
+                                <p className="text-sm text-muted-foreground">
+                                    Adjust settings anytime from the Settings
+                                    menu
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -35,7 +35,7 @@ export function OnboardingForm() {
             {step === "connect" && (
                 <div className="space-y-4">
                     <div>
-                        <h2 className="text-xl font-bold">
+                        <h2 className="text-xl font-semibold">
                             Connect Your Plaud Account
                         </h2>
                         <p className="text-sm text-muted-foreground mt-1">
@@ -70,7 +70,9 @@ export function OnboardingForm() {
                         className="mx-auto"
                     />
                     <div>
-                        <h2 className="text-2xl font-bold">Setup Complete!</h2>
+                        <h2 className="text-2xl font-semibold">
+                            Setup Complete!
+                        </h2>
                         <p className="text-sm text-muted-foreground mt-1">
                             Your recordings will start syncing automatically
                         </p>
@@ -107,7 +109,7 @@ export function OnboardingForm() {
                             instance. No data leaves your server.
                         </p>
                         <p>
-                            This is open source software — every line is
+                            This is open source software. Every line is
                             available for inspection:{" "}
                             <a
                                 href={GITHUB_REPO}

--- a/src/components/onboarding/onboarding-form.tsx
+++ b/src/components/onboarding/onboarding-form.tsx
@@ -13,7 +13,7 @@ const GITHUB_REPO = "https://github.com/openplaud/openplaud";
 
 export function OnboardingForm() {
     const [step, setStep] = useState<Step>("connect");
-    const router = useRouter();
+    const { push } = useRouter();
 
     return (
         <Panel className="w-full max-w-2xl space-y-6">
@@ -78,7 +78,7 @@ export function OnboardingForm() {
                         </p>
                     </div>
                     <MetalButton
-                        onClick={() => router.push("/dashboard")}
+                        onClick={() => push("/dashboard")}
                         variant="cyan"
                         className="w-full"
                     >

--- a/src/components/panel.tsx
+++ b/src/components/panel.tsx
@@ -1,28 +1,26 @@
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {
     variant?: "default" | "inset" | "glass";
+    ref?: React.Ref<HTMLDivElement>;
 }
 
-const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
-    ({ className, variant = "default", ...props }, ref) => {
-        const variantClass =
-            variant === "inset"
-                ? "panel-inset"
-                : variant === "glass"
-                  ? "glass-panel"
-                  : "panel";
+function Panel({ className, variant = "default", ref, ...props }: PanelProps) {
+    const variantClass =
+        variant === "inset"
+            ? "panel-inset"
+            : variant === "glass"
+              ? "glass-panel"
+              : "panel";
 
-        return (
-            <div
-                ref={ref}
-                className={cn(variantClass, "rounded-lg p-6", className)}
-                {...props}
-            />
-        );
-    },
-);
-Panel.displayName = "Panel";
+    return (
+        <div
+            ref={ref}
+            className={cn(variantClass, "rounded-lg p-6", className)}
+            {...props}
+        />
+    );
+}
 
 export { Panel };

--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -391,6 +391,7 @@ function EmailCodePane({
                         onChange={(e) => setEmail(e.target.value)}
                         onKeyDown={(e) => e.key === "Enter" && handleSendCode()}
                         disabled={isLoading}
+                        // oxlint-disable-next-line jsx-a11y/no-autofocus -- intentional -- modal-entry input, focusing it is the whole UX point
                         autoFocus
                     />
                     <p className="text-xs text-muted-foreground">
@@ -448,6 +449,7 @@ function EmailCodePane({
                     onKeyDown={(e) => e.key === "Enter" && handleVerify()}
                     disabled={isLoading}
                     className="font-mono text-lg tracking-[0.3em] text-center"
+                    // oxlint-disable-next-line jsx-a11y/no-autofocus -- intentional -- OTP code input shown right after "we sent you a code"; user is expected to type immediately
                     autoFocus
                     autoComplete="one-time-code"
                 />

--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -210,7 +210,7 @@ function ConnectorPane({
                     <span className="font-medium">OpenPlaud Connector</span>{" "}
                     browser extension. Sign in to Plaud the way you normally do
                     (Google, Apple, or email) and the connector hands the
-                    session back here — no copy-pasting.
+                    session back here, no copy-pasting.
                 </p>
                 <Button asChild className="w-full">
                     <a
@@ -248,9 +248,9 @@ function ConnectorPane({
     return (
         <div className="space-y-3">
             <p className="text-sm text-muted-foreground leading-relaxed">
-                Click below to sign in to Plaud in a new tab — use Google,
-                Apple, or email/password as you normally would. The connector
-                will return you here automatically.
+                Click below to sign in to Plaud in a new tab. Use Google, Apple,
+                or email/password as you normally would. The connector will
+                return you here automatically.
             </p>
             <Button
                 onClick={handleConnect}
@@ -660,8 +660,8 @@ function PasteTokenPane({
                         above.
                     </li>
                     <li>
-                        Pick the matching region from the dropdown — e.g. if the
-                        host was{" "}
+                        Pick the matching region from the dropdown. For example,
+                        if the host was{" "}
                         <span className="font-mono">api-euc1.plaud.ai</span>,
                         choose EU.
                     </li>

--- a/src/components/recordings/back-button.tsx
+++ b/src/components/recordings/back-button.tsx
@@ -9,7 +9,7 @@ export function BackButton() {
 
     return (
         <MetalButton onClick={() => router.push("/dashboard")} size="icon">
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft className="size-4" />
         </MetalButton>
     );
 }

--- a/src/components/recordings/back-button.tsx
+++ b/src/components/recordings/back-button.tsx
@@ -5,10 +5,10 @@ import { useRouter } from "next/navigation";
 import { MetalButton } from "@/components/metal-button";
 
 export function BackButton() {
-    const router = useRouter();
+    const { push } = useRouter();
 
     return (
-        <MetalButton onClick={() => router.push("/dashboard")} size="icon">
+        <MetalButton onClick={() => push("/dashboard")} size="icon">
             <ArrowLeft className="size-4" />
         </MetalButton>
     );

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import { TranscriptionPanel } from "@/components/dashboard/transcription-panel";
+import { LocalTime } from "@/components/local-time";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -117,7 +118,7 @@ export function RecordingWorkstation({
                             {recording.filename}
                         </h1>
                         <p className="text-muted-foreground text-sm mt-1">
-                            {new Date(recording.startTime).toLocaleString()}
+                            <LocalTime value={recording.startTime} />
                         </p>
                     </div>
                     <Button
@@ -191,9 +192,10 @@ export function RecordingWorkstation({
                                         Date
                                     </div>
                                     <div className="font-medium">
-                                        {new Date(
-                                            recording.startTime,
-                                        ).toLocaleDateString()}
+                                        <LocalTime
+                                            value={recording.startTime}
+                                            variant="date"
+                                        />
                                     </div>
                                 </div>
                             </div>

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -113,7 +113,7 @@ export function RecordingWorkstation({
                         <ArrowLeft className="size-4" />
                     </Button>
                     <div className="flex-1 min-w-0">
-                        <h1 className="text-3xl font-bold truncate">
+                        <h1 className="text-3xl font-semibold truncate">
                             {recording.filename}
                         </h1>
                         <p className="text-muted-foreground text-sm mt-1">

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -110,7 +110,7 @@ export function RecordingWorkstation({
                         variant="outline"
                         size="icon"
                     >
-                        <ArrowLeft className="w-4 h-4" />
+                        <ArrowLeft className="size-4" />
                     </Button>
                     <div className="flex-1 min-w-0">
                         <h1 className="text-3xl font-bold truncate">
@@ -127,7 +127,7 @@ export function RecordingWorkstation({
                         aria-label="Delete recording"
                         title="Delete recording"
                     >
-                        <Trash2 className="w-4 h-4" />
+                        <Trash2 className="size-4" />
                     </Button>
                 </div>
 
@@ -233,7 +233,7 @@ export function RecordingWorkstation({
                         >
                             {isDeleting ? (
                                 <>
-                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    <Loader2 className="size-4 mr-2 animate-spin" />
                                     Deleting…
                                 </>
                             ) : (

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -48,7 +48,7 @@ export function RecordingWorkstation({
     initialAutoPlayNext,
     scrubberStyle,
 }: RecordingWorkstationProps) {
-    const router = useRouter();
+    const { push, refresh } = useRouter();
     const [isTranscribing, setIsTranscribing] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -65,7 +65,7 @@ export function RecordingWorkstation({
 
             if (response.ok) {
                 toast.success("Transcription complete");
-                router.refresh();
+                refresh();
             } else {
                 const error = await response.json();
                 toast.error(error.error || "Transcription failed");
@@ -75,7 +75,7 @@ export function RecordingWorkstation({
         } finally {
             setIsTranscribing(false);
         }
-    }, [recording.id, router]);
+    }, [recording.id, refresh]);
 
     const handleDelete = useCallback(async () => {
         setIsDeleting(true);
@@ -87,8 +87,8 @@ export function RecordingWorkstation({
             if (response.ok) {
                 toast.success("Recording deleted");
                 setDeleteDialogOpen(false);
-                router.push("/dashboard");
-                router.refresh();
+                push("/dashboard");
+                refresh();
             } else {
                 const error = await response.json().catch(() => ({}));
                 toast.error(error.error || "Failed to delete recording");
@@ -98,7 +98,7 @@ export function RecordingWorkstation({
             toast.error("Failed to delete recording");
             setIsDeleting(false);
         }
-    }, [recording.id, router]);
+    }, [recording.id, refresh, push]);
 
     return (
         <div className="bg-background">
@@ -106,7 +106,7 @@ export function RecordingWorkstation({
                 {/* Header */}
                 <div className="flex items-center gap-4 mb-6">
                     <Button
-                        onClick={() => router.push("/dashboard")}
+                        onClick={() => push("/dashboard")}
                         variant="outline"
                         size="icon"
                     >

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -175,7 +175,9 @@ export function TranscriptionSection({
                 <div className="space-y-4">
                     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                         <div className="flex flex-wrap items-center gap-3">
-                            <h2 className="text-xl font-bold">Transcription</h2>
+                            <h2 className="text-xl font-semibold">
+                                Transcription
+                            </h2>
                             {detectedLanguage && (
                                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-panel-inset">
                                     <LEDIndicator
@@ -243,7 +245,9 @@ export function TranscriptionSection({
                     <div className="space-y-4">
                         <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                             <div className="flex items-center gap-3">
-                                <h2 className="text-xl font-bold">Summary</h2>
+                                <h2 className="text-xl font-semibold">
+                                    Summary
+                                </h2>
                             </div>
                             <div className="flex items-center gap-2">
                                 {!isSummarizing && (

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -204,7 +204,7 @@ export function TranscriptionSection({
                             className="w-full md:w-auto"
                         >
                             {isProcessing
-                                ? "Processing..."
+                                ? "Processing…"
                                 : transcription
                                   ? "Re-transcribe"
                                   : "Transcribe"}
@@ -276,17 +276,17 @@ export function TranscriptionSection({
                                 >
                                     {isSummarizing ? (
                                         <>
-                                            <Loader2 className="w-4 h-4 mr-2 animate-spin inline" />
-                                            Generating...
+                                            <Loader2 className="size-4 mr-2 animate-spin inline" />
+                                            Generating…
                                         </>
                                     ) : summaryData ? (
                                         <>
-                                            <RefreshCw className="w-4 h-4 mr-2 inline" />
+                                            <RefreshCw className="size-4 mr-2 inline" />
                                             Re-generate
                                         </>
                                     ) : (
                                         <>
-                                            <Sparkles className="w-4 h-4 mr-2 inline" />
+                                            <Sparkles className="size-4 mr-2 inline" />
                                             Summarize
                                         </>
                                     )}
@@ -296,9 +296,9 @@ export function TranscriptionSection({
 
                         {isSummarizing ? (
                             <Panel variant="inset" className="text-center py-8">
-                                <Loader2 className="w-8 h-8 animate-spin text-accent-cyan mx-auto mb-4" />
+                                <Loader2 className="size-8 animate-spin text-accent-cyan mx-auto mb-4" />
                                 <p className="text-muted-foreground">
-                                    Generating summary...
+                                    Generating summary…
                                 </p>
                             </Panel>
                         ) : summaryData?.summary ? (
@@ -311,9 +311,9 @@ export function TranscriptionSection({
                                     className="flex items-center gap-1 text-sm font-medium hover:text-accent-cyan transition-colors"
                                 >
                                     {summaryExpanded ? (
-                                        <ChevronUp className="w-4 h-4" />
+                                        <ChevronUp className="size-4" />
                                     ) : (
-                                        <ChevronDown className="w-4 h-4" />
+                                        <ChevronDown className="size-4" />
                                     )}
                                     {summaryExpanded
                                         ? "Collapse"
@@ -346,7 +346,7 @@ export function TranscriptionSection({
                                                                         }
                                                                         className="text-sm text-muted-foreground flex items-start gap-2"
                                                                     >
-                                                                        <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-accent-cyan shrink-0" />
+                                                                        <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
                                                                         {point}
                                                                     </li>
                                                                 );
@@ -374,7 +374,7 @@ export function TranscriptionSection({
                                                                         }
                                                                         className="text-sm text-muted-foreground flex items-start gap-2"
                                                                     >
-                                                                        <ListChecks className="w-3.5 h-3.5 mt-0.5 text-accent-cyan shrink-0" />
+                                                                        <ListChecks className="size-3.5 mt-0.5 text-accent-cyan shrink-0" />
                                                                         {item}
                                                                     </li>
                                                                 );
@@ -402,7 +402,7 @@ export function TranscriptionSection({
                                                 variant="cyan"
                                                 className="text-xs"
                                             >
-                                                <Trash2 className="w-3.5 h-3.5 mr-1 inline" />
+                                                <Trash2 className="size-3.5 mr-1 inline" />
                                                 Delete
                                             </MetalButton>
                                         </div>
@@ -411,7 +411,7 @@ export function TranscriptionSection({
                             </div>
                         ) : (
                             <Panel variant="inset" className="text-center py-8">
-                                <ListChecks className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
+                                <ListChecks className="size-10 text-muted-foreground mx-auto mb-3" />
                                 <p className="text-sm text-muted-foreground">
                                     No summary yet. Click &quot;Summarize&quot;
                                     to generate one.

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -9,7 +9,7 @@ import {
     Sparkles,
     Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { LEDIndicator } from "@/components/led-indicator";
 import { MetalButton } from "@/components/metal-button";
@@ -21,15 +21,8 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { useTranscriptionSummary } from "@/hooks/use-transcription-summary";
 import { SUMMARY_PRESETS } from "@/lib/ai/summary-presets";
-
-interface SummaryData {
-    summary: string | null;
-    keyPoints: string[] | null;
-    actionItems: string[] | null;
-    provider?: string;
-    model?: string;
-}
 
 interface TranscriptionSectionProps {
     recordingId: string;
@@ -49,34 +42,20 @@ export function TranscriptionSection({
     const [transcriptionType, setTranscriptionType] = useState(initialType);
     const [isProcessing, setIsProcessing] = useState(false);
 
-    // Summary state
-    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
-    const [isSummarizing, setIsSummarizing] = useState(false);
-    const [summaryExpanded, setSummaryExpanded] = useState(true);
-    const [summaryPreset, setSummaryPreset] = useState("general");
-
-    // Key to force re-fetch summary (e.g. after re-transcription)
-    const [summaryFetchKey, setSummaryFetchKey] = useState(0);
-
-    // Fetch existing summary on mount / after re-transcribe
-    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch trigger
-    useEffect(() => {
-        const controller = new AbortController();
-        fetch(`/api/recordings/${recordingId}/summary`, {
-            signal: controller.signal,
-        })
-            .then((res) => res.json())
-            .then((data) => {
-                if (data.summary) {
-                    setSummaryData(data);
-                } else {
-                    setSummaryData(null);
-                }
-            })
-            .catch(() => {});
-
-        return () => controller.abort();
-    }, [recordingId, summaryFetchKey]);
+    const {
+        summaryData,
+        isSummarizing,
+        summaryExpanded,
+        setSummaryExpanded,
+        summaryPreset,
+        setSummaryPreset,
+        handleSummarize,
+        handleDeleteSummary,
+        refetchSummary,
+    } = useTranscriptionSummary({
+        recordingId,
+        transcriptionText: transcription,
+    });
 
     const handleTranscribe = async () => {
         setIsProcessing(true);
@@ -107,9 +86,12 @@ export function TranscriptionSection({
             setTranscription(data.transcription);
             setDetectedLanguage(data.detectedLanguage);
             setTranscriptionType("server");
-            // Invalidate cached summary — it was based on old text
-            setSummaryData(null);
-            setSummaryFetchKey((k) => k + 1);
+            // Force a summary re-fetch -- the server may have already
+            // auto-summarized. The hook also handles text-change
+            // invalidation via its internal ref, but we trigger here
+            // explicitly because we own the transcription state and
+            // know the moment it changes.
+            refetchSummary();
             toast.success("Transcription complete");
         } catch {
             toast.error("Transcription failed. Please try again.");
@@ -117,56 +99,6 @@ export function TranscriptionSection({
             setIsProcessing(false);
         }
     };
-
-    const handleSummarize = useCallback(async () => {
-        setIsSummarizing(true);
-        try {
-            const response = await fetch(
-                `/api/recordings/${recordingId}/summary`,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ preset: summaryPreset }),
-                },
-            );
-
-            if (response.ok) {
-                const data = await response.json();
-                setSummaryData(data);
-                toast.success("Summary generated");
-            } else {
-                const error = await response.json();
-                toast.error(error.error || "Summary generation failed");
-            }
-        } catch {
-            toast.error("Failed to generate summary");
-        } finally {
-            setIsSummarizing(false);
-        }
-    }, [recordingId, summaryPreset]);
-
-    const handleDeleteSummary = useCallback(async () => {
-        // Optimistic delete
-        const previous = summaryData;
-        setSummaryData(null);
-
-        try {
-            const response = await fetch(
-                `/api/recordings/${recordingId}/summary`,
-                { method: "DELETE" },
-            );
-
-            if (response.ok) {
-                toast.success("Summary deleted");
-            } else {
-                setSummaryData(previous);
-                toast.error("Failed to delete summary");
-            }
-        } catch {
-            setSummaryData(previous);
-            toast.error("Failed to delete summary");
-        }
-    }, [recordingId, summaryData]);
 
     return (
         <div className="space-y-6">
@@ -239,7 +171,7 @@ export function TranscriptionSection({
                 </div>
             </Panel>
 
-            {/* Summary Panel — only show when transcription exists */}
+            {/* Summary Panel -- only show when transcription exists */}
             {transcription && (
                 <Panel>
                     <div className="space-y-4">

--- a/src/components/settings-content.tsx
+++ b/src/components/settings-content.tsx
@@ -25,6 +25,8 @@ interface Provider {
     createdAt: Date;
 }
 
+const EMPTY_PROVIDERS: Provider[] = [];
+
 interface SettingsContentProps {
     activeSection: SettingsSection;
     initialProviders?: Provider[];
@@ -34,7 +36,7 @@ interface SettingsContentProps {
 
 export function SettingsContent({
     activeSection,
-    initialProviders = [],
+    initialProviders = EMPTY_PROVIDERS,
     onReRunOnboarding,
     isHosted = false,
 }: SettingsContentProps) {

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,45 +1,17 @@
 "use client";
 
-import {
-    Bell,
-    Bot,
-    Download,
-    FileText,
-    HardDrive,
-    KeyRound,
-    ListChecks,
-    Mic,
-    Monitor,
-    Play,
-    RefreshCw,
-    Settings as SettingsIcon,
-    Webhook,
-    Wrench,
-} from "lucide-react";
-import * as React from "react";
+import { useCallback } from "react";
+import { SettingsNavMobile } from "@/components/settings-nav-mobile";
+import { SettingsNavSidebar } from "@/components/settings-nav-sidebar";
 import {
     Dialog,
     DialogContent,
     DialogDescription,
     DialogTitle,
 } from "@/components/ui/dialog";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
-import {
-    Sidebar,
-    SidebarContent,
-    SidebarGroup,
-    SidebarGroupContent,
-    SidebarMenu,
-    SidebarMenuButton,
-    SidebarMenuItem,
-    SidebarProvider,
-} from "@/components/ui/sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { useSettingsNav } from "@/hooks/use-settings-nav";
+import type { SettingsSection } from "@/types/settings";
 import { SettingsContent } from "./settings-content";
 
 export interface Provider {
@@ -60,78 +32,6 @@ interface SettingsDialogProps {
     isHosted?: boolean;
 }
 
-import type { SettingsSection } from "@/types/settings";
-
-type NavItem = {
-    name: string;
-    id: SettingsSection;
-    icon: typeof Bot;
-};
-
-// Grouped navigation. The grouping is presentational only; iteration
-// code below flattens via `settingsNav` so keyboard nav, hash routing,
-// and localStorage continue to operate on a flat indexed list.
-const settingsNavGroups: { label: string; items: NavItem[] }[] = [
-    {
-        label: "AI",
-        items: [
-            { name: "Providers", id: "providers", icon: Bot },
-            { name: "Transcription", id: "transcription", icon: FileText },
-            { name: "Summary", id: "summary", icon: ListChecks },
-        ],
-    },
-    {
-        label: "Plaud",
-        items: [
-            { name: "Plaud Account", id: "plaud-account", icon: Mic },
-            { name: "Sync", id: "sync", icon: RefreshCw },
-        ],
-    },
-    {
-        label: "Personalize",
-        items: [
-            { name: "Playback", id: "playback", icon: Play },
-            { name: "Display", id: "display", icon: Monitor },
-            { name: "Notifications", id: "notifications", icon: Bell },
-        ],
-    },
-    {
-        label: "Data",
-        items: [
-            { name: "Storage", id: "storage", icon: HardDrive },
-            { name: "Export/Backup", id: "export", icon: Download },
-        ],
-    },
-    {
-        label: "Integrations",
-        items: [
-            { name: "API Keys", id: "api-keys", icon: KeyRound },
-            { name: "Webhooks", id: "webhooks", icon: Webhook },
-        ],
-    },
-    ...(process.env.NODE_ENV !== "production"
-        ? [
-              {
-                  label: "Advanced",
-                  items: [
-                      {
-                          name: "Developer Tools",
-                          id: "dev" as SettingsSection,
-                          icon: Wrench,
-                      },
-                  ],
-              },
-          ]
-        : []),
-];
-
-// Flat list derived from the groups — keep this the single source of
-// truth for keyboard nav / hash routing / localStorage. Changing the
-// group structure above must not break index-based iteration.
-const settingsNav: NavItem[] = settingsNavGroups.flatMap((g) => g.items);
-
-const STORAGE_KEY = "settings-last-section";
-
 const EMPTY_PROVIDERS: Provider[] = [];
 
 export function SettingsDialog({
@@ -141,129 +41,13 @@ export function SettingsDialog({
     onReRunOnboarding,
     isHosted = false,
 }: SettingsDialogProps) {
-    const [activeSection, setActiveSection] =
-        React.useState<SettingsSection>("providers");
-    const [keyboardSelectedIndex, setKeyboardSelectedIndex] =
-        React.useState<number>(0);
+    const onClose = useCallback(() => onOpenChange(false), [onOpenChange]);
+    const { activeSection, setActiveSection, keyboardSelectedIndex } =
+        useSettingsNav(open, onClose);
 
-    const activeNavItem = settingsNav.find((item) => item.id === activeSection);
-
-    React.useEffect(() => {
-        if (typeof window === "undefined") return;
-
-        const hash = window.location.hash.slice(1);
-        const validSection = settingsNav.find((item) => item.id === hash)?.id as
-            | SettingsSection
-            | undefined;
-
-        if (validSection) {
-            setActiveSection(validSection);
-            setKeyboardSelectedIndex(
-                settingsNav.findIndex((item) => item.id === validSection),
-            );
-        } else {
-            const lastSection = localStorage.getItem(STORAGE_KEY);
-            if (lastSection) {
-                const validLastSection = settingsNav.find(
-                    (item) => item.id === lastSection,
-                )?.id as SettingsSection | undefined;
-                if (validLastSection) {
-                    setActiveSection(validLastSection);
-                    setKeyboardSelectedIndex(
-                        settingsNav.findIndex(
-                            (item) => item.id === validLastSection,
-                        ),
-                    );
-                }
-            }
-        }
-    }, []);
-
-    React.useEffect(() => {
-        if (typeof window === "undefined") return;
-        window.location.hash = activeSection;
-        localStorage.setItem(STORAGE_KEY, activeSection);
-    }, [activeSection]);
-
-    React.useEffect(() => {
-        if (open) {
-            const timer = setTimeout(() => {
-                const firstButton = document.querySelector(
-                    '[data-settings-nav="first"]',
-                ) as HTMLButtonElement | null;
-                firstButton?.focus();
-            }, 100);
-            return () => clearTimeout(timer);
-        }
-    }, [open]);
-
-    const handleKeyDown = React.useCallback(
-        (e: KeyboardEvent) => {
-            if (!open) return;
-
-            if (e.key === "Escape") {
-                onOpenChange(false);
-                return;
-            }
-
-            const target = e.target as HTMLElement;
-            if (
-                target.tagName === "INPUT" ||
-                target.tagName === "TEXTAREA" ||
-                target.isContentEditable
-            ) {
-                return;
-            }
-
-            switch (e.key) {
-                case "ArrowDown": {
-                    e.preventDefault();
-                    setKeyboardSelectedIndex((prev) => {
-                        const next = Math.min(prev + 1, settingsNav.length - 1);
-                        return next;
-                    });
-                    break;
-                }
-                case "ArrowUp": {
-                    e.preventDefault();
-                    setKeyboardSelectedIndex((prev) => Math.max(prev - 1, 0));
-                    break;
-                }
-                case "Enter":
-                case " ": {
-                    e.preventDefault();
-                    const selectedItem = settingsNav[keyboardSelectedIndex];
-                    if (selectedItem) {
-                        setActiveSection(selectedItem.id);
-                    }
-                    break;
-                }
-            }
-        },
-        [open, keyboardSelectedIndex, onOpenChange],
-    );
-
-    React.useEffect(() => {
-        if (open) {
-            window.addEventListener("keydown", handleKeyDown);
-            return () => window.removeEventListener("keydown", handleKeyDown);
-        }
-    }, [open, handleKeyDown]);
-
-    React.useEffect(() => {
-        const index = settingsNav.findIndex(
-            (item) => item.id === activeSection,
-        );
-        if (index !== -1) {
-            setKeyboardSelectedIndex(index);
-        }
-    }, [activeSection]);
-
-    const handleSectionChange = React.useCallback(
-        (section: SettingsSection) => {
-            setActiveSection(section);
-        },
-        [],
+    const handleSectionChange = useCallback(
+        (section: SettingsSection) => setActiveSection(section),
+        [setActiveSection],
     );
 
     return (
@@ -275,183 +59,28 @@ export function SettingsDialog({
                     sections, Enter or Space to select, and Escape to close.
                 </DialogDescription>
                 <SidebarProvider className="items-start">
-                    {/*
-                      Sidebar needs an explicit height to match <main>'s
-                      h-[600px], otherwise SidebarContent's overflow-y-auto
-                      has no bound to scroll against: DialogContent uses
-                      max-h (a constraint, not a definite height) so the
-                      sidebar's h-full would resolve to its content height
-                      and grow rather than scroll once we cross ~13 nav items.
-                    */}
-                    <Sidebar className="hidden md:flex md:h-[600px]">
-                        {/*
-                          Header sits outside SidebarContent so it doesn't
-                          scroll away with the nav. min-h-0 on SidebarContent
-                          is the flex-scroll incantation: without it, a
-                          flex-1 child can refuse to shrink below its
-                          content height even with overflow-y-auto.
-                        */}
-                        {/*
-                          Match the main panel <header>'s h-16 exactly
-                          so the two bottom borders line up. Previously
-                          this used py-4 which resolved to ~56px,
-                          leaving an 8px step between the sidebar and
-                          breadcrumb rules.
-                        */}
-                        <div className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-                            <SettingsIcon className="size-5" />
-                            <h2 className="text-lg font-semibold">Settings</h2>
-                        </div>
-                        <SidebarContent className="min-h-0">
-                            {/*
-                              Use a real <nav> for the navigation
-                              landmark instead of overloading
-                              SidebarMenu (which renders <ul>) with
-                              role="navigation". Each group below has
-                              its own <ul> via SidebarMenu, so the
-                              <li> items always sit under a proper
-                              list parent — fixing the previous
-                              ul > div > li nesting which is invalid
-                              HTML and confuses screen readers.
-                            */}
-                            <nav
-                                aria-label="Settings sections"
-                                className="space-y-4"
-                            >
-                                {settingsNavGroups.map((group) => (
-                                    <SidebarGroup
-                                        key={group.label}
-                                        className="space-y-1"
-                                    >
-                                        <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
-                                            {group.label}
-                                        </div>
-                                        <SidebarGroupContent>
-                                            <SidebarMenu>
-                                                {group.items.map((item) => {
-                                                    // Resolve the item's flat
-                                                    // index so keyboard nav
-                                                    // (which still indexes a
-                                                    // flat list) stays in
-                                                    // sync with what's
-                                                    // rendered.
-                                                    const flatIndex =
-                                                        settingsNav.findIndex(
-                                                            (n) =>
-                                                                n.id ===
-                                                                item.id,
-                                                        );
-                                                    return (
-                                                        <SidebarMenuItem
-                                                            key={item.id}
-                                                        >
-                                                            <SidebarMenuButton
-                                                                data-settings-nav={
-                                                                    flatIndex ===
-                                                                    0
-                                                                        ? "first"
-                                                                        : undefined
-                                                                }
-                                                                isActive={
-                                                                    activeSection ===
-                                                                    item.id
-                                                                }
-                                                                data-keyboard-selected={
-                                                                    keyboardSelectedIndex ===
-                                                                    flatIndex
-                                                                }
-                                                                onClick={() =>
-                                                                    handleSectionChange(
-                                                                        item.id,
-                                                                    )
-                                                                }
-                                                                aria-label={`${item.name} settings`}
-                                                                aria-current={
-                                                                    activeSection ===
-                                                                    item.id
-                                                                        ? "page"
-                                                                        : undefined
-                                                                }
-                                                                className={
-                                                                    item.id ===
-                                                                    "dev"
-                                                                        ? "text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 data-[active=true]:bg-red-500/10 data-[active=true]:text-red-700 dark:data-[active=true]:text-red-300"
-                                                                        : undefined
-                                                                }
-                                                            >
-                                                                <item.icon
-                                                                    className="size-4"
-                                                                    aria-hidden="true"
-                                                                />
-                                                                <span>
-                                                                    {item.name}
-                                                                </span>
-                                                            </SidebarMenuButton>
-                                                        </SidebarMenuItem>
-                                                    );
-                                                })}
-                                            </SidebarMenu>
-                                        </SidebarGroupContent>
-                                    </SidebarGroup>
-                                ))}
-                            </nav>
-                        </SidebarContent>
-                    </Sidebar>
+                    <SettingsNavSidebar
+                        activeSection={activeSection}
+                        keyboardSelectedIndex={keyboardSelectedIndex}
+                        onSectionChange={handleSectionChange}
+                    />
 
                     <main className="flex h-[600px] flex-1 flex-col overflow-hidden">
                         {/*
-                          Desktop: header bar is intentionally empty
-                          — the sidebar's active item plus the section
-                          h2 inside each pane communicate "where am I";
-                          a third breadcrumb on top was redundant. The
-                          h-16 + border-b stays so the rule lines up
-                          with the sidebar's "Settings" header.
-                          Mobile: the section picker lives here because
-                          the sidebar is hidden below md.
+                          Desktop: header bar is intentionally empty -- the
+                          sidebar's active item plus the section h2 inside
+                          each pane communicate "where am I"; a third
+                          breadcrumb on top was redundant. The h-16 +
+                          border-b stays so the rule lines up with the
+                          sidebar's "Settings" header.
+                          Mobile: the section picker lives here because the
+                          sidebar is hidden below md.
                         */}
                         <header className="flex h-16 shrink-0 items-center justify-end gap-2 border-b px-4 md:justify-end">
-                            {/*
-                              Desktop: the sidebar's selected item is the
-                              source of truth for "where am I" — a header
-                              label here would just duplicate the section's
-                              own SectionHeader and the highlighted nav row.
-                              The h-16 + border-b shell stays so the rule
-                              lines up with the sidebar's "Settings" header.
-                              Mobile: the section picker fills this slot
-                              since the sidebar is hidden below md.
-                            */}
-                            <div className="md:hidden">
-                                <Select
-                                    value={activeSection}
-                                    onValueChange={(value) =>
-                                        handleSectionChange(
-                                            value as SettingsSection,
-                                        )
-                                    }
-                                >
-                                    <SelectTrigger
-                                        className="w-[180px]"
-                                        aria-label="Select settings section"
-                                    >
-                                        <SelectValue>
-                                            {activeNavItem?.name || "Settings"}
-                                        </SelectValue>
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {settingsNav.map((item) => (
-                                            <SelectItem
-                                                key={item.id}
-                                                value={item.id}
-                                            >
-                                                <div className="flex items-center gap-2">
-                                                    <item.icon className="size-4" />
-                                                    <span>{item.name}</span>
-                                                </div>
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
+                            <SettingsNavMobile
+                                activeSection={activeSection}
+                                onSectionChange={handleSectionChange}
+                            />
                         </header>
 
                         <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 pt-6">

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -132,10 +132,12 @@ const settingsNav: NavItem[] = settingsNavGroups.flatMap((g) => g.items);
 
 const STORAGE_KEY = "settings-last-section";
 
+const EMPTY_PROVIDERS: Provider[] = [];
+
 export function SettingsDialog({
     open,
     onOpenChange,
-    initialProviders = [],
+    initialProviders = EMPTY_PROVIDERS,
     onReRunOnboarding,
     isHosted = false,
 }: SettingsDialogProps) {
@@ -442,7 +444,7 @@ export function SettingsDialog({
                                                 value={item.id}
                                             >
                                                 <div className="flex items-center gap-2">
-                                                    <item.icon className="w-4 h-4" />
+                                                    <item.icon className="size-4" />
                                                     <span>{item.name}</span>
                                                 </div>
                                             </SelectItem>

--- a/src/components/settings-nav-config.ts
+++ b/src/components/settings-nav-config.ts
@@ -1,0 +1,93 @@
+import {
+    Bell,
+    Bot,
+    Download,
+    FileText,
+    HardDrive,
+    KeyRound,
+    ListChecks,
+    Mic,
+    Monitor,
+    Play,
+    RefreshCw,
+    Webhook,
+    Wrench,
+} from "lucide-react";
+import type { SettingsSection } from "@/types/settings";
+
+export type NavItem = {
+    name: string;
+    id: SettingsSection;
+    icon: typeof Bot;
+};
+
+/**
+ * Grouped navigation. The grouping is presentational only; iteration
+ * code flattens via `settingsNav` so keyboard nav, hash routing, and
+ * localStorage continue to operate on a flat indexed list.
+ *
+ * Lives at module scope so the array reference is stable across
+ * renders (would otherwise bust memoization on every dialog mount).
+ */
+export const settingsNavGroups: { label: string; items: NavItem[] }[] = [
+    {
+        label: "AI",
+        items: [
+            { name: "Providers", id: "providers", icon: Bot },
+            { name: "Transcription", id: "transcription", icon: FileText },
+            { name: "Summary", id: "summary", icon: ListChecks },
+        ],
+    },
+    {
+        label: "Plaud",
+        items: [
+            { name: "Plaud Account", id: "plaud-account", icon: Mic },
+            { name: "Sync", id: "sync", icon: RefreshCw },
+        ],
+    },
+    {
+        label: "Personalize",
+        items: [
+            { name: "Playback", id: "playback", icon: Play },
+            { name: "Display", id: "display", icon: Monitor },
+            { name: "Notifications", id: "notifications", icon: Bell },
+        ],
+    },
+    {
+        label: "Data",
+        items: [
+            { name: "Storage", id: "storage", icon: HardDrive },
+            { name: "Export/Backup", id: "export", icon: Download },
+        ],
+    },
+    {
+        label: "Integrations",
+        items: [
+            { name: "API Keys", id: "api-keys", icon: KeyRound },
+            { name: "Webhooks", id: "webhooks", icon: Webhook },
+        ],
+    },
+    ...(process.env.NODE_ENV !== "production"
+        ? [
+              {
+                  label: "Advanced",
+                  items: [
+                      {
+                          name: "Developer Tools",
+                          id: "dev" as SettingsSection,
+                          icon: Wrench,
+                      },
+                  ],
+              },
+          ]
+        : []),
+];
+
+/**
+ * Flat list derived from the groups -- keep this the single source of
+ * truth for keyboard nav / hash routing / localStorage. Changing the
+ * group structure above must not break index-based iteration.
+ */
+export const settingsNav: NavItem[] = settingsNavGroups.flatMap((g) => g.items);
+
+export const SETTINGS_STORAGE_KEY = "settings-last-section";

--- a/src/components/settings-nav-mobile.tsx
+++ b/src/components/settings-nav-mobile.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { settingsNav } from "@/components/settings-nav-config";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type { SettingsSection } from "@/types/settings";
+
+interface Props {
+    activeSection: SettingsSection;
+    onSectionChange: (section: SettingsSection) => void;
+}
+
+/**
+ * Section picker shown in the dialog header below md. Replaces the
+ * sidebar (hidden at that breakpoint) so users on small screens
+ * still have a way to switch sections without a separate route.
+ */
+export function SettingsNavMobile({ activeSection, onSectionChange }: Props) {
+    const activeNavItem = settingsNav.find((item) => item.id === activeSection);
+
+    return (
+        <div className="md:hidden">
+            <Select
+                value={activeSection}
+                onValueChange={(value) =>
+                    onSectionChange(value as SettingsSection)
+                }
+            >
+                <SelectTrigger
+                    className="w-[180px]"
+                    aria-label="Select settings section"
+                >
+                    <SelectValue>
+                        {activeNavItem?.name || "Settings"}
+                    </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                    {settingsNav.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                            <div className="flex items-center gap-2">
+                                <item.icon className="size-4" />
+                                <span>{item.name}</span>
+                            </div>
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}

--- a/src/components/settings-nav-sidebar.tsx
+++ b/src/components/settings-nav-sidebar.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Settings as SettingsIcon } from "lucide-react";
+import {
+    settingsNav,
+    settingsNavGroups,
+} from "@/components/settings-nav-config";
+import {
+    Sidebar,
+    SidebarContent,
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import type { SettingsSection } from "@/types/settings";
+
+interface Props {
+    activeSection: SettingsSection;
+    keyboardSelectedIndex: number;
+    onSectionChange: (section: SettingsSection) => void;
+}
+
+/**
+ * Desktop sidebar navigation. Hidden below md (the mobile picker
+ * lives in the dialog header). Grouped layout for visual scanning,
+ * but the underlying nav is a single flat list -- the parent's
+ * keyboard handler indexes the flat order via `settingsNav`.
+ */
+export function SettingsNavSidebar({
+    activeSection,
+    keyboardSelectedIndex,
+    onSectionChange,
+}: Props) {
+    return (
+        // Sidebar needs an explicit height to match <main>'s h-[600px],
+        // otherwise SidebarContent's overflow-y-auto has no bound to
+        // scroll against: DialogContent uses max-h (a constraint, not
+        // a definite height) so the sidebar's h-full would resolve to
+        // its content height and grow rather than scroll once we cross
+        // ~13 nav items.
+        <Sidebar className="hidden md:flex md:h-[600px]">
+            {/*
+              Header sits outside SidebarContent so it doesn't scroll
+              away with the nav. Match the main panel <header>'s h-16
+              exactly so the two bottom borders line up.
+            */}
+            <div className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+                <SettingsIcon className="size-5" />
+                <h2 className="text-lg font-semibold">Settings</h2>
+            </div>
+            <SidebarContent className="min-h-0">
+                {/*
+                  Use a real <nav> for the navigation landmark instead
+                  of overloading SidebarMenu (which renders <ul>) with
+                  role="navigation". Each group below has its own <ul>
+                  via SidebarMenu, so <li> items always sit under a
+                  proper list parent -- fixing the previous ul > div >
+                  li nesting which is invalid HTML and confuses screen
+                  readers.
+                */}
+                <nav aria-label="Settings sections" className="space-y-4">
+                    {settingsNavGroups.map((group) => (
+                        <SidebarGroup key={group.label} className="space-y-1">
+                            <div className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                                {group.label}
+                            </div>
+                            <SidebarGroupContent>
+                                <SidebarMenu>
+                                    {group.items.map((item) => {
+                                        // Resolve the item's flat
+                                        // index so keyboard nav (which
+                                        // still indexes a flat list)
+                                        // stays in sync with what's
+                                        // rendered.
+                                        const flatIndex = settingsNav.findIndex(
+                                            (n) => n.id === item.id,
+                                        );
+                                        return (
+                                            <SidebarMenuItem key={item.id}>
+                                                <SidebarMenuButton
+                                                    data-settings-nav={
+                                                        flatIndex === 0
+                                                            ? "first"
+                                                            : undefined
+                                                    }
+                                                    isActive={
+                                                        activeSection ===
+                                                        item.id
+                                                    }
+                                                    data-keyboard-selected={
+                                                        keyboardSelectedIndex ===
+                                                        flatIndex
+                                                    }
+                                                    onClick={() =>
+                                                        onSectionChange(item.id)
+                                                    }
+                                                    aria-label={`${item.name} settings`}
+                                                    aria-current={
+                                                        activeSection ===
+                                                        item.id
+                                                            ? "page"
+                                                            : undefined
+                                                    }
+                                                    className={
+                                                        item.id === "dev"
+                                                            ? "text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 data-[active=true]:bg-red-500/10 data-[active=true]:text-red-700 dark:data-[active=true]:text-red-300"
+                                                            : undefined
+                                                    }
+                                                >
+                                                    <item.icon
+                                                        className="size-4"
+                                                        aria-hidden="true"
+                                                    />
+                                                    <span>{item.name}</span>
+                                                </SidebarMenuButton>
+                                            </SidebarMenuItem>
+                                        );
+                                    })}
+                                </SidebarMenu>
+                            </SidebarGroupContent>
+                        </SidebarGroup>
+                    ))}
+                </nav>
+            </SidebarContent>
+        </Sidebar>
+    );
+}

--- a/src/components/settings-sections/dev-section.tsx
+++ b/src/components/settings-sections/dev-section.tsx
@@ -82,9 +82,9 @@ export function DevSection() {
                         variant="outline"
                     >
                         {isLoadingPlaud ? (
-                            <Loader2 className="w-4 h-4 animate-spin" />
+                            <Loader2 className="size-4 animate-spin" />
                         ) : (
-                            <RefreshCw className="w-4 h-4" />
+                            <RefreshCw className="size-4" />
                         )}
                         <span className="ml-2">Probe</span>
                     </Button>
@@ -100,9 +100,9 @@ export function DevSection() {
                             <>
                                 <div className="flex items-center gap-2">
                                     {plaudInfo.reachable ? (
-                                        <CheckCircle2 className="w-4 h-4 text-green-500" />
+                                        <CheckCircle2 className="size-4 text-green-500" />
                                     ) : (
-                                        <XCircle className="w-4 h-4 text-red-500" />
+                                        <XCircle className="size-4 text-red-500" />
                                     )}
                                     <span>
                                         {plaudInfo.reachable

--- a/src/components/settings-sections/display-section.tsx
+++ b/src/components/settings-sections/display-section.tsx
@@ -163,7 +163,7 @@ export function DisplaySection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/export-section.tsx
+++ b/src/components/settings-sections/export-section.tsx
@@ -170,7 +170,7 @@ export function ExportSection({ onReRunOnboarding }: ExportSectionProps) {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }
@@ -316,7 +316,7 @@ export function ExportSection({ onReRunOnboarding }: ExportSectionProps) {
                         variant="outline"
                         className="w-full"
                     >
-                        <RefreshCw className="w-4 h-4 mr-2" />
+                        <RefreshCw className="size-4 mr-2" />
                         Re-run Onboarding
                     </Button>
                     <p className="text-xs text-muted-foreground">
@@ -331,12 +331,12 @@ export function ExportSection({ onReRunOnboarding }: ExportSectionProps) {
                         >
                             {isExporting ? (
                                 <>
-                                    <div className="animate-spin w-4 h-4 mr-2 border-2 border-primary border-t-transparent rounded-full" />
-                                    Exporting...
+                                    <div className="animate-spin size-4 mr-2 border-2 border-primary border-t-transparent rounded-full" />
+                                    Exporting…
                                 </>
                             ) : (
                                 <>
-                                    <Download className="w-4 h-4 mr-2" />
+                                    <Download className="size-4 mr-2" />
                                     Export All
                                 </>
                             )}
@@ -349,12 +349,12 @@ export function ExportSection({ onReRunOnboarding }: ExportSectionProps) {
                         >
                             {isBackingUp ? (
                                 <>
-                                    <div className="animate-spin w-4 h-4 mr-2 border-2 border-primary border-t-transparent rounded-full" />
-                                    Creating...
+                                    <div className="animate-spin size-4 mr-2 border-2 border-primary border-t-transparent rounded-full" />
+                                    Creating…
                                 </>
                             ) : (
                                 <>
-                                    <Download className="w-4 h-4 mr-2" />
+                                    <Download className="size-4 mr-2" />
                                     Create Backup
                                 </>
                             )}

--- a/src/components/settings-sections/notifications-section.tsx
+++ b/src/components/settings-sections/notifications-section.tsx
@@ -156,7 +156,7 @@ export function NotificationsSection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/plaud-account-section.tsx
+++ b/src/components/settings-sections/plaud-account-section.tsx
@@ -135,7 +135,7 @@ export function PlaudAccountSection() {
     if (isLoading) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }
@@ -162,7 +162,7 @@ export function PlaudAccountSection() {
                 <Card className="py-4">
                     <CardContent className="space-y-4">
                         <div className="flex items-start gap-3">
-                            <CheckCircle2 className="w-5 h-5 text-primary mt-0.5 shrink-0" />
+                            <CheckCircle2 className="size-5 text-primary mt-0.5 shrink-0" />
                             <div className="flex-1 min-w-0">
                                 <p className="font-medium truncate">
                                     {currentEmail ? (
@@ -196,7 +196,7 @@ export function PlaudAccountSection() {
                                 variant="outline"
                                 onClick={() => setConfirmOpen("switch")}
                             >
-                                <RefreshCw className="w-4 h-4 mr-2" />
+                                <RefreshCw className="size-4 mr-2" />
                                 Switch account
                             </Button>
                             <Button
@@ -204,7 +204,7 @@ export function PlaudAccountSection() {
                                 onClick={() => setConfirmOpen("disconnect")}
                                 className="text-destructive hover:text-destructive hover:bg-destructive/10"
                             >
-                                <Link2Off className="w-4 h-4 mr-2" />
+                                <Link2Off className="size-4 mr-2" />
                                 Disconnect
                             </Button>
                         </div>

--- a/src/components/settings-sections/plaud-account-section.tsx
+++ b/src/components/settings-sections/plaud-account-section.tsx
@@ -153,7 +153,7 @@ export function PlaudAccountSection() {
                 />
                 <p className="text-sm text-muted-foreground mt-1">
                     The Plaud account OpenPlaud pulls recordings from. Switching
-                    accounts keeps your existing recordings — only future syncs
+                    accounts keeps your existing recordings; only future syncs
                     change.
                 </p>
             </div>
@@ -249,7 +249,7 @@ export function PlaudAccountSection() {
                                         </span>{" "}
                                         and let you sign in with a different
                                         Plaud account. Your existing recordings
-                                        stay — only future syncs will come from
+                                        stay; only future syncs will come from
                                         the new account.
                                     </p>
                                 ) : (

--- a/src/components/settings-sections/playback-section.tsx
+++ b/src/components/settings-sections/playback-section.tsx
@@ -144,7 +144,7 @@ export function PlaybackSection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/prompt-manager.tsx
+++ b/src/components/settings-sections/prompt-manager.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { nanoid } from "nanoid";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useConfirm } from "@/components/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useSettings } from "@/hooks/use-settings";
+import { PROMPT_PRESETS } from "@/lib/ai/prompt-presets";
+
+interface CustomPrompt {
+    id: string;
+    name: string;
+    prompt: string;
+    createdAt: string;
+}
+
+type EditingPrompt = {
+    id?: string;
+    name: string;
+    prompt: string;
+};
+
+/**
+ * Title-generation prompt management. Owns:
+ *  - Active prompt selector (chooses among presets + user customs).
+ *  - Preset prompt list (read-only view of the shipped PROMPT_PRESETS).
+ *  - Custom prompt CRUD with confirm-delete.
+ *  - View dialog (read the full prompt text) and edit dialog
+ *    (create / edit a custom prompt).
+ *
+ * Hoisted out of ProvidersSection because the AI providers list and
+ * the prompt manager only share a tab bar; their data, dialogs, and
+ * persistence calls are otherwise independent. Keeping them in one
+ * 710-line component meant useState calls + effects + dialogs
+ * cross-pollinating that didn't need to.
+ *
+ * Persists via PUT /api/settings/user, `titleGenerationPrompt` field.
+ */
+export function PromptManager() {
+    const confirm = useConfirm();
+    const { isLoadingSettings, isSavingSettings, setIsLoadingSettings } =
+        useSettings();
+    const [selectedPromptId, setSelectedPromptId] = useState<string>("default");
+    const [customPrompts, setCustomPrompts] = useState<CustomPrompt[]>([]);
+    const [editingCustomPrompt, setEditingCustomPrompt] =
+        useState<EditingPrompt | null>(null);
+    const [viewingPromptId, setViewingPromptId] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchSettings = async () => {
+            try {
+                const response = await fetch("/api/settings/user");
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.titleGenerationPrompt) {
+                        const promptConfig = data.titleGenerationPrompt as {
+                            selectedPrompt?: string;
+                            customPrompts?: CustomPrompt[];
+                        };
+                        setSelectedPromptId(
+                            promptConfig.selectedPrompt || "default",
+                        );
+                        setCustomPrompts(promptConfig.customPrompts || []);
+                    } else {
+                        setSelectedPromptId("default");
+                        setCustomPrompts([]);
+                    }
+                }
+            } catch (error) {
+                console.error("Failed to fetch settings:", error);
+            } finally {
+                setIsLoadingSettings(false);
+            }
+        };
+        fetchSettings();
+    }, [setIsLoadingSettings]);
+
+    const handlePromptSettingChange = async (config: {
+        selectedPrompt: string;
+        customPrompts: CustomPrompt[];
+    }) => {
+        try {
+            const response = await fetch("/api/settings/user", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ titleGenerationPrompt: config }),
+            });
+            if (!response.ok) {
+                throw new Error("Failed to save prompt settings");
+            }
+            toast.success("Prompt settings saved");
+        } catch {
+            toast.error("Failed to save prompt settings");
+        }
+    };
+
+    const handleSaveCustomPrompt = async (prompt: EditingPrompt) => {
+        const isEdit = !!prompt.id;
+        const newPrompt: CustomPrompt = {
+            id: prompt.id || nanoid(),
+            name: prompt.name,
+            prompt: prompt.prompt,
+            createdAt: isEdit
+                ? customPrompts.find((p) => p.id === prompt.id)?.createdAt ||
+                  new Date().toISOString()
+                : new Date().toISOString(),
+        };
+
+        const updatedPrompts = isEdit
+            ? customPrompts.map((p) => (p.id === prompt.id ? newPrompt : p))
+            : [...customPrompts, newPrompt];
+
+        setCustomPrompts(updatedPrompts);
+        setEditingCustomPrompt(null);
+
+        await handlePromptSettingChange({
+            selectedPrompt: selectedPromptId,
+            customPrompts: updatedPrompts,
+        });
+    };
+
+    const handleDeleteCustomPrompt = (id: string) => {
+        void confirm({
+            title: "Delete this custom prompt?",
+            description:
+                "Recordings already summarized with this prompt keep their existing summaries, but you won't be able to apply it again.",
+            confirmLabel: "Delete",
+            destructive: true,
+            onConfirm: async () => {
+                const updatedPrompts = customPrompts.filter((p) => p.id !== id);
+                setCustomPrompts(updatedPrompts);
+                const newSelectedPrompt =
+                    selectedPromptId === id ? "default" : selectedPromptId;
+                setSelectedPromptId(newSelectedPrompt);
+                await handlePromptSettingChange({
+                    selectedPrompt: newSelectedPrompt,
+                    customPrompts: updatedPrompts,
+                });
+            },
+        });
+    };
+
+    if (isLoadingSettings) {
+        return (
+            <div className="flex items-center justify-center py-8">
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
+            </div>
+        );
+    }
+
+    const viewingText =
+        viewingPromptId &&
+        (PROMPT_PRESETS[viewingPromptId as keyof typeof PROMPT_PRESETS]
+            ?.prompt ||
+            customPrompts.find((p) => p.id === viewingPromptId)?.prompt ||
+            "");
+
+    const viewingName =
+        viewingPromptId &&
+        (PROMPT_PRESETS[viewingPromptId as keyof typeof PROMPT_PRESETS]?.name ||
+            customPrompts.find((p) => p.id === viewingPromptId)?.name ||
+            "Prompt");
+
+    const viewingDescription =
+        viewingPromptId &&
+        (PROMPT_PRESETS[viewingPromptId as keyof typeof PROMPT_PRESETS]
+            ?.description ||
+            "Custom prompt");
+
+    return (
+        <div className="space-y-6">
+            {/* Active prompt selector */}
+            <div className="space-y-2">
+                <Label htmlFor="selected-prompt">Active Prompt</Label>
+                <Select
+                    value={selectedPromptId}
+                    onValueChange={(value) => {
+                        setSelectedPromptId(value);
+                        handlePromptSettingChange({
+                            selectedPrompt: value,
+                            customPrompts,
+                        });
+                    }}
+                    disabled={isSavingSettings}
+                >
+                    <SelectTrigger id="selected-prompt">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {Object.values(PROMPT_PRESETS).map((preset) => (
+                            <SelectItem key={preset.id} value={preset.id}>
+                                {preset.name} (Preset)
+                            </SelectItem>
+                        ))}
+                        {customPrompts.map((prompt) => (
+                            <SelectItem key={prompt.id} value={prompt.id}>
+                                {prompt.name} (Custom)
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                    Select which prompt to use for title generation
+                </p>
+            </div>
+
+            {/* Preset prompts (read-only) */}
+            <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Preset Prompts</h3>
+                </div>
+                <div className="space-y-2">
+                    {Object.values(PROMPT_PRESETS).map((preset) => (
+                        <div key={preset.id} className="p-4 border rounded-lg">
+                            <div className="flex items-start justify-between mb-2">
+                                <div className="flex-1">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <h4 className="font-medium">
+                                            {preset.name}
+                                        </h4>
+                                        {selectedPromptId === preset.id && (
+                                            <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
+                                                Active
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground mb-2">
+                                        {preset.description}
+                                    </p>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                        setViewingPromptId(preset.id)
+                                    }
+                                >
+                                    View Prompt
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* Custom prompts */}
+            <div className="space-y-4 pt-4 border-t">
+                <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Custom Prompts</h3>
+                    <Button
+                        onClick={() =>
+                            setEditingCustomPrompt({ name: "", prompt: "" })
+                        }
+                        size="sm"
+                    >
+                        <Plus className="size-4 mr-2" />
+                        Add Custom Prompt
+                    </Button>
+                </div>
+                {customPrompts.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-4">
+                        No custom prompts yet. Create one to get started.
+                    </p>
+                ) : (
+                    <div className="space-y-2">
+                        {customPrompts.map((prompt) => (
+                            <div
+                                key={prompt.id}
+                                className="p-4 border rounded-lg"
+                            >
+                                <div className="flex items-start justify-between mb-2">
+                                    <div className="flex-1">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <h4 className="font-medium">
+                                                {prompt.name}
+                                            </h4>
+                                            {selectedPromptId === prompt.id && (
+                                                <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
+                                                    Active
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                setViewingPromptId(prompt.id)
+                                            }
+                                        >
+                                            View
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                setEditingCustomPrompt({
+                                                    id: prompt.id,
+                                                    name: prompt.name,
+                                                    prompt: prompt.prompt,
+                                                })
+                                            }
+                                        >
+                                            <Pencil className="size-4" />
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                handleDeleteCustomPrompt(
+                                                    prompt.id,
+                                                )
+                                            }
+                                        >
+                                            <Trash2 className="size-4 text-destructive" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* View prompt dialog */}
+            {viewingPromptId && (
+                <Dialog
+                    open={!!viewingPromptId}
+                    onOpenChange={(open) => !open && setViewingPromptId(null)}
+                >
+                    <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+                        <DialogTitle>{viewingName}</DialogTitle>
+                        <DialogDescription>
+                            {viewingDescription}
+                        </DialogDescription>
+                        <div className="mt-4">
+                            <pre className="p-4 bg-muted rounded-md text-sm font-mono whitespace-pre-wrap overflow-x-auto">
+                                {viewingText}
+                            </pre>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
+
+            {/* Edit/create custom prompt dialog */}
+            {editingCustomPrompt && (
+                <Dialog
+                    open={!!editingCustomPrompt}
+                    onOpenChange={(open) =>
+                        !open && setEditingCustomPrompt(null)
+                    }
+                >
+                    <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+                        <DialogTitle>
+                            {editingCustomPrompt.id
+                                ? "Edit Custom Prompt"
+                                : "Create Custom Prompt"}
+                        </DialogTitle>
+                        <DialogDescription>
+                            Create a custom prompt for title generation. Use{" "}
+                            <code className="px-1 py-0.5 bg-muted rounded">
+                                {"{transcription}"}
+                            </code>{" "}
+                            as a placeholder for the transcription text.
+                        </DialogDescription>
+                        <div className="space-y-4 mt-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="custom-prompt-name">Name</Label>
+                                <Input
+                                    id="custom-prompt-name"
+                                    value={editingCustomPrompt.name}
+                                    onChange={(e) =>
+                                        setEditingCustomPrompt((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      name: e.target.value,
+                                                  }
+                                                : prev,
+                                        )
+                                    }
+                                    placeholder="My Custom Prompt"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="custom-prompt-text">
+                                    Prompt
+                                </Label>
+                                <textarea
+                                    id="custom-prompt-text"
+                                    className="w-full min-h-[300px] px-3 py-2 text-sm border rounded-md resize-y font-mono"
+                                    value={editingCustomPrompt.prompt}
+                                    onChange={(e) =>
+                                        setEditingCustomPrompt((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      prompt: e.target.value,
+                                                  }
+                                                : prev,
+                                        )
+                                    }
+                                    placeholder={`You are a title generator for audio recordings. Generate a concise, descriptive title based on the transcription provided.
+
+RULES (MUST FOLLOW):
+1. Maximum 60 characters (strict limit)
+2. No quotes, colons, semicolons, or special punctuation marks
+3. Use title case (capitalize important words)
+4. Focus on the main topic, subject, or action discussed
+5. Remove filler words, greetings, and conversational fluff
+6. Be specific and descriptive, not generic
+7. If the transcription is very short or unclear, create a meaningful title based on context
+8. Do not include timestamps, dates, or metadata
+9. Do not use phrases like "Recording about" or "Discussion of"
+10. Return ONLY the title text, nothing else
+
+Transcription:
+{transcription}
+
+Generate the title now:`}
+                                />
+                            </div>
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setEditingCustomPrompt(null)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={() => {
+                                        if (
+                                            !editingCustomPrompt.name ||
+                                            !editingCustomPrompt.prompt
+                                        ) {
+                                            toast.error(
+                                                "Name and prompt are required",
+                                            );
+                                            return;
+                                        }
+                                        handleSaveCustomPrompt(
+                                            editingCustomPrompt,
+                                        );
+                                    }}
+                                    disabled={
+                                        !editingCustomPrompt.name ||
+                                        !editingCustomPrompt.prompt
+                                    }
+                                >
+                                    {editingCustomPrompt.id ? "Save" : "Create"}
+                                </Button>
+                            </div>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
+        </div>
+    );
+}

--- a/src/components/settings-sections/providers-section.tsx
+++ b/src/components/settings-sections/providers-section.tsx
@@ -1,35 +1,16 @@
 "use client";
 
 import { Bot, Pencil, Plus, Sparkles, Trash2 } from "lucide-react";
-import { nanoid } from "nanoid";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { useConfirm } from "@/components/confirm-dialog";
 import { AddProviderDialog } from "@/components/settings/add-provider-dialog";
 import { EditProviderDialog } from "@/components/settings/edit-provider-dialog";
 import { SettingsSectionHeader } from "@/components/settings/section-header";
+import { PromptManager } from "@/components/settings-sections/prompt-manager";
 import { Button } from "@/components/ui/button";
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
-import { useSettings } from "@/hooks/use-settings";
-import { PROMPT_PRESETS } from "@/lib/ai/prompt-presets";
 
 type AISubSection = "providers" | "prompts";
-
-const EMPTY_PROVIDERS: Provider[] = [];
 
 interface Provider {
     id: string;
@@ -41,18 +22,33 @@ interface Provider {
     createdAt: Date;
 }
 
+const EMPTY_PROVIDERS: Provider[] = [];
+
 interface ProvidersSectionProps {
     initialProviders?: Provider[];
     isHosted?: boolean;
 }
 
+/**
+ * AI Providers settings section.
+ *
+ * Two tabs:
+ *  - "Providers": the configured AI providers (transcription / enhancement)
+ *    plus the AddProviderDialog and EditProviderDialog. Local state seeded
+ *    from `initialProviders` and updated in place by the dialogs.
+ *  - "Prompts": delegated entirely to <PromptManager />, which owns its own
+ *    settings round-trip + custom prompt CRUD.
+ *
+ * Note: `initialProviders` is the server-rendered seed only. The local
+ * `providers` state diverges from it after add/edit/delete actions; we do
+ * NOT re-sync from the prop on changes (would clobber local edits). If the
+ * parent ever needs to force a reset, pass a `key` prop instead.
+ */
 export function ProvidersSection({
     initialProviders = EMPTY_PROVIDERS,
     isHosted = false,
 }: ProvidersSectionProps) {
     const confirm = useConfirm();
-    const { isLoadingSettings, isSavingSettings, setIsLoadingSettings } =
-        useSettings();
     const [providers, setProviders] = useState<Provider[]>(initialProviders);
     const [isAddProviderOpen, setIsAddProviderOpen] = useState(false);
     const [isEditProviderOpen, setIsEditProviderOpen] = useState(false);
@@ -61,138 +57,6 @@ export function ProvidersSection({
     );
     const [deletingId, setDeletingId] = useState<string | null>(null);
     const [aiSubSection, setAiSubSection] = useState<AISubSection>("providers");
-    const [selectedPromptId, setSelectedPromptId] = useState<string>("default");
-    const [customPrompts, setCustomPrompts] = useState<
-        Array<{
-            id: string;
-            name: string;
-            prompt: string;
-            createdAt: string;
-        }>
-    >([]);
-    const [editingCustomPrompt, setEditingCustomPrompt] = useState<{
-        id?: string;
-        name: string;
-        prompt: string;
-    } | null>(null);
-    const [viewingPromptId, setViewingPromptId] = useState<string | null>(null);
-
-    // Note: `initialProviders` is the server-rendered seed only. The local
-    // `providers` state diverges from it after add/edit/delete actions in
-    // this component, so we do NOT re-sync from the prop on changes (would
-    // clobber local edits). If the parent ever needs to force a reset,
-    // pass a `key` prop instead.
-
-    useEffect(() => {
-        const fetchSettings = async () => {
-            try {
-                const response = await fetch("/api/settings/user");
-                if (response.ok) {
-                    const data = await response.json();
-                    if (data.titleGenerationPrompt) {
-                        const promptConfig = data.titleGenerationPrompt as {
-                            selectedPrompt?: string;
-                            customPrompts?: Array<{
-                                id: string;
-                                name: string;
-                                prompt: string;
-                                createdAt: string;
-                            }>;
-                        };
-                        setSelectedPromptId(
-                            promptConfig.selectedPrompt || "default",
-                        );
-                        setCustomPrompts(promptConfig.customPrompts || []);
-                    } else {
-                        setSelectedPromptId("default");
-                        setCustomPrompts([]);
-                    }
-                }
-            } catch (error) {
-                console.error("Failed to fetch settings:", error);
-            } finally {
-                setIsLoadingSettings(false);
-            }
-        };
-        fetchSettings();
-    }, [setIsLoadingSettings]);
-
-    const handlePromptSettingChange = async (config: {
-        selectedPrompt: string;
-        customPrompts: Array<{
-            id: string;
-            name: string;
-            prompt: string;
-            createdAt: string;
-        }>;
-    }) => {
-        try {
-            const response = await fetch("/api/settings/user", {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    titleGenerationPrompt: config,
-                }),
-            });
-
-            if (!response.ok) {
-                throw new Error("Failed to save prompt settings");
-            }
-            toast.success("Prompt settings saved");
-        } catch {
-            toast.error("Failed to save prompt settings");
-        }
-    };
-
-    const handleSaveCustomPrompt = async (prompt: {
-        id?: string;
-        name: string;
-        prompt: string;
-    }) => {
-        const isEdit = !!prompt.id;
-        const newPrompt = {
-            id: prompt.id || nanoid(),
-            name: prompt.name,
-            prompt: prompt.prompt,
-            createdAt: isEdit
-                ? customPrompts.find((p) => p.id === prompt.id)?.createdAt ||
-                  new Date().toISOString()
-                : new Date().toISOString(),
-        };
-
-        const updatedPrompts = isEdit
-            ? customPrompts.map((p) => (p.id === prompt.id ? newPrompt : p))
-            : [...customPrompts, newPrompt];
-
-        setCustomPrompts(updatedPrompts);
-        setEditingCustomPrompt(null);
-
-        await handlePromptSettingChange({
-            selectedPrompt: selectedPromptId,
-            customPrompts: updatedPrompts,
-        });
-    };
-
-    const handleDeleteCustomPrompt = (id: string) => {
-        void confirm({
-            title: "Delete this custom prompt?",
-            description:
-                "Recordings already summarized with this prompt keep their existing summaries, but you won't be able to apply it again.",
-            confirmLabel: "Delete",
-            destructive: true,
-            onConfirm: async () => {
-                const updatedPrompts = customPrompts.filter((p) => p.id !== id);
-                setCustomPrompts(updatedPrompts);
-                const newSelectedPrompt =
-                    selectedPromptId === id ? "default" : selectedPromptId;
-                setSelectedPromptId(newSelectedPrompt);
-                await handlePromptSettingChange({
-                    selectedPrompt: newSelectedPrompt,
-                    customPrompts: updatedPrompts,
-                });
-            },
-        });
-    };
 
     const refreshProviders = async () => {
         try {
@@ -285,457 +149,17 @@ export function ProvidersSection({
                     </button>
                 </div>
 
-                {/* Providers Section */}
                 {aiSubSection === "providers" && (
-                    <div>
-                        {providers.length === 0 ? (
-                            <div className="text-center py-12">
-                                <Bot className="size-16 mx-auto mb-4 text-muted-foreground" />
-                                <h3 className="font-semibold mb-2">
-                                    No providers configured
-                                </h3>
-                                <p className="text-sm text-muted-foreground mb-4">
-                                    Add an AI provider to enable transcription
-                                </p>
-                                <Button
-                                    onClick={() => setIsAddProviderOpen(true)}
-                                    size="sm"
-                                >
-                                    <Plus className="size-4 mr-2" />
-                                    Add Provider
-                                </Button>
-                            </div>
-                        ) : (
-                            <div className="space-y-3">
-                                {providers.map((provider) => (
-                                    <div
-                                        key={provider.id}
-                                        className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent transition-colors"
-                                    >
-                                        <div className="flex-1 min-w-0">
-                                            <div className="flex items-center gap-2 mb-1">
-                                                <h3 className="font-semibold">
-                                                    {provider.provider}
-                                                </h3>
-                                                {provider.isDefaultTranscription && (
-                                                    <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
-                                                        Transcription
-                                                    </span>
-                                                )}
-                                                {provider.isDefaultEnhancement && (
-                                                    <span className="text-xs px-2 py-0.5 bg-purple-500/10 text-purple-600 rounded border border-purple-500/20">
-                                                        Enhancement
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {provider.defaultModel && (
-                                                <p className="text-sm text-muted-foreground">
-                                                    Model:{" "}
-                                                    {provider.defaultModel}
-                                                </p>
-                                            )}
-                                            {provider.baseUrl && (
-                                                <p className="text-xs text-muted-foreground font-mono truncate">
-                                                    {provider.baseUrl}
-                                                </p>
-                                            )}
-                                        </div>
-                                        <div className="flex items-center gap-2 ml-4">
-                                            <Button
-                                                onClick={() =>
-                                                    handleEdit(provider)
-                                                }
-                                                variant="outline"
-                                                size="icon"
-                                            >
-                                                <Pencil className="size-4" />
-                                            </Button>
-                                            <Button
-                                                onClick={() =>
-                                                    handleDelete(provider.id)
-                                                }
-                                                variant="outline"
-                                                size="icon"
-                                                disabled={
-                                                    deletingId === provider.id
-                                                }
-                                            >
-                                                {deletingId === provider.id ? (
-                                                    <div className="animate-spin size-4 border-2 border-destructive border-t-transparent rounded-full" />
-                                                ) : (
-                                                    <Trash2 className="size-4 text-destructive" />
-                                                )}
-                                            </Button>
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
+                    <ProvidersList
+                        providers={providers}
+                        deletingId={deletingId}
+                        onAdd={() => setIsAddProviderOpen(true)}
+                        onEdit={handleEdit}
+                        onDelete={handleDelete}
+                    />
                 )}
 
-                {/* Prompts Section */}
-                {aiSubSection === "prompts" && (
-                    <div className="space-y-6">
-                        {isLoadingSettings ? (
-                            <div className="flex items-center justify-center py-8">
-                                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
-                            </div>
-                        ) : (
-                            <>
-                                {/* Selected Prompt */}
-                                <div className="space-y-2">
-                                    <Label htmlFor="selected-prompt">
-                                        Active Prompt
-                                    </Label>
-                                    <Select
-                                        value={selectedPromptId}
-                                        onValueChange={(value) => {
-                                            setSelectedPromptId(value);
-                                            handlePromptSettingChange({
-                                                selectedPrompt: value,
-                                                customPrompts,
-                                            });
-                                        }}
-                                        disabled={isSavingSettings}
-                                    >
-                                        <SelectTrigger id="selected-prompt">
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {Object.values(PROMPT_PRESETS).map(
-                                                (preset) => (
-                                                    <SelectItem
-                                                        key={preset.id}
-                                                        value={preset.id}
-                                                    >
-                                                        {preset.name} (Preset)
-                                                    </SelectItem>
-                                                ),
-                                            )}
-                                            {customPrompts.map((prompt) => (
-                                                <SelectItem
-                                                    key={prompt.id}
-                                                    value={prompt.id}
-                                                >
-                                                    {prompt.name} (Custom)
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <p className="text-xs text-muted-foreground">
-                                        Select which prompt to use for title
-                                        generation
-                                    </p>
-                                </div>
-
-                                {/* Preset Prompts (Read-only) */}
-                                <div className="space-y-4">
-                                    <div className="flex items-center justify-between">
-                                        <h3 className="text-sm font-semibold">
-                                            Preset Prompts
-                                        </h3>
-                                    </div>
-                                    <div className="space-y-2">
-                                        {Object.values(PROMPT_PRESETS).map(
-                                            (preset) => (
-                                                <div
-                                                    key={preset.id}
-                                                    className="p-4 border rounded-lg"
-                                                >
-                                                    <div className="flex items-start justify-between mb-2">
-                                                        <div className="flex-1">
-                                                            <div className="flex items-center gap-2 mb-1">
-                                                                <h4 className="font-medium">
-                                                                    {
-                                                                        preset.name
-                                                                    }
-                                                                </h4>
-                                                                {selectedPromptId ===
-                                                                    preset.id && (
-                                                                    <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
-                                                                        Active
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                            <p className="text-xs text-muted-foreground mb-2">
-                                                                {
-                                                                    preset.description
-                                                                }
-                                                            </p>
-                                                        </div>
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            onClick={() =>
-                                                                setViewingPromptId(
-                                                                    preset.id,
-                                                                )
-                                                            }
-                                                        >
-                                                            View Prompt
-                                                        </Button>
-                                                    </div>
-                                                </div>
-                                            ),
-                                        )}
-                                    </div>
-                                </div>
-
-                                {/* Custom Prompts */}
-                                <div className="space-y-4 pt-4 border-t">
-                                    <div className="flex items-center justify-between">
-                                        <h3 className="text-sm font-semibold">
-                                            Custom Prompts
-                                        </h3>
-                                        <Button
-                                            onClick={() =>
-                                                setEditingCustomPrompt({
-                                                    name: "",
-                                                    prompt: "",
-                                                })
-                                            }
-                                            size="sm"
-                                        >
-                                            <Plus className="size-4 mr-2" />
-                                            Add Custom Prompt
-                                        </Button>
-                                    </div>
-                                    {customPrompts.length === 0 ? (
-                                        <p className="text-sm text-muted-foreground text-center py-4">
-                                            No custom prompts yet. Create one to
-                                            get started.
-                                        </p>
-                                    ) : (
-                                        <div className="space-y-2">
-                                            {customPrompts.map((prompt) => (
-                                                <div
-                                                    key={prompt.id}
-                                                    className="p-4 border rounded-lg"
-                                                >
-                                                    <div className="flex items-start justify-between mb-2">
-                                                        <div className="flex-1">
-                                                            <div className="flex items-center gap-2 mb-1">
-                                                                <h4 className="font-medium">
-                                                                    {
-                                                                        prompt.name
-                                                                    }
-                                                                </h4>
-                                                                {selectedPromptId ===
-                                                                    prompt.id && (
-                                                                    <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
-                                                                        Active
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                        <div className="flex items-center gap-2">
-                                                            <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                onClick={() =>
-                                                                    setViewingPromptId(
-                                                                        prompt.id,
-                                                                    )
-                                                                }
-                                                            >
-                                                                View
-                                                            </Button>
-                                                            <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                onClick={() =>
-                                                                    setEditingCustomPrompt(
-                                                                        {
-                                                                            id: prompt.id,
-                                                                            name: prompt.name,
-                                                                            prompt: prompt.prompt,
-                                                                        },
-                                                                    )
-                                                                }
-                                                            >
-                                                                <Pencil className="size-4" />
-                                                            </Button>
-                                                            <Button
-                                                                variant="outline"
-                                                                size="sm"
-                                                                onClick={() =>
-                                                                    handleDeleteCustomPrompt(
-                                                                        prompt.id,
-                                                                    )
-                                                                }
-                                                            >
-                                                                <Trash2 className="size-4 text-destructive" />
-                                                            </Button>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    )}
-                                </div>
-                            </>
-                        )}
-                    </div>
-                )}
-
-                {/* View Prompt Dialog */}
-                {viewingPromptId && (
-                    <Dialog
-                        open={!!viewingPromptId}
-                        onOpenChange={(open) =>
-                            !open && setViewingPromptId(null)
-                        }
-                    >
-                        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
-                            <DialogTitle>
-                                {PROMPT_PRESETS[
-                                    viewingPromptId as keyof typeof PROMPT_PRESETS
-                                ]?.name ||
-                                    customPrompts.find(
-                                        (p) => p.id === viewingPromptId,
-                                    )?.name ||
-                                    "Prompt"}
-                            </DialogTitle>
-                            <DialogDescription>
-                                {PROMPT_PRESETS[
-                                    viewingPromptId as keyof typeof PROMPT_PRESETS
-                                ]?.description || "Custom prompt"}
-                            </DialogDescription>
-                            <div className="mt-4">
-                                <pre className="p-4 bg-muted rounded-md text-sm font-mono whitespace-pre-wrap overflow-x-auto">
-                                    {PROMPT_PRESETS[
-                                        viewingPromptId as keyof typeof PROMPT_PRESETS
-                                    ]?.prompt ||
-                                        customPrompts.find(
-                                            (p) => p.id === viewingPromptId,
-                                        )?.prompt ||
-                                        ""}
-                                </pre>
-                            </div>
-                        </DialogContent>
-                    </Dialog>
-                )}
-
-                {/* Edit/Create Custom Prompt Dialog */}
-                {editingCustomPrompt && (
-                    <Dialog
-                        open={!!editingCustomPrompt}
-                        onOpenChange={(open) =>
-                            !open && setEditingCustomPrompt(null)
-                        }
-                    >
-                        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
-                            <DialogTitle>
-                                {editingCustomPrompt.id
-                                    ? "Edit Custom Prompt"
-                                    : "Create Custom Prompt"}
-                            </DialogTitle>
-                            <DialogDescription>
-                                Create a custom prompt for title generation. Use{" "}
-                                <code className="px-1 py-0.5 bg-muted rounded">
-                                    {"{transcription}"}
-                                </code>{" "}
-                                as a placeholder for the transcription text.
-                            </DialogDescription>
-                            <div className="space-y-4 mt-4">
-                                <div className="space-y-2">
-                                    <Label htmlFor="custom-prompt-name">
-                                        Name
-                                    </Label>
-                                    <Input
-                                        id="custom-prompt-name"
-                                        value={editingCustomPrompt.name}
-                                        onChange={(e) =>
-                                            setEditingCustomPrompt((prev) =>
-                                                prev
-                                                    ? {
-                                                          ...prev,
-                                                          name: e.target.value,
-                                                      }
-                                                    : prev,
-                                            )
-                                        }
-                                        placeholder="My Custom Prompt"
-                                    />
-                                </div>
-                                <div className="space-y-2">
-                                    <Label htmlFor="custom-prompt-text">
-                                        Prompt
-                                    </Label>
-                                    <textarea
-                                        id="custom-prompt-text"
-                                        className="w-full min-h-[300px] px-3 py-2 text-sm border rounded-md resize-y font-mono"
-                                        value={editingCustomPrompt.prompt}
-                                        onChange={(e) =>
-                                            setEditingCustomPrompt((prev) =>
-                                                prev
-                                                    ? {
-                                                          ...prev,
-                                                          prompt: e.target
-                                                              .value,
-                                                      }
-                                                    : prev,
-                                            )
-                                        }
-                                        placeholder={`You are a title generator for audio recordings. Generate a concise, descriptive title based on the transcription provided.
-
-RULES (MUST FOLLOW):
-1. Maximum 60 characters (strict limit)
-2. No quotes, colons, semicolons, or special punctuation marks
-3. Use title case (capitalize important words)
-4. Focus on the main topic, subject, or action discussed
-5. Remove filler words, greetings, and conversational fluff
-6. Be specific and descriptive, not generic
-7. If the transcription is very short or unclear, create a meaningful title based on context
-8. Do not include timestamps, dates, or metadata
-9. Do not use phrases like "Recording about" or "Discussion of"
-10. Return ONLY the title text, nothing else
-
-Transcription:
-{transcription}
-
-Generate the title now:`}
-                                    />
-                                </div>
-                                <div className="flex justify-end gap-2">
-                                    <Button
-                                        variant="outline"
-                                        onClick={() =>
-                                            setEditingCustomPrompt(null)
-                                        }
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        onClick={() => {
-                                            if (
-                                                !editingCustomPrompt.name ||
-                                                !editingCustomPrompt.prompt
-                                            ) {
-                                                toast.error(
-                                                    "Name and prompt are required",
-                                                );
-                                                return;
-                                            }
-                                            handleSaveCustomPrompt(
-                                                editingCustomPrompt,
-                                            );
-                                        }}
-                                        disabled={
-                                            !editingCustomPrompt.name ||
-                                            !editingCustomPrompt.prompt
-                                        }
-                                    >
-                                        {editingCustomPrompt.id
-                                            ? "Save"
-                                            : "Create"}
-                                    </Button>
-                                </div>
-                            </div>
-                        </DialogContent>
-                    </Dialog>
-                )}
+                {aiSubSection === "prompts" && <PromptManager />}
             </div>
 
             <AddProviderDialog
@@ -765,5 +189,98 @@ Generate the title now:`}
                 }}
             />
         </>
+    );
+}
+
+/**
+ * Configured-providers list with edit/delete row actions. Pure
+ * presentation -- the parent owns the data + dialog state.
+ */
+function ProvidersList({
+    providers,
+    deletingId,
+    onAdd,
+    onEdit,
+    onDelete,
+}: {
+    providers: Provider[];
+    deletingId: string | null;
+    onAdd: () => void;
+    onEdit: (provider: Provider) => void;
+    onDelete: (id: string) => void;
+}) {
+    if (providers.length === 0) {
+        return (
+            <div className="text-center py-12">
+                <Bot className="size-16 mx-auto mb-4 text-muted-foreground" />
+                <h3 className="font-semibold mb-2">No providers configured</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                    Add an AI provider to enable transcription
+                </p>
+                <Button onClick={onAdd} size="sm">
+                    <Plus className="size-4 mr-2" />
+                    Add Provider
+                </Button>
+            </div>
+        );
+    }
+    return (
+        <div className="space-y-3">
+            {providers.map((provider) => (
+                <div
+                    key={provider.id}
+                    className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent transition-colors"
+                >
+                    <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                            <h3 className="font-semibold">
+                                {provider.provider}
+                            </h3>
+                            {provider.isDefaultTranscription && (
+                                <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
+                                    Transcription
+                                </span>
+                            )}
+                            {provider.isDefaultEnhancement && (
+                                <span className="text-xs px-2 py-0.5 bg-purple-500/10 text-purple-600 rounded border border-purple-500/20">
+                                    Enhancement
+                                </span>
+                            )}
+                        </div>
+                        {provider.defaultModel && (
+                            <p className="text-sm text-muted-foreground">
+                                Model: {provider.defaultModel}
+                            </p>
+                        )}
+                        {provider.baseUrl && (
+                            <p className="text-xs text-muted-foreground font-mono truncate">
+                                {provider.baseUrl}
+                            </p>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-2 ml-4">
+                        <Button
+                            onClick={() => onEdit(provider)}
+                            variant="outline"
+                            size="icon"
+                        >
+                            <Pencil className="size-4" />
+                        </Button>
+                        <Button
+                            onClick={() => onDelete(provider.id)}
+                            variant="outline"
+                            size="icon"
+                            disabled={deletingId === provider.id}
+                        >
+                            {deletingId === provider.id ? (
+                                <div className="animate-spin size-4 border-2 border-destructive border-t-transparent rounded-full" />
+                            ) : (
+                                <Trash2 className="size-4 text-destructive" />
+                            )}
+                        </Button>
+                    </div>
+                </div>
+            ))}
+        </div>
     );
 }

--- a/src/components/settings-sections/providers-section.tsx
+++ b/src/components/settings-sections/providers-section.tsx
@@ -29,6 +29,8 @@ import { PROMPT_PRESETS } from "@/lib/ai/prompt-presets";
 
 type AISubSection = "providers" | "prompts";
 
+const EMPTY_PROVIDERS: Provider[] = [];
+
 interface Provider {
     id: string;
     provider: string;
@@ -45,7 +47,7 @@ interface ProvidersSectionProps {
 }
 
 export function ProvidersSection({
-    initialProviders = [],
+    initialProviders = EMPTY_PROVIDERS,
     isHosted = false,
 }: ProvidersSectionProps) {
     const confirm = useConfirm();
@@ -75,9 +77,11 @@ export function ProvidersSection({
     } | null>(null);
     const [viewingPromptId, setViewingPromptId] = useState<string | null>(null);
 
-    useEffect(() => {
-        setProviders(initialProviders);
-    }, [initialProviders]);
+    // Note: `initialProviders` is the server-rendered seed only. The local
+    // `providers` state diverges from it after add/edit/delete actions in
+    // this component, so we do NOT re-sync from the prop on changes (would
+    // clobber local edits). If the parent ever needs to force a reset,
+    // pass a `key` prop instead.
 
     useEffect(() => {
         const fetchSettings = async () => {
@@ -248,7 +252,7 @@ export function ProvidersSection({
                             onClick={() => setIsAddProviderOpen(true)}
                             size="sm"
                         >
-                            <Plus className="w-4 h-4 mr-2" />
+                            <Plus className="size-4 mr-2" />
                             Add Provider
                         </Button>
                     )}
@@ -276,7 +280,7 @@ export function ProvidersSection({
                                 : "border-transparent text-muted-foreground hover:text-foreground"
                         }`}
                     >
-                        <Sparkles className="w-4 h-4 inline mr-2" />
+                        <Sparkles className="size-4 inline mr-2" />
                         Prompts
                     </button>
                 </div>
@@ -286,7 +290,7 @@ export function ProvidersSection({
                     <div>
                         {providers.length === 0 ? (
                             <div className="text-center py-12">
-                                <Bot className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
+                                <Bot className="size-16 mx-auto mb-4 text-muted-foreground" />
                                 <h3 className="font-semibold mb-2">
                                     No providers configured
                                 </h3>
@@ -297,7 +301,7 @@ export function ProvidersSection({
                                     onClick={() => setIsAddProviderOpen(true)}
                                     size="sm"
                                 >
-                                    <Plus className="w-4 h-4 mr-2" />
+                                    <Plus className="size-4 mr-2" />
                                     Add Provider
                                 </Button>
                             </div>
@@ -344,7 +348,7 @@ export function ProvidersSection({
                                                 variant="outline"
                                                 size="icon"
                                             >
-                                                <Pencil className="w-4 h-4" />
+                                                <Pencil className="size-4" />
                                             </Button>
                                             <Button
                                                 onClick={() =>
@@ -357,9 +361,9 @@ export function ProvidersSection({
                                                 }
                                             >
                                                 {deletingId === provider.id ? (
-                                                    <div className="animate-spin w-4 h-4 border-2 border-destructive border-t-transparent rounded-full" />
+                                                    <div className="animate-spin size-4 border-2 border-destructive border-t-transparent rounded-full" />
                                                 ) : (
-                                                    <Trash2 className="w-4 h-4 text-destructive" />
+                                                    <Trash2 className="size-4 text-destructive" />
                                                 )}
                                             </Button>
                                         </div>
@@ -375,7 +379,7 @@ export function ProvidersSection({
                     <div className="space-y-6">
                         {isLoadingSettings ? (
                             <div className="flex items-center justify-center py-8">
-                                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
                             </div>
                         ) : (
                             <>
@@ -493,7 +497,7 @@ export function ProvidersSection({
                                             }
                                             size="sm"
                                         >
-                                            <Plus className="w-4 h-4 mr-2" />
+                                            <Plus className="size-4 mr-2" />
                                             Add Custom Prompt
                                         </Button>
                                     </div>
@@ -550,7 +554,7 @@ export function ProvidersSection({
                                                                     )
                                                                 }
                                                             >
-                                                                <Pencil className="w-4 h-4" />
+                                                                <Pencil className="size-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline"
@@ -561,7 +565,7 @@ export function ProvidersSection({
                                                                     )
                                                                 }
                                                             >
-                                                                <Trash2 className="w-4 h-4 text-destructive" />
+                                                                <Trash2 className="size-4 text-destructive" />
                                                             </Button>
                                                         </div>
                                                     </div>
@@ -643,10 +647,14 @@ export function ProvidersSection({
                                         id="custom-prompt-name"
                                         value={editingCustomPrompt.name}
                                         onChange={(e) =>
-                                            setEditingCustomPrompt({
-                                                ...editingCustomPrompt,
-                                                name: e.target.value,
-                                            })
+                                            setEditingCustomPrompt((prev) =>
+                                                prev
+                                                    ? {
+                                                          ...prev,
+                                                          name: e.target.value,
+                                                      }
+                                                    : prev,
+                                            )
                                         }
                                         placeholder="My Custom Prompt"
                                     />
@@ -660,10 +668,15 @@ export function ProvidersSection({
                                         className="w-full min-h-[300px] px-3 py-2 text-sm border rounded-md resize-y font-mono"
                                         value={editingCustomPrompt.prompt}
                                         onChange={(e) =>
-                                            setEditingCustomPrompt({
-                                                ...editingCustomPrompt,
-                                                prompt: e.target.value,
-                                            })
+                                            setEditingCustomPrompt((prev) =>
+                                                prev
+                                                    ? {
+                                                          ...prev,
+                                                          prompt: e.target
+                                                              .value,
+                                                      }
+                                                    : prev,
+                                            )
                                         }
                                         placeholder={`You are a title generator for audio recordings. Generate a concise, descriptive title based on the transcription provided.
 

--- a/src/components/settings-sections/storage-section.tsx
+++ b/src/components/settings-sections/storage-section.tsx
@@ -197,7 +197,7 @@ export function StorageSection({ isHosted = false }: StorageSectionProps) {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/summary-section.tsx
+++ b/src/components/settings-sections/summary-section.tsx
@@ -102,7 +102,7 @@ export function SummarySection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/sync-section.tsx
+++ b/src/components/settings-sections/sync-section.tsx
@@ -131,7 +131,7 @@ export function SyncSection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings-sections/transcription-section.tsx
+++ b/src/components/settings-sections/transcription-section.tsx
@@ -212,7 +212,7 @@ export function TranscriptionSection() {
     if (isLoadingSettings) {
         return (
             <div className="flex items-center justify-center py-8">
-                <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
             </div>
         );
     }

--- a/src/components/settings/api-keys-section.tsx
+++ b/src/components/settings/api-keys-section.tsx
@@ -166,14 +166,14 @@ export function ApiKeysSection() {
 
             {isLoading ? (
                 <div className="flex items-center justify-center py-8">
-                    <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                    <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
                 </div>
             ) : apiKeys.length === 0 ? (
                 <div className="text-center py-12 border rounded-lg">
-                    <KeyRound className="w-12 h-12 mx-auto mb-3 text-muted-foreground" />
+                    <KeyRound className="size-12 mx-auto mb-3 text-muted-foreground" />
                     <h3 className="font-semibold mb-2">No API keys</h3>
                     <Button size="sm" onClick={() => setIsCreateOpen(true)}>
-                        <Plus className="w-4 h-4" />
+                        <Plus className="size-4" />
                         Create Key
                     </Button>
                 </div>
@@ -218,7 +218,7 @@ export function ApiKeysSection() {
                                 disabled={Boolean(apiKey.revokedAt)}
                                 aria-label={`Revoke ${apiKey.name}`}
                             >
-                                <Trash2 className="w-4 h-4 text-destructive" />
+                                <Trash2 className="size-4 text-destructive" />
                             </Button>
                         </div>
                     ))}
@@ -243,7 +243,7 @@ export function ApiKeysSection() {
                                     className="flex-1"
                                     onClick={copyCreatedKey}
                                 >
-                                    <Clipboard className="w-4 h-4" />
+                                    <Clipboard className="size-4" />
                                     Copy
                                 </Button>
                                 <Button
@@ -254,7 +254,7 @@ export function ApiKeysSection() {
                                         setIsCreateOpen(false);
                                     }}
                                 >
-                                    <Check className="w-4 h-4" />
+                                    <Check className="size-4" />
                                     Saved
                                 </Button>
                             </div>

--- a/src/components/settings/edit-provider-dialog.tsx
+++ b/src/components/settings/edit-provider-dialog.tsx
@@ -214,7 +214,7 @@ export function EditProviderDialog({
                         </Select>
                         {legacyLocalProvider && (
                             <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-300">
-                                <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                                <AlertTriangle className="size-3.5 shrink-0 mt-0.5" />
                                 <span>
                                     {legacyLocalProvider} isn&apos;t usable on
                                     the hosted app — we can&apos;t reach your
@@ -245,7 +245,7 @@ export function EditProviderDialog({
                             className="font-mono text-sm"
                         />
                         <div className="text-xs text-muted-foreground flex items-center gap-2">
-                            <Shield className="w-3.5 h-3.5 shrink-0" />
+                            <Shield className="size-3.5 shrink-0" />
                             <span>
                                 For security, the saved API key is never shown.
                                 Leave this blank to keep your current key, or

--- a/src/components/settings/settings-page-content.tsx
+++ b/src/components/settings/settings-page-content.tsx
@@ -4,23 +4,25 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { type Provider, SettingsDialog } from "@/components/settings-dialog";
 
+const EMPTY_PROVIDERS: Provider[] = [];
+
 interface SettingsPageContentProps {
     initialProviders?: Provider[];
     isHosted?: boolean;
 }
 
 export function SettingsPageContent({
-    initialProviders = [],
+    initialProviders = EMPTY_PROVIDERS,
     isHosted = false,
 }: SettingsPageContentProps) {
-    const router = useRouter();
+    const { push } = useRouter();
     const [open, setOpen] = useState(true);
 
     const handleOpenChange = (newOpen: boolean) => {
         setOpen(newOpen);
         if (!newOpen) {
             // Navigate back to dashboard when dialog closes
-            router.push("/dashboard");
+            push("/dashboard");
         }
     };
 

--- a/src/components/settings/webhook-deliveries-dialog.tsx
+++ b/src/components/settings/webhook-deliveries-dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+    formatWebhookDate,
+    type WebhookDelivery,
+    type WebhookEndpoint,
+} from "./webhook-types";
+
+interface Props {
+    /** Webhook whose deliveries should be displayed; `null` closes the dialog. */
+    webhook: WebhookEndpoint | null;
+    onClose: () => void;
+}
+
+/**
+ * Read-mostly deliveries inspector for a single webhook endpoint. Fetches
+ * its own list whenever the `webhook` prop changes -- the parent doesn't
+ * keep delivery state around, so opening the dialog from one webhook then
+ * another never flashes the wrong endpoint's history.
+ */
+export function WebhookDeliveriesDialog({ webhook, onClose }: Props) {
+    const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
+
+    const webhookId = webhook?.id ?? null;
+
+    const refresh = useCallback(async () => {
+        if (!webhookId) return;
+        try {
+            const response = await fetch(
+                `/api/settings/webhooks/${webhookId}/deliveries`,
+            );
+            if (!response.ok) throw new Error("Failed to fetch deliveries");
+            const data = (await response.json()) as {
+                deliveries: WebhookDelivery[];
+            };
+            setDeliveries(data.deliveries);
+        } catch {
+            toast.error("Failed to load deliveries");
+        }
+    }, [webhookId]);
+
+    useEffect(() => {
+        if (!webhookId) {
+            // Clear stale deliveries when the dialog closes so re-opening
+            // it for a different webhook can't briefly flash the old list.
+            setDeliveries([]);
+            return;
+        }
+        void refresh();
+    }, [webhookId, refresh]);
+
+    const redeliver = async (deliveryId: string) => {
+        if (!webhookId) return;
+        try {
+            const response = await fetch(
+                `/api/settings/webhooks/${webhookId}/deliveries/${deliveryId}/redeliver`,
+                { method: "POST" },
+            );
+            if (!response.ok) throw new Error("Failed to redeliver");
+            toast.success("Delivery queued");
+            await refresh();
+        } catch {
+            toast.error("Failed to queue delivery");
+        }
+    };
+
+    return (
+        <Dialog
+            open={Boolean(webhook)}
+            onOpenChange={(open) => {
+                if (!open) onClose();
+            }}
+        >
+            <DialogContent className="max-w-3xl">
+                <DialogTitle>Webhook Deliveries</DialogTitle>
+                <div className="max-h-[420px] space-y-2 overflow-y-auto">
+                    {deliveries.length === 0 ? (
+                        <p className="py-8 text-center text-sm text-muted-foreground">
+                            No deliveries yet
+                        </p>
+                    ) : (
+                        deliveries.map((delivery) => (
+                            <div
+                                key={delivery.id}
+                                className="grid gap-2 rounded-lg border p-3 text-sm sm:grid-cols-[1fr_auto]"
+                            >
+                                <div className="space-y-1">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <span className="font-medium">
+                                            {delivery.event}
+                                        </span>
+                                        <span className="rounded border px-2 py-0.5 text-xs">
+                                            {delivery.status}
+                                        </span>
+                                        {delivery.lastResponseStatus && (
+                                            <span className="rounded border px-2 py-0.5 text-xs">
+                                                HTTP{" "}
+                                                {delivery.lastResponseStatus}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Attempts: {delivery.attempts} · Last:{" "}
+                                        {formatWebhookDate(
+                                            delivery.lastAttemptAt,
+                                        )}
+                                    </p>
+                                    {delivery.lastError && (
+                                        <p className="text-xs text-destructive">
+                                            {delivery.lastError}
+                                        </p>
+                                    )}
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={delivery.status === "processing"}
+                                    onClick={() => redeliver(delivery.id)}
+                                >
+                                    <RotateCcw className="size-4" />
+                                    Redeliver
+                                </Button>
+                            </div>
+                        ))
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/settings/webhook-editor-dialog.tsx
+++ b/src/components/settings/webhook-editor-dialog.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { Check, Clipboard } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { DEFAULT_WEBHOOK_EVENTS, type WebhookEndpoint } from "./webhook-types";
+
+interface WebhookForm {
+    url: string;
+    description: string;
+    enabled: boolean;
+    events: string[];
+}
+
+function buildForm(
+    webhook: WebhookEndpoint | null,
+    events: string[],
+): WebhookForm {
+    if (webhook) {
+        return {
+            url: webhook.url,
+            description: webhook.description || "",
+            enabled: webhook.enabled,
+            events: webhook.events,
+        };
+    }
+    return {
+        url: "",
+        description: "",
+        enabled: true,
+        events: [events[0] ?? DEFAULT_WEBHOOK_EVENTS[0]],
+    };
+}
+
+interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** When non-null, the dialog edits this webhook; otherwise it creates. */
+    editingWebhook: WebhookEndpoint | null;
+    /** Server-known event list (subset of DEFAULT_WEBHOOK_EVENTS in practice). */
+    events: string[];
+    /** Called after a successful save so the parent can re-fetch the list. */
+    onSaved: () => Promise<void> | void;
+}
+
+/**
+ * Create/edit dialog for a webhook endpoint. After a successful create, the
+ * server returns a one-time signing secret which we show in-place (and ask
+ * the user to copy) before letting the dialog close. Edits never return a
+ * new secret -- closing the dialog right away is correct there.
+ */
+export function WebhookEditorDialog({
+    open,
+    onOpenChange,
+    editingWebhook,
+    events,
+    onSaved,
+}: Props) {
+    const [form, setForm] = useState<WebhookForm>(() =>
+        buildForm(editingWebhook, events),
+    );
+    const [isSaving, setIsSaving] = useState(false);
+    const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+
+    // Re-seed the form whenever the dialog opens for a (possibly different)
+    // webhook. Without this, opening the dialog for webhook B after editing
+    // webhook A would show A's URL/events.
+    useEffect(() => {
+        if (open) {
+            setCreatedSecret(null);
+            setForm(buildForm(editingWebhook, events));
+        }
+    }, [open, editingWebhook, events]);
+
+    const toggleEvent = (event: string) => {
+        setForm((current) => {
+            const hasEvent = current.events.includes(event);
+            const nextEvents = hasEvent
+                ? current.events.filter((item) => item !== event)
+                : [...current.events, event];
+            return { ...current, events: nextEvents };
+        });
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsSaving(true);
+
+        try {
+            const response = await fetch(
+                editingWebhook
+                    ? `/api/settings/webhooks/${editingWebhook.id}`
+                    : "/api/settings/webhooks",
+                {
+                    method: editingWebhook ? "PATCH" : "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(form),
+                },
+            );
+
+            const data = (await response.json()) as {
+                webhook?: WebhookEndpoint;
+                secret?: string;
+                error?: string;
+            };
+            if (!response.ok || !data.webhook) {
+                throw new Error(data.error || "Failed to save webhook");
+            }
+
+            await onSaved();
+            if (data.secret) {
+                // Hold the dialog open so the secret can be copied; the user
+                // dismisses via the "Saved" button.
+                setCreatedSecret(data.secret);
+            } else {
+                onOpenChange(false);
+            }
+            toast.success(editingWebhook ? "Webhook updated" : "Webhook added");
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : "Failed to save webhook",
+            );
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const copySecret = async () => {
+        if (!createdSecret) return;
+        await navigator.clipboard.writeText(createdSecret);
+        toast.success("Secret copied");
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-xl">
+                <DialogTitle>
+                    {editingWebhook ? "Edit Webhook" : "Add Webhook"}
+                </DialogTitle>
+                {createdSecret ? (
+                    <div className="space-y-4">
+                        <DialogDescription>
+                            This signing secret is shown once.
+                        </DialogDescription>
+                        <div className="rounded-md border bg-muted p-3 font-mono text-sm break-all">
+                            {createdSecret}
+                        </div>
+                        <div className="flex gap-2">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1"
+                                onClick={copySecret}
+                            >
+                                <Clipboard className="size-4" />
+                                Copy
+                            </Button>
+                            <Button
+                                type="button"
+                                className="flex-1"
+                                onClick={() => {
+                                    setCreatedSecret(null);
+                                    onOpenChange(false);
+                                }}
+                            >
+                                <Check className="size-4" />
+                                Saved
+                            </Button>
+                        </div>
+                    </div>
+                ) : (
+                    <form onSubmit={handleSubmit} className="space-y-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="webhook-url">URL</Label>
+                            <Input
+                                id="webhook-url"
+                                value={form.url}
+                                onChange={(event) =>
+                                    setForm((current) => ({
+                                        ...current,
+                                        url: event.target.value,
+                                    }))
+                                }
+                                placeholder="https://example.com/webhook"
+                                disabled={isSaving}
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="webhook-description">
+                                Description
+                            </Label>
+                            <Input
+                                id="webhook-description"
+                                value={form.description}
+                                onChange={(event) =>
+                                    setForm((current) => ({
+                                        ...current,
+                                        description: event.target.value,
+                                    }))
+                                }
+                                placeholder="Automation receiver"
+                                disabled={isSaving}
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label>Events</Label>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                                {events.map((event) => (
+                                    <label
+                                        key={event}
+                                        className="flex items-center gap-2 rounded-md border p-2 text-sm"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={form.events.includes(
+                                                event,
+                                            )}
+                                            onChange={() => toggleEvent(event)}
+                                            disabled={
+                                                isSaving ||
+                                                (form.events.length === 1 &&
+                                                    form.events.includes(event))
+                                            }
+                                        />
+                                        <span>{event}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="flex items-center justify-between rounded-md border p-3">
+                            <Label htmlFor="webhook-enabled">Enabled</Label>
+                            <Switch
+                                id="webhook-enabled"
+                                checked={form.enabled}
+                                onCheckedChange={(checked) =>
+                                    setForm((current) => ({
+                                        ...current,
+                                        enabled: checked,
+                                    }))
+                                }
+                                disabled={isSaving}
+                            />
+                        </div>
+                        <div className="flex justify-end gap-2">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => onOpenChange(false)}
+                                disabled={isSaving}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={
+                                    isSaving ||
+                                    !form.url.trim() ||
+                                    form.events.length === 0
+                                }
+                            >
+                                Save
+                            </Button>
+                        </div>
+                    </form>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/settings/webhook-types.ts
+++ b/src/components/settings/webhook-types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for the webhooks settings UI.
+ *
+ * Lives in its own file (not co-located with WebhooksSection) so the editor
+ * and deliveries dialogs can import without pulling in the parent component.
+ */
+
+export type WebhookEndpoint = {
+    id: string;
+    url: string;
+    secret: string;
+    events: string[];
+    description: string | null;
+    enabled: boolean;
+    lastDeliveryAt: string | null;
+    lastDeliveryStatus: string | null;
+    createdAt: string;
+};
+
+export type WebhookDelivery = {
+    id: string;
+    event: string;
+    status: string;
+    attempts: number;
+    lastAttemptAt: string | null;
+    nextAttemptAt: string;
+    lastResponseStatus: number | null;
+    lastError: string | null;
+    createdAt: string;
+};
+
+export const DEFAULT_WEBHOOK_EVENTS = [
+    "recording.synced",
+    "recording.updated",
+    "recording.deleted",
+    "transcription.completed",
+    "transcription.failed",
+];
+
+export function formatWebhookDate(value: string | null): string {
+    if (!value) return "Never";
+    return new Date(value).toLocaleString();
+}

--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -79,7 +79,7 @@ export function WebhooksSection() {
     const [isEditorOpen, setIsEditorOpen] = useState(false);
     const [editingWebhook, setEditingWebhook] =
         useState<WebhookEndpoint | null>(null);
-    const [form, setForm] = useState(emptyForm());
+    const [form, setForm] = useState(() => emptyForm());
     const [createdSecret, setCreatedSecret] = useState<string | null>(null);
     const [deliveryWebhook, setDeliveryWebhook] =
         useState<WebhookEndpoint | null>(null);
@@ -248,14 +248,14 @@ export function WebhooksSection() {
 
             {isLoading ? (
                 <div className="flex items-center justify-center py-8">
-                    <div className="animate-spin w-6 h-6 border-2 border-primary border-t-transparent rounded-full" />
+                    <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
                 </div>
             ) : webhooks.length === 0 ? (
                 <div className="text-center py-12 border rounded-lg">
-                    <Webhook className="w-12 h-12 mx-auto mb-3 text-muted-foreground" />
+                    <Webhook className="size-12 mx-auto mb-3 text-muted-foreground" />
                     <h3 className="font-semibold mb-2">No webhooks</h3>
                     <Button size="sm" onClick={() => openEditor(null)}>
-                        <Plus className="w-4 h-4" />
+                        <Plus className="size-4" />
                         Add Webhook
                     </Button>
                 </div>
@@ -329,7 +329,7 @@ export function WebhooksSection() {
                                         onClick={() => openEditor(webhook)}
                                         aria-label="Edit webhook"
                                     >
-                                        <Pencil className="w-4 h-4" />
+                                        <Pencil className="size-4" />
                                     </Button>
                                     <Button
                                         variant="outline"
@@ -337,7 +337,7 @@ export function WebhooksSection() {
                                         onClick={() => handleDelete(webhook.id)}
                                         aria-label="Delete webhook"
                                     >
-                                        <Trash2 className="w-4 h-4 text-destructive" />
+                                        <Trash2 className="size-4 text-destructive" />
                                     </Button>
                                 </div>
                             </div>
@@ -366,7 +366,7 @@ export function WebhooksSection() {
                                     className="flex-1"
                                     onClick={copySecret}
                                 >
-                                    <Clipboard className="w-4 h-4" />
+                                    <Clipboard className="size-4" />
                                     Copy
                                 </Button>
                                 <Button
@@ -377,7 +377,7 @@ export function WebhooksSection() {
                                         setIsEditorOpen(false);
                                     }}
                                 >
-                                    <Check className="w-4 h-4" />
+                                    <Check className="size-4" />
                                     Saved
                                 </Button>
                             </div>
@@ -539,7 +539,7 @@ export function WebhooksSection() {
                                         }
                                         onClick={() => redeliver(delivery.id)}
                                     >
-                                        <RotateCcw className="w-4 h-4" />
+                                        <RotateCcw className="size-4" />
                                         Redeliver
                                     </Button>
                                 </div>

--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -1,89 +1,29 @@
 "use client";
 
-import {
-    Check,
-    Clipboard,
-    Pencil,
-    Plus,
-    RotateCcw,
-    Trash2,
-    Webhook,
-} from "lucide-react";
+import { Pencil, Plus, Trash2, Webhook } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useConfirm } from "@/components/confirm-dialog";
 import { SettingsSectionHeader } from "@/components/settings/section-header";
 import { Button } from "@/components/ui/button";
+import { WebhookDeliveriesDialog } from "./webhook-deliveries-dialog";
+import { WebhookEditorDialog } from "./webhook-editor-dialog";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-
-type WebhookEndpoint = {
-    id: string;
-    url: string;
-    secret: string;
-    events: string[];
-    description: string | null;
-    enabled: boolean;
-    lastDeliveryAt: string | null;
-    lastDeliveryStatus: string | null;
-    createdAt: string;
-};
-
-type WebhookDelivery = {
-    id: string;
-    event: string;
-    status: string;
-    attempts: number;
-    lastAttemptAt: string | null;
-    nextAttemptAt: string;
-    lastResponseStatus: number | null;
-    lastError: string | null;
-    createdAt: string;
-};
-
-const DEFAULT_EVENTS = [
-    "recording.synced",
-    "recording.updated",
-    "recording.deleted",
-    "transcription.completed",
-    "transcription.failed",
-];
-
-function formatDate(value: string | null): string {
-    if (!value) return "Never";
-    return new Date(value).toLocaleString();
-}
-
-function emptyForm(events = DEFAULT_EVENTS) {
-    return {
-        url: "",
-        description: "",
-        enabled: true,
-        events: [events[0]],
-    };
-}
+    DEFAULT_WEBHOOK_EVENTS,
+    formatWebhookDate,
+    type WebhookEndpoint,
+} from "./webhook-types";
 
 export function WebhooksSection() {
     const confirm = useConfirm();
     const [webhooks, setWebhooks] = useState<WebhookEndpoint[]>([]);
-    const [events, setEvents] = useState<string[]>(DEFAULT_EVENTS);
+    const [events, setEvents] = useState<string[]>(DEFAULT_WEBHOOK_EVENTS);
     const [isLoading, setIsLoading] = useState(true);
-    const [isSaving, setIsSaving] = useState(false);
     const [isEditorOpen, setIsEditorOpen] = useState(false);
     const [editingWebhook, setEditingWebhook] =
         useState<WebhookEndpoint | null>(null);
-    const [form, setForm] = useState(() => emptyForm());
-    const [createdSecret, setCreatedSecret] = useState<string | null>(null);
     const [deliveryWebhook, setDeliveryWebhook] =
         useState<WebhookEndpoint | null>(null);
-    const [deliveries, setDeliveries] = useState<WebhookDelivery[]>([]);
 
     const refreshWebhooks = useCallback(async () => {
         try {
@@ -106,88 +46,9 @@ export function WebhooksSection() {
         refreshWebhooks();
     }, [refreshWebhooks]);
 
-    const refreshDeliveries = async (webhookId: string) => {
-        try {
-            const response = await fetch(
-                `/api/settings/webhooks/${webhookId}/deliveries`,
-            );
-            if (!response.ok) throw new Error("Failed to fetch deliveries");
-            const data = (await response.json()) as {
-                deliveries: WebhookDelivery[];
-            };
-            setDeliveries(data.deliveries);
-        } catch {
-            toast.error("Failed to load deliveries");
-        }
-    };
-
     const openEditor = (webhook: WebhookEndpoint | null) => {
-        setCreatedSecret(null);
         setEditingWebhook(webhook);
-        setForm(
-            webhook
-                ? {
-                      url: webhook.url,
-                      description: webhook.description || "",
-                      enabled: webhook.enabled,
-                      events: webhook.events,
-                  }
-                : emptyForm(events),
-        );
         setIsEditorOpen(true);
-    };
-
-    const toggleEvent = (event: string) => {
-        setForm((current) => {
-            const hasEvent = current.events.includes(event);
-            const nextEvents = hasEvent
-                ? current.events.filter((item) => item !== event)
-                : [...current.events, event];
-            return { ...current, events: nextEvents };
-        });
-    };
-
-    const handleSubmit = async (event: React.FormEvent) => {
-        event.preventDefault();
-        setIsSaving(true);
-
-        try {
-            const response = await fetch(
-                editingWebhook
-                    ? `/api/settings/webhooks/${editingWebhook.id}`
-                    : "/api/settings/webhooks",
-                {
-                    method: editingWebhook ? "PATCH" : "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(form),
-                },
-            );
-
-            const data = (await response.json()) as {
-                webhook?: WebhookEndpoint;
-                secret?: string;
-                error?: string;
-            };
-            if (!response.ok || !data.webhook) {
-                throw new Error(data.error || "Failed to save webhook");
-            }
-
-            await refreshWebhooks();
-            if (data.secret) {
-                setCreatedSecret(data.secret);
-            } else {
-                setIsEditorOpen(false);
-            }
-            toast.success(editingWebhook ? "Webhook updated" : "Webhook added");
-        } catch (error) {
-            toast.error(
-                error instanceof Error
-                    ? error.message
-                    : "Failed to save webhook",
-            );
-        } finally {
-            setIsSaving(false);
-        }
     };
 
     const handleDelete = (webhookId: string) => {
@@ -209,27 +70,6 @@ export function WebhooksSection() {
             },
             errorMessage: "Failed to delete webhook",
         });
-    };
-
-    const copySecret = async () => {
-        if (!createdSecret) return;
-        await navigator.clipboard.writeText(createdSecret);
-        toast.success("Secret copied");
-    };
-
-    const redeliver = async (deliveryId: string) => {
-        if (!deliveryWebhook) return;
-        try {
-            const response = await fetch(
-                `/api/settings/webhooks/${deliveryWebhook.id}/deliveries/${deliveryId}/redeliver`,
-                { method: "POST" },
-            );
-            if (!response.ok) throw new Error("Failed to redeliver");
-            toast.success("Delivery queued");
-            await refreshDeliveries(deliveryWebhook.id);
-        } catch {
-            toast.error("Failed to queue delivery");
-        }
     };
 
     return (
@@ -262,292 +102,115 @@ export function WebhooksSection() {
             ) : (
                 <div className="space-y-3">
                     {webhooks.map((webhook) => (
-                        <div
+                        <WebhookRow
                             key={webhook.id}
-                            className="space-y-3 rounded-lg border p-4"
-                        >
-                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                <div className="min-w-0 space-y-2">
-                                    <div className="flex flex-wrap items-center gap-2">
-                                        <h3 className="truncate font-medium">
-                                            {webhook.description || webhook.url}
-                                        </h3>
-                                        <span
-                                            className={`rounded border px-2 py-0.5 text-xs ${
-                                                webhook.enabled
-                                                    ? "text-primary"
-                                                    : "text-muted-foreground"
-                                            }`}
-                                        >
-                                            {webhook.enabled
-                                                ? "Enabled"
-                                                : "Disabled"}
-                                        </span>
-                                        {webhook.lastDeliveryStatus && (
-                                            <span className="rounded border px-2 py-0.5 text-xs">
-                                                {webhook.lastDeliveryStatus}
-                                            </span>
-                                        )}
-                                    </div>
-                                    <p className="truncate font-mono text-xs text-muted-foreground">
-                                        {webhook.url}
-                                    </p>
-                                    <div className="flex flex-wrap gap-1">
-                                        {webhook.events.map((event) => (
-                                            <span
-                                                key={event}
-                                                className="rounded bg-muted px-2 py-0.5 text-xs"
-                                            >
-                                                {event}
-                                            </span>
-                                        ))}
-                                    </div>
-                                    <p className="text-xs text-muted-foreground">
-                                        Last delivery:{" "}
-                                        {formatDate(webhook.lastDeliveryAt)}
-                                    </p>
-                                </div>
-                                <div className="flex gap-2">
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={() => {
-                                            // Clear stale deliveries from a
-                                            // previously opened webhook so
-                                            // the dialog never flashes the
-                                            // wrong endpoint's history.
-                                            setDeliveries([]);
-                                            setDeliveryWebhook(webhook);
-                                            refreshDeliveries(webhook.id);
-                                        }}
-                                    >
-                                        Deliveries
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        size="icon"
-                                        onClick={() => openEditor(webhook)}
-                                        aria-label="Edit webhook"
-                                    >
-                                        <Pencil className="size-4" />
-                                    </Button>
-                                    <Button
-                                        variant="outline"
-                                        size="icon"
-                                        onClick={() => handleDelete(webhook.id)}
-                                        aria-label="Delete webhook"
-                                    >
-                                        <Trash2 className="size-4 text-destructive" />
-                                    </Button>
-                                </div>
-                            </div>
-                        </div>
+                            webhook={webhook}
+                            onEdit={openEditor}
+                            onDelete={handleDelete}
+                            onShowDeliveries={setDeliveryWebhook}
+                        />
                     ))}
                 </div>
             )}
 
-            <Dialog open={isEditorOpen} onOpenChange={setIsEditorOpen}>
-                <DialogContent className="max-w-xl">
-                    <DialogTitle>
-                        {editingWebhook ? "Edit Webhook" : "Add Webhook"}
-                    </DialogTitle>
-                    {createdSecret ? (
-                        <div className="space-y-4">
-                            <DialogDescription>
-                                This signing secret is shown once.
-                            </DialogDescription>
-                            <div className="rounded-md border bg-muted p-3 font-mono text-sm break-all">
-                                {createdSecret}
-                            </div>
-                            <div className="flex gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    className="flex-1"
-                                    onClick={copySecret}
-                                >
-                                    <Clipboard className="size-4" />
-                                    Copy
-                                </Button>
-                                <Button
-                                    type="button"
-                                    className="flex-1"
-                                    onClick={() => {
-                                        setCreatedSecret(null);
-                                        setIsEditorOpen(false);
-                                    }}
-                                >
-                                    <Check className="size-4" />
-                                    Saved
-                                </Button>
-                            </div>
-                        </div>
-                    ) : (
-                        <form onSubmit={handleSubmit} className="space-y-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="webhook-url">URL</Label>
-                                <Input
-                                    id="webhook-url"
-                                    value={form.url}
-                                    onChange={(event) =>
-                                        setForm((current) => ({
-                                            ...current,
-                                            url: event.target.value,
-                                        }))
-                                    }
-                                    placeholder="https://example.com/webhook"
-                                    disabled={isSaving}
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="webhook-description">
-                                    Description
-                                </Label>
-                                <Input
-                                    id="webhook-description"
-                                    value={form.description}
-                                    onChange={(event) =>
-                                        setForm((current) => ({
-                                            ...current,
-                                            description: event.target.value,
-                                        }))
-                                    }
-                                    placeholder="Automation receiver"
-                                    disabled={isSaving}
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Events</Label>
-                                <div className="grid gap-2 sm:grid-cols-2">
-                                    {events.map((event) => (
-                                        <label
-                                            key={event}
-                                            className="flex items-center gap-2 rounded-md border p-2 text-sm"
-                                        >
-                                            <input
-                                                type="checkbox"
-                                                checked={form.events.includes(
-                                                    event,
-                                                )}
-                                                onChange={() =>
-                                                    toggleEvent(event)
-                                                }
-                                                disabled={
-                                                    isSaving ||
-                                                    (form.events.length === 1 &&
-                                                        form.events.includes(
-                                                            event,
-                                                        ))
-                                                }
-                                            />
-                                            <span>{event}</span>
-                                        </label>
-                                    ))}
-                                </div>
-                            </div>
-                            <div className="flex items-center justify-between rounded-md border p-3">
-                                <Label htmlFor="webhook-enabled">Enabled</Label>
-                                <Switch
-                                    id="webhook-enabled"
-                                    checked={form.enabled}
-                                    onCheckedChange={(checked) =>
-                                        setForm((current) => ({
-                                            ...current,
-                                            enabled: checked,
-                                        }))
-                                    }
-                                    disabled={isSaving}
-                                />
-                            </div>
-                            <div className="flex justify-end gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => setIsEditorOpen(false)}
-                                    disabled={isSaving}
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    type="submit"
-                                    disabled={
-                                        isSaving ||
-                                        !form.url.trim() ||
-                                        form.events.length === 0
-                                    }
-                                >
-                                    Save
-                                </Button>
-                            </div>
-                        </form>
-                    )}
-                </DialogContent>
-            </Dialog>
+            <WebhookEditorDialog
+                open={isEditorOpen}
+                onOpenChange={setIsEditorOpen}
+                editingWebhook={editingWebhook}
+                events={events}
+                onSaved={refreshWebhooks}
+            />
 
-            <Dialog
-                open={Boolean(deliveryWebhook)}
-                onOpenChange={(open) => {
-                    if (!open) setDeliveryWebhook(null);
-                }}
-            >
-                <DialogContent className="max-w-3xl">
-                    <DialogTitle>Webhook Deliveries</DialogTitle>
-                    <div className="max-h-[420px] space-y-2 overflow-y-auto">
-                        {deliveries.length === 0 ? (
-                            <p className="py-8 text-center text-sm text-muted-foreground">
-                                No deliveries yet
-                            </p>
-                        ) : (
-                            deliveries.map((delivery) => (
-                                <div
-                                    key={delivery.id}
-                                    className="grid gap-2 rounded-lg border p-3 text-sm sm:grid-cols-[1fr_auto]"
-                                >
-                                    <div className="space-y-1">
-                                        <div className="flex flex-wrap items-center gap-2">
-                                            <span className="font-medium">
-                                                {delivery.event}
-                                            </span>
-                                            <span className="rounded border px-2 py-0.5 text-xs">
-                                                {delivery.status}
-                                            </span>
-                                            {delivery.lastResponseStatus && (
-                                                <span className="rounded border px-2 py-0.5 text-xs">
-                                                    HTTP{" "}
-                                                    {
-                                                        delivery.lastResponseStatus
-                                                    }
-                                                </span>
-                                            )}
-                                        </div>
-                                        <p className="text-xs text-muted-foreground">
-                                            Attempts: {delivery.attempts} ·
-                                            Last:{" "}
-                                            {formatDate(delivery.lastAttemptAt)}
-                                        </p>
-                                        {delivery.lastError && (
-                                            <p className="text-xs text-destructive">
-                                                {delivery.lastError}
-                                            </p>
-                                        )}
-                                    </div>
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        disabled={
-                                            delivery.status === "processing"
-                                        }
-                                        onClick={() => redeliver(delivery.id)}
-                                    >
-                                        <RotateCcw className="size-4" />
-                                        Redeliver
-                                    </Button>
-                                </div>
-                            ))
+            <WebhookDeliveriesDialog
+                webhook={deliveryWebhook}
+                onClose={() => setDeliveryWebhook(null)}
+            />
+        </div>
+    );
+}
+
+/**
+ * One row in the webhook list. Pure presentation -- all mutation goes
+ * through the callbacks the parent owns.
+ */
+function WebhookRow({
+    webhook,
+    onEdit,
+    onDelete,
+    onShowDeliveries,
+}: {
+    webhook: WebhookEndpoint;
+    onEdit: (webhook: WebhookEndpoint) => void;
+    onDelete: (webhookId: string) => void;
+    onShowDeliveries: (webhook: WebhookEndpoint) => void;
+}) {
+    return (
+        <div className="space-y-3 rounded-lg border p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="truncate font-medium">
+                            {webhook.description || webhook.url}
+                        </h3>
+                        <span
+                            className={`rounded border px-2 py-0.5 text-xs ${
+                                webhook.enabled
+                                    ? "text-primary"
+                                    : "text-muted-foreground"
+                            }`}
+                        >
+                            {webhook.enabled ? "Enabled" : "Disabled"}
+                        </span>
+                        {webhook.lastDeliveryStatus && (
+                            <span className="rounded border px-2 py-0.5 text-xs">
+                                {webhook.lastDeliveryStatus}
+                            </span>
                         )}
                     </div>
-                </DialogContent>
-            </Dialog>
+                    <p className="truncate font-mono text-xs text-muted-foreground">
+                        {webhook.url}
+                    </p>
+                    <div className="flex flex-wrap gap-1">
+                        {webhook.events.map((event) => (
+                            <span
+                                key={event}
+                                className="rounded bg-muted px-2 py-0.5 text-xs"
+                            >
+                                {event}
+                            </span>
+                        ))}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Last delivery:{" "}
+                        {formatWebhookDate(webhook.lastDeliveryAt)}
+                    </p>
+                </div>
+                <div className="flex gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onShowDeliveries(webhook)}
+                    >
+                        Deliveries
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => onEdit(webhook)}
+                        aria-label="Edit webhook"
+                    >
+                        <Pencil className="size-4" />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => onDelete(webhook.id)}
+                        aria-label="Delete webhook"
+                    >
+                        <Trash2 className="size-4 text-destructive" />
+                    </Button>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -9,6 +9,13 @@ export function ThemeToggle({ className }: { className?: string }) {
     const { setTheme, resolvedTheme } = useTheme();
     const [mounted, setMounted] = useState(false);
 
+    // useEffect+setState on mount is the next-themes-recommended pattern for
+    // SSR-safe theme reads. resolvedTheme is undefined on the server and on
+    // the first client render, so we paint a neutral placeholder until the
+    // store has settled. We can't use useSyncExternalStore here because
+    // next-themes doesn't expose its store -- only its hook. The placeholder
+    // branch below is the actual flicker-prevention; the lint warning about
+    // useEffect-on-mount is pattern-matching the shape, not the intent.
     useEffect(() => {
         setMounted(true);
     }, []);

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -2,7 +2,7 @@
 
 import { Slot } from "@radix-ui/react-slot";
 import { ChevronRight } from "lucide-react";
-import * as React from "react";
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
@@ -32,12 +32,15 @@ function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
     );
 }
 
-const BreadcrumbLink = React.forwardRef<
-    React.ElementRef<"a">,
-    React.ComponentPropsWithoutRef<"a"> & {
-        asChild?: boolean;
-    }
->(({ className, asChild = false, ...props }, ref) => {
+function BreadcrumbLink({
+    className,
+    asChild = false,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean;
+    ref?: React.Ref<HTMLAnchorElement>;
+}) {
     const Comp = asChild ? Slot : "a";
     return (
         <Comp
@@ -46,8 +49,7 @@ const BreadcrumbLink = React.forwardRef<
             {...props}
         />
     );
-});
-BreadcrumbLink.displayName = "BreadcrumbLink";
+}
 
 function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
     return (

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -83,7 +83,7 @@ function DropdownMenuSubTrigger({
             {...props}
         >
             {children}
-            <ChevronRight className="ml-auto h-4 w-4" />
+            <ChevronRight className="ml-auto size-4" />
         </DropdownMenuPrimitive.SubTrigger>
     );
 }
@@ -163,9 +163,9 @@ function DropdownMenuCheckboxItem({
             checked={checked}
             {...props}
         >
-            <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+            <span className="absolute left-2 flex size-3.5 items-center justify-center">
                 <DropdownMenuPrimitive.ItemIndicator>
-                    <Check className="h-4 w-4" />
+                    <Check className="size-4" />
                 </DropdownMenuPrimitive.ItemIndicator>
             </span>
             {children}
@@ -187,9 +187,9 @@ function DropdownMenuRadioItem({
             )}
             {...props}
         >
-            <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+            <span className="absolute left-2 flex size-3.5 items-center justify-center">
                 <DropdownMenuPrimitive.ItemIndicator>
-                    <Circle className="h-2 w-2 fill-current" />
+                    <Circle className="size-2 fill-current" />
                 </DropdownMenuPrimitive.ItemIndicator>
             </span>
             {children}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -3,6 +3,7 @@
 import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
+import { use } from "react";
 import {
     Controller,
     type ControllerProps,
@@ -42,8 +43,8 @@ const FormField = <
 };
 
 const useFormField = () => {
-    const fieldContext = React.useContext(FormFieldContext);
-    const itemContext = React.useContext(FormItemContext);
+    const fieldContext = use(FormFieldContext);
+    const itemContext = use(FormItemContext);
     const { getFieldState } = useFormContext();
     const formState = useFormState({ name: fieldContext.name });
     const fieldState = getFieldState(fieldContext.name, formState);

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,28 +1,33 @@
 "use client";
 
 import * as ProgressPrimitive from "@radix-ui/react-progress";
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Progress = React.forwardRef<
-    React.ElementRef<typeof ProgressPrimitive.Root>,
-    React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-    <ProgressPrimitive.Root
-        ref={ref}
-        className={cn(
-            "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-            className,
-        )}
-        {...props}
-    >
-        <ProgressPrimitive.Indicator
-            className="h-full w-full flex-1 bg-primary transition-all"
-            style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-        />
-    </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+function Progress({
+    className,
+    value,
+    ref,
+    ...props
+}: React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    ref?: React.Ref<React.ComponentRef<typeof ProgressPrimitive.Root>>;
+}) {
+    return (
+        <ProgressPrimitive.Root
+            ref={ref}
+            className={cn(
+                "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+                className,
+            )}
+            {...props}
+        >
+            <ProgressPrimitive.Indicator
+                className="h-full w-full flex-1 bg-primary transition-all"
+                style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+            />
+        </ProgressPrimitive.Root>
+    );
+}
 
 export { Progress };

--- a/src/hooks/use-playback-engine.ts
+++ b/src/hooks/use-playback-engine.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import type { Recording } from "@/types/recording";
+
+export const PLAYBACK_SPEED_OPTIONS = [
+    { label: "0.5x", value: 0.5 },
+    { label: "0.75x", value: 0.75 },
+    { label: "1x", value: 1.0 },
+    { label: "1.25x", value: 1.25 },
+    { label: "1.5x", value: 1.5 },
+    { label: "2x", value: 2.0 },
+] as const;
+
+interface Options {
+    recording: Recording;
+    /** Called when audio finishes playing AND autoPlayNext is on. */
+    onEnded?: () => void;
+    initialPlaybackSpeed?: number;
+    initialVolume?: number;
+    initialAutoPlayNext?: boolean;
+}
+
+/**
+ * Owns the HTMLAudioElement and all of its lifecycle: src swap on
+ * recording change, listener wiring (timeupdate / loadedmetadata /
+ * durationchange / ended / seeked), and the derived playback state
+ * (isPlaying, currentTime, duration, volume, playbackSpeed).
+ *
+ * Returns a stable `audioRef` (attach to a hidden <audio>), the
+ * derived state, and imperative handlers (toggle, seek, cycleSpeed,
+ * toggleMute). Keyboard bindings live in usePlaybackKeyboard so the
+ * test surface for "given an audio element, control playback" stays
+ * separate from "given a player UI, react to keys".
+ */
+export function usePlaybackEngine({
+    recording,
+    onEnded,
+    initialPlaybackSpeed = 1.0,
+    initialVolume = 75,
+    initialAutoPlayNext = false,
+}: Options) {
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [duration, setDuration] = useState(0);
+    const [volume, setVolume] = useState(initialVolume);
+    const [playbackSpeed, setPlaybackSpeed] = useState(initialPlaybackSpeed);
+    const [autoPlayNext] = useState(initialAutoPlayNext);
+    const audioRef = useRef<HTMLAudioElement>(null);
+    const isSeekingRef = useRef(false);
+
+    // Reset transport state and re-point src whenever the recording
+    // changes. The src swap is duplicated in the listener-wiring
+    // effect below for the case where the element wasn't mounted yet
+    // when this effect ran -- both branches guard with the `audio.src
+    // !==` check so the swap is idempotent.
+    useEffect(() => {
+        setCurrentTime(0);
+        setDuration(0);
+        setIsPlaying(false);
+        if (audioRef.current) {
+            audioRef.current.currentTime = 0;
+            audioRef.current.src = `/api/recordings/${recording.id}/audio`;
+            audioRef.current.load();
+        }
+    }, [recording]);
+
+    useEffect(() => {
+        if (audioRef.current) {
+            audioRef.current.volume = volume / 100;
+        }
+    }, [volume]);
+
+    useEffect(() => {
+        if (audioRef.current) {
+            audioRef.current.playbackRate = playbackSpeed;
+        }
+    }, [playbackSpeed]);
+
+    // Listener wiring. Re-runs whenever the recording changes (so the
+    // ended handler closes over the right onEnded / autoPlayNext) but
+    // the listener identities themselves are stable within a single
+    // mount of the recording.
+    useEffect(() => {
+        if (!audioRef.current) return;
+        const audio = audioRef.current;
+        const recordingId = recording.id;
+
+        const updateTime = () => {
+            if (!isSeekingRef.current) {
+                setCurrentTime(audio.currentTime);
+            }
+        };
+        const updateDuration = () => {
+            if (audio.duration && !Number.isNaN(audio.duration)) {
+                setDuration(audio.duration);
+            }
+        };
+        const handleEnded = () => {
+            setIsPlaying(false);
+            if (autoPlayNext && onEnded) {
+                onEnded();
+            }
+        };
+        const handleSeeked = () => {
+            isSeekingRef.current = false;
+            setCurrentTime(audio.currentTime);
+        };
+
+        if (audio.src !== `/api/recordings/${recordingId}/audio`) {
+            audio.src = `/api/recordings/${recordingId}/audio`;
+            audio.load();
+        }
+
+        audio.addEventListener("timeupdate", updateTime);
+        audio.addEventListener("loadedmetadata", updateDuration);
+        audio.addEventListener("durationchange", updateDuration);
+        audio.addEventListener("ended", handleEnded);
+        audio.addEventListener("seeked", handleSeeked);
+
+        if (audio.duration && !Number.isNaN(audio.duration)) {
+            setDuration(audio.duration);
+        }
+
+        return () => {
+            audio.removeEventListener("timeupdate", updateTime);
+            audio.removeEventListener("loadedmetadata", updateDuration);
+            audio.removeEventListener("durationchange", updateDuration);
+            audio.removeEventListener("ended", handleEnded);
+            audio.removeEventListener("seeked", handleSeeked);
+        };
+    }, [recording, autoPlayNext, onEnded]);
+
+    const togglePlayPause = useCallback(() => {
+        if (!audioRef.current) return;
+        if (isPlaying) {
+            audioRef.current.pause();
+        } else {
+            audioRef.current.playbackRate = playbackSpeed;
+            audioRef.current.play().catch((error) => {
+                console.error("Error playing audio:", error);
+                toast.error("Failed to play audio");
+            });
+        }
+        setIsPlaying(!isPlaying);
+    }, [isPlaying, playbackSpeed]);
+
+    /**
+     * Seek to a ratio in [0, 1] of the audio's duration. Used by both
+     * the slider (which translates 0-100 -> 0-1 itself) and the
+     * waveform click handler. Centralising means seek semantics stay
+     * identical regardless of which control the user touches.
+     */
+    const seekToRatio = useCallback((ratio: number) => {
+        const audio = audioRef.current;
+        if (!audio) return;
+        const audioDuration = audio.duration;
+        if (!audioDuration || Number.isNaN(audioDuration)) {
+            audio.load();
+            return;
+        }
+        const newTime = Math.max(
+            0,
+            Math.min(audioDuration, ratio * audioDuration),
+        );
+        isSeekingRef.current = true;
+        audio.currentTime = newTime;
+        setCurrentTime(newTime);
+    }, []);
+
+    /**
+     * Seek by signed seconds offset (used by keyboard left/right).
+     * Clamps to [0, duration].
+     */
+    const seekRelative = useCallback(
+        (deltaSeconds: number) => {
+            const audio = audioRef.current;
+            if (!audio || duration <= 0) return;
+            const newTime = Math.max(
+                0,
+                Math.min(duration, currentTime + deltaSeconds),
+            );
+            audio.currentTime = newTime;
+            setCurrentTime(newTime);
+        },
+        [currentTime, duration],
+    );
+
+    const cycleSpeed = useCallback(() => {
+        const currentIndex = PLAYBACK_SPEED_OPTIONS.findIndex(
+            (opt) => opt.value === playbackSpeed,
+        );
+        const nextIndex = (currentIndex + 1) % PLAYBACK_SPEED_OPTIONS.length;
+        const nextSpeed = PLAYBACK_SPEED_OPTIONS[nextIndex].value;
+        setPlaybackSpeed(nextSpeed);
+        if (audioRef.current) {
+            audioRef.current.playbackRate = nextSpeed;
+        }
+    }, [playbackSpeed]);
+
+    // Mute toggle stashes the previous volume so unmute restores it.
+    // A pure 0/75 toggle would be surprising for users who set their
+    // own preferred level.
+    const previousVolumeRef = useRef<number>(volume > 0 ? volume : 75);
+    useEffect(() => {
+        if (volume > 0) previousVolumeRef.current = volume;
+    }, [volume]);
+    const toggleMute = useCallback(() => {
+        setVolume((v) => (v > 0 ? 0 : previousVolumeRef.current || 75));
+    }, []);
+
+    return {
+        audioRef,
+        isPlaying,
+        currentTime,
+        duration,
+        volume,
+        setVolume,
+        playbackSpeed,
+        togglePlayPause,
+        seekToRatio,
+        seekRelative,
+        cycleSpeed,
+        toggleMute,
+    };
+}

--- a/src/hooks/use-playback-keyboard.ts
+++ b/src/hooks/use-playback-keyboard.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface Options {
+    onToggle: () => void;
+    onSeekRelative: (deltaSeconds: number) => void;
+    onVolumeDelta: (delta: number) => void;
+}
+
+/**
+ * Global keyboard shortcuts for the recording player.
+ *
+ * Space     -> play/pause
+ * ArrowLeft -> seek -5s
+ * ArrowRight-> seek +5s
+ * ArrowUp   -> volume +5
+ * ArrowDown -> volume -5
+ *
+ * Skipped while the user is typing in an input/textarea/contentEditable
+ * so the shortcuts don't fight form fields. Listener attaches once and
+ * delegates to the supplied callbacks -- the engine hook owns the
+ * actual state mutations so this hook stays purely about key->intent
+ * mapping.
+ */
+export function usePlaybackKeyboard({
+    onToggle,
+    onSeekRelative,
+    onVolumeDelta,
+}: Options) {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as HTMLElement;
+            if (
+                target.tagName === "INPUT" ||
+                target.tagName === "TEXTAREA" ||
+                target.isContentEditable
+            ) {
+                return;
+            }
+
+            switch (e.key) {
+                case " ":
+                    e.preventDefault();
+                    onToggle();
+                    break;
+                case "ArrowLeft":
+                    e.preventDefault();
+                    onSeekRelative(-5);
+                    break;
+                case "ArrowRight":
+                    e.preventDefault();
+                    onSeekRelative(5);
+                    break;
+                case "ArrowUp":
+                    e.preventDefault();
+                    onVolumeDelta(5);
+                    break;
+                case "ArrowDown":
+                    e.preventDefault();
+                    onVolumeDelta(-5);
+                    break;
+            }
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [onToggle, onSeekRelative, onVolumeDelta]);
+}

--- a/src/hooks/use-settings-nav.ts
+++ b/src/hooks/use-settings-nav.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+    SETTINGS_STORAGE_KEY,
+    settingsNav,
+} from "@/components/settings-nav-config";
+import type { SettingsSection } from "@/types/settings";
+
+/**
+ * Owns nav state for the settings dialog: which section is active,
+ * which row is keyboard-highlighted, plus the URL-hash <-> localStorage
+ * sync and the arrow-key / enter / escape handler.
+ *
+ * Lifted out of SettingsDialog so the dialog itself can focus on
+ * layout/composition. The hook is "always on" -- it adds a window
+ * keydown listener whenever `open` is true, mirroring the original
+ * component's behavior exactly.
+ */
+export function useSettingsNav(open: boolean, onClose: () => void) {
+    const [activeSection, setActiveSection] =
+        useState<SettingsSection>("providers");
+    const [keyboardSelectedIndex, setKeyboardSelectedIndex] = useState(0);
+
+    // Initial section resolution: prefer URL hash, fall back to
+    // localStorage. Runs once on mount; subsequent changes are
+    // pushed to the hash + storage in the effect below.
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+
+        const hash = window.location.hash.slice(1);
+        const validSection = settingsNav.find((item) => item.id === hash)?.id;
+
+        if (validSection) {
+            setActiveSection(validSection);
+            setKeyboardSelectedIndex(
+                settingsNav.findIndex((item) => item.id === validSection),
+            );
+            return;
+        }
+        const lastSection = localStorage.getItem(SETTINGS_STORAGE_KEY);
+        if (!lastSection) return;
+        const validLastSection = settingsNav.find(
+            (item) => item.id === lastSection,
+        )?.id;
+        if (validLastSection) {
+            setActiveSection(validLastSection);
+            setKeyboardSelectedIndex(
+                settingsNav.findIndex((item) => item.id === validLastSection),
+            );
+        }
+    }, []);
+
+    // Persist active section to URL hash + localStorage so deep links
+    // round-trip and reopening the dialog lands on the last-visited
+    // section.
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        window.location.hash = activeSection;
+        localStorage.setItem(SETTINGS_STORAGE_KEY, activeSection);
+    }, [activeSection]);
+
+    // Focus the first nav button when the dialog opens. Small delay
+    // gives Radix's focus-trap a chance to settle so our focus call
+    // doesn't get clobbered.
+    useEffect(() => {
+        if (!open) return;
+        const timer = setTimeout(() => {
+            const firstButton = document.querySelector(
+                '[data-settings-nav="first"]',
+            ) as HTMLButtonElement | null;
+            firstButton?.focus();
+        }, 100);
+        return () => clearTimeout(timer);
+    }, [open]);
+
+    // Sync the keyboard cursor with the active section whenever the
+    // user clicks a different row (so arrow-key nav picks up where
+    // the click left off, not where the keyboard cursor used to be).
+    useEffect(() => {
+        const index = settingsNav.findIndex(
+            (item) => item.id === activeSection,
+        );
+        if (index !== -1) {
+            setKeyboardSelectedIndex(index);
+        }
+    }, [activeSection]);
+
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (!open) return;
+
+            if (e.key === "Escape") {
+                onClose();
+                return;
+            }
+
+            // Don't hijack arrow keys when the user is typing in a
+            // form field somewhere inside the settings pane.
+            const target = e.target as HTMLElement;
+            if (
+                target.tagName === "INPUT" ||
+                target.tagName === "TEXTAREA" ||
+                target.isContentEditable
+            ) {
+                return;
+            }
+
+            switch (e.key) {
+                case "ArrowDown": {
+                    e.preventDefault();
+                    setKeyboardSelectedIndex((prev) =>
+                        Math.min(prev + 1, settingsNav.length - 1),
+                    );
+                    break;
+                }
+                case "ArrowUp": {
+                    e.preventDefault();
+                    setKeyboardSelectedIndex((prev) => Math.max(prev - 1, 0));
+                    break;
+                }
+                case "Enter":
+                case " ": {
+                    e.preventDefault();
+                    const selectedItem = settingsNav[keyboardSelectedIndex];
+                    if (selectedItem) {
+                        setActiveSection(selectedItem.id);
+                    }
+                    break;
+                }
+            }
+        },
+        [open, keyboardSelectedIndex, onClose],
+    );
+
+    useEffect(() => {
+        if (!open) return;
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [open, handleKeyDown]);
+
+    return {
+        activeSection,
+        setActiveSection,
+        keyboardSelectedIndex,
+    };
+}

--- a/src/hooks/use-transcribe-queue.ts
+++ b/src/hooks/use-transcribe-queue.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+type ActionKind = "transcribing" | "summarizing";
+
+interface Options {
+    /** Called after a successful transcribe so the parent can refresh data. */
+    onTranscribeComplete: () => void;
+}
+
+/**
+ * Per-recording action state for transcription and summarization.
+ *
+ * A standalone "isTranscribing" boolean races when two transcribes run
+ * concurrently -- each request's `finally` would flip it back to false
+ * while another was still pending. The per-id map below is the source
+ * of truth; callers derive `anyTranscribing` / `isCurrentTranscribing`
+ * etc. from `inFlightActions`.
+ *
+ * `markAction` is exposed so future summarize handlers can use the
+ * same map without duplicating the Map-update plumbing.
+ */
+export function useTranscribeQueue({ onTranscribeComplete }: Options) {
+    const [inFlightActions, setInFlightActions] = useState<
+        Map<string, ActionKind>
+    >(new Map());
+
+    const markAction = useCallback((id: string, kind: ActionKind | null) => {
+        setInFlightActions((prev) => {
+            const next = new Map(prev);
+            if (kind === null) next.delete(id);
+            else next.set(id, kind);
+            return next;
+        });
+    }, []);
+
+    /**
+     * Trigger transcription for a specific recording id. Used by:
+     *   - the per-recording "Transcribe" button in TranscriptionPanel
+     *     (via a wrapper that targets the currently selected recording
+     *     for backwards compatibility), and
+     *   - the command palette's per-row "Transcribe X" quick actions,
+     *     which need to dispatch against an arbitrary recording without
+     *     having to first change the selection.
+     */
+    const transcribeById = useCallback(
+        async (id: string) => {
+            markAction(id, "transcribing");
+            try {
+                const response = await fetch(
+                    `/api/recordings/${id}/transcribe`,
+                    { method: "POST" },
+                );
+                if (response.ok) {
+                    toast.success("Transcription complete");
+                    onTranscribeComplete();
+                } else {
+                    const error = await response.json();
+                    toast.error(error.error || "Transcription failed");
+                }
+            } catch {
+                toast.error("Failed to transcribe recording");
+            } finally {
+                // Per-id clear only -- don't touch any global "is
+                // transcribing" flag (there isn't one), so a concurrent
+                // transcribe on a different recording keeps its own
+                // marker intact.
+                markAction(id, null);
+            }
+        },
+        [markAction, onTranscribeComplete],
+    );
+
+    return {
+        inFlightActions,
+        markAction,
+        transcribeById,
+    };
+}

--- a/src/hooks/use-transcription-summary.ts
+++ b/src/hooks/use-transcription-summary.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+export interface SummaryData {
+    summary: string | null;
+    keyPoints: string[] | null;
+    actionItems: string[] | null;
+    provider?: string;
+    model?: string;
+}
+
+interface UseTranscriptionSummaryOptions {
+    /** Recording id used for `/api/recordings/:id/summary` requests. */
+    recordingId: string | null | undefined;
+    /**
+     * Latest transcription text. When this changes we drop the cached
+     * summary (stale relative to the new text) and re-fetch -- the
+     * server may have already auto-summarized after a re-transcribe.
+     */
+    transcriptionText: string | null | undefined;
+}
+
+/**
+ * Shared summary state for the transcription views. Both the dashboard
+ * (`TranscriptionPanel`) and the recording detail page
+ * (`recordings/TranscriptionSection`) use the same endpoints with the
+ * same expand/preset/optimistic-delete UX -- only the visual chrome
+ * differs.
+ *
+ * Returns flat state + handlers; callers compose their own JSX so the
+ * dashboard's shadcn `Card`/`Button` look and the recording page's
+ * `Panel`/`MetalButton` look stay distinct on purpose.
+ */
+export function useTranscriptionSummary({
+    recordingId,
+    transcriptionText,
+}: UseTranscriptionSummaryOptions) {
+    const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
+    const [isSummarizing, setIsSummarizing] = useState(false);
+    const [summaryExpanded, setSummaryExpanded] = useState(true);
+    const [summaryPreset, setSummaryPreset] = useState("general");
+
+    // Re-fetch trigger separate from the URL/id key so callers can
+    // bump it imperatively (e.g. right after a re-transcribe finishes,
+    // before the new text has propagated through props).
+    const [summaryFetchKey, setSummaryFetchKey] = useState(0);
+
+    // Detect when transcription text actually changes -> invalidate
+    // the cached summary so the next fetch lands fresh. We compare
+    // through a ref because the dashboard variant receives the text
+    // via prop (parent-owned), and reading prop-vs-state isn't enough
+    // to spot a stale summary.
+    const transcriptionTextRef = useRef(transcriptionText);
+    if (transcriptionText !== transcriptionTextRef.current) {
+        transcriptionTextRef.current = transcriptionText;
+        setSummaryFetchKey((k) => k + 1);
+        setSummaryData(null);
+    }
+
+    // Fetch when recording id changes or the re-fetch key bumps.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: summaryFetchKey is an intentional re-fetch trigger
+    useEffect(() => {
+        if (!recordingId) {
+            setSummaryData(null);
+            return;
+        }
+        const controller = new AbortController();
+        fetch(`/api/recordings/${recordingId}/summary`, {
+            signal: controller.signal,
+        })
+            .then((res) => res.json())
+            .then((data) => {
+                if (data.summary) {
+                    setSummaryData(data);
+                } else {
+                    setSummaryData(null);
+                }
+            })
+            .catch(() => {});
+        return () => controller.abort();
+    }, [recordingId, summaryFetchKey]);
+
+    const handleSummarize = useCallback(async () => {
+        if (!recordingId) return;
+        setIsSummarizing(true);
+        try {
+            const response = await fetch(
+                `/api/recordings/${recordingId}/summary`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ preset: summaryPreset }),
+                },
+            );
+            if (response.ok) {
+                const data = (await response.json()) as SummaryData;
+                setSummaryData(data);
+                toast.success("Summary generated");
+            } else {
+                const error = await response.json().catch(() => ({}));
+                toast.error(error.error || "Summary generation failed");
+            }
+        } catch {
+            toast.error("Failed to generate summary");
+        } finally {
+            setIsSummarizing(false);
+        }
+    }, [recordingId, summaryPreset]);
+
+    const handleDeleteSummary = useCallback(async () => {
+        if (!recordingId) return;
+        // Optimistic delete -- the summary disappears immediately and
+        // only comes back if the server rejects the request.
+        const previous = summaryData;
+        setSummaryData(null);
+
+        try {
+            const response = await fetch(
+                `/api/recordings/${recordingId}/summary`,
+                { method: "DELETE" },
+            );
+            if (response.ok) {
+                toast.success("Summary deleted");
+            } else {
+                setSummaryData(previous);
+                toast.error("Failed to delete summary");
+            }
+        } catch {
+            setSummaryData(previous);
+            toast.error("Failed to delete summary");
+        }
+    }, [recordingId, summaryData]);
+
+    /**
+     * Imperative re-fetch trigger. Use after a re-transcribe call
+     * where the server may already have re-summarized -- bumping the
+     * key forces a GET without changing recordingId.
+     */
+    const refetchSummary = useCallback(() => {
+        setSummaryData(null);
+        setSummaryFetchKey((k) => k + 1);
+    }, []);
+
+    return {
+        summaryData,
+        isSummarizing,
+        summaryExpanded,
+        setSummaryExpanded,
+        summaryPreset,
+        setSummaryPreset,
+        handleSummarize,
+        handleDeleteSummary,
+        refetchSummary,
+    };
+}

--- a/src/hooks/use-upload-queue.ts
+++ b/src/hooks/use-upload-queue.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import type { PendingUpload } from "@/components/dashboard/recording-list";
+
+interface Options {
+    /** Called after a successful upload so the parent can refresh data. */
+    onUploadComplete: () => void;
+}
+
+/**
+ * Audio upload queue: hidden <input type="file"> ref, in-flight flag,
+ * optimistic placeholder rows, and the POST. The placeholder rows are
+ * surfaced via `pendingUploads` so the recording list can show a
+ * "Uploading..." row before the server response lands.
+ *
+ * The input is wired by attaching `uploadInputRef` to a hidden input
+ * and calling `triggerUpload()` from a visible button. The hook also
+ * resets `e.target.value` after pickup so picking the same file twice
+ * in a row still fires a `change` event.
+ */
+export function useUploadQueue({ onUploadComplete }: Options) {
+    const [isUploading, setIsUploading] = useState(false);
+    const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
+    const uploadInputRef = useRef<HTMLInputElement>(null);
+
+    const handleUpload = useCallback(
+        async (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            // Reset so picking the same file twice still fires change.
+            e.target.value = "";
+
+            // Optimistic placeholder in the list. Uses a `pending:`
+            // prefixed id namespace so the row can't collide with a
+            // server-issued recording id.
+            const placeholderId = `pending:${Date.now()}:${Math.random()
+                .toString(36)
+                .slice(2)}`;
+            setPendingUploads((prev) => [
+                ...prev,
+                {
+                    id: placeholderId,
+                    filename: file.name,
+                    filesize: file.size,
+                },
+            ]);
+
+            setIsUploading(true);
+            try {
+                const formData = new FormData();
+                formData.append("file", file);
+                const response = await fetch("/api/recordings/upload", {
+                    method: "POST",
+                    body: formData,
+                });
+                if (response.ok) {
+                    const data = await response.json();
+                    toast.success(`"${data.filename}" uploaded`);
+                    onUploadComplete();
+                } else {
+                    const error = await response.json();
+                    toast.error(error.error || "Upload failed");
+                }
+            } catch {
+                toast.error("Failed to upload recording");
+            } finally {
+                setIsUploading(false);
+                setPendingUploads((prev) =>
+                    prev.filter((p) => p.id !== placeholderId),
+                );
+            }
+        },
+        [onUploadComplete],
+    );
+
+    const triggerUpload = useCallback(() => {
+        uploadInputRef.current?.click();
+    }, []);
+
+    return {
+        isUploading,
+        pendingUploads,
+        uploadInputRef,
+        handleUpload,
+        triggerUpload,
+    };
+}

--- a/src/lib/admin/ip-allowlist.ts
+++ b/src/lib/admin/ip-allowlist.ts
@@ -135,9 +135,10 @@ export function ipMatchesAllowlist(
         ip = ip.slice(7);
     }
 
-    const parsedEntries = allowlist
-        .map(parseCidr)
-        .filter((p): p is ParsedCidr => p !== null);
+    const parsedEntries = allowlist.flatMap((entry) => {
+        const parsed = parseCidr(entry);
+        return parsed ? [parsed] : [];
+    });
     if (parsedEntries.length === 0) {
         // Misconfigured allowlist -- fail closed.
         return false;

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -55,238 +55,304 @@ export async function fleetOverview() {
     const d14 = sql`${new Date(now - 14 * DAY_MS).toISOString()}::timestamp`;
     const d30 = sql`${new Date(now - 30 * DAY_MS).toISOString()}::timestamp`;
 
-    const [userTotal] = await db.select({ n: count() }).from(users);
-
-    // New signups: current 7d window vs prior 7d window (days 7-14 ago).
-    const [signups7] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(gte(users.createdAt, d7));
-    const [signupsPrior7] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(and(gte(users.createdAt, d14), lt(users.createdAt, d7)));
-    const [signups30] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(gte(users.createdAt, d30));
-
-    // New Plaud connections (the real activation event after signup).
-    const [plaudConn7] = await db
-        .select({ n: count() })
-        .from(plaudConnections)
-        .where(gte(plaudConnections.createdAt, d7));
-    const [plaudConnPrior7] = await db
-        .select({ n: count() })
-        .from(plaudConnections)
-        .where(
-            and(
-                gte(plaudConnections.createdAt, d14),
-                lt(plaudConnections.createdAt, d7),
-            ),
-        );
-    // Some legacy deployments allow more than one plaud_connections row per
-    // user; counting rows would overcount the active-user metric. Use
-    // countDistinct(userId) so the value tracks distinct people, not
-    // connection rows.
-    const [activeIn7] = await db
-        .select({ n: countDistinct(plaudConnections.userId) })
-        .from(plaudConnections)
-        .where(gte(plaudConnections.lastSync, d7));
-    const [activeIn30] = await db
-        .select({ n: countDistinct(plaudConnections.userId) })
-        .from(plaudConnections)
-        .where(gte(plaudConnections.lastSync, d30));
-
-    const [suspended] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(isNotNull(users.suspendedAt));
-
-    // Suspensions performed in the current 7d window vs prior 7d window.
-    // Abuse-spike signal -- the cumulative "Suspended" count never
-    // meaningfully decreases, so the trend lives in the delta.
-    const [suspensions7] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(gte(users.suspendedAt, d7));
-    const [suspensionsPrior7] = await db
-        .select({ n: count() })
-        .from(users)
-        .where(and(gte(users.suspendedAt, d14), lt(users.suspendedAt, d7)));
-
-    const [recordingTotal] = await db
-        .select({ n: count() })
-        .from(recordings)
-        .where(isNull(recordings.deletedAt));
-
-    const [storageBytes] = await db
-        .select({ b: sum(recordings.filesize) })
-        .from(recordings)
-        .where(isNull(recordings.deletedAt));
-
-    // Storage backend split. Hosted cares about S3 spend; self-host cares
-    // about local disk pressure. One row per distinct storageType.
-    const storageByTypeRows = await db
-        .select({
-            type: recordings.storageType,
-            b: sum(recordings.filesize),
-        })
-        .from(recordings)
-        .where(isNull(recordings.deletedAt))
-        .groupBy(recordings.storageType);
-
-    const transcriptionByType = await db
-        .select({
-            type: transcriptions.transcriptionType,
-            n: count(),
-        })
-        .from(transcriptions)
-        .groupBy(transcriptions.transcriptionType);
-
-    const [enhancementTotal] = await db
-        .select({ n: count() })
-        .from(aiEnhancements);
-
-    const [recordingsLast7] = await db
-        .select({ n: count() })
-        .from(recordings)
-        .where(
-            and(isNull(recordings.deletedAt), gte(recordings.createdAt, d7)),
-        );
-    const [recordingsPrior7] = await db
-        .select({ n: count() })
-        .from(recordings)
-        .where(
-            and(
-                isNull(recordings.deletedAt),
-                gte(recordings.createdAt, d14),
-                lt(recordings.createdAt, d7),
-            ),
-        );
-    const [bytesLast7] = await db
-        .select({ b: sum(recordings.filesize) })
-        .from(recordings)
-        .where(
-            and(isNull(recordings.deletedAt), gte(recordings.createdAt, d7)),
-        );
-    const [bytesPrior7] = await db
-        .select({ b: sum(recordings.filesize) })
-        .from(recordings)
-        .where(
-            and(
-                isNull(recordings.deletedAt),
-                gte(recordings.createdAt, d14),
-                lt(recordings.createdAt, d7),
-            ),
-        );
-
-    const [transcriptionsLast30] = await db
-        .select({ n: count() })
-        .from(transcriptions)
-        .where(
-            and(
-                eq(transcriptions.transcriptionType, "server"),
-                gte(transcriptions.createdAt, d30),
-            ),
-        );
-
-    // Server transcriptions 7d + prior 7d. The 30d figure is too coarse to
-    // spot a spike; 7d WoW is what we actually look at.
-    const [serverTx7] = await db
-        .select({ n: count() })
-        .from(transcriptions)
-        .where(
-            and(
-                eq(transcriptions.transcriptionType, "server"),
-                gte(transcriptions.createdAt, d7),
-            ),
-        );
-    const [serverTxPrior7] = await db
-        .select({ n: count() })
-        .from(transcriptions)
-        .where(
-            and(
-                eq(transcriptions.transcriptionType, "server"),
-                gte(transcriptions.createdAt, d14),
-                lt(transcriptions.createdAt, d7),
-            ),
-        );
-
-    // Server audio MINUTES transcribed 7d + prior 7d. Whisper bills by
-    // minute, not by row count -- this is the real cost driver. Joined to
-    // recordings to get duration; we do not select any recording PII.
-    const [serverAudioMs7] = await db
-        .select({ ms: sum(recordings.duration) })
-        .from(transcriptions)
-        .innerJoin(recordings, eq(recordings.id, transcriptions.recordingId))
-        .where(
-            and(
-                eq(transcriptions.transcriptionType, "server"),
-                gte(transcriptions.createdAt, d7),
-            ),
-        );
-    const [serverAudioMsPrior7] = await db
-        .select({ ms: sum(recordings.duration) })
-        .from(transcriptions)
-        .innerJoin(recordings, eq(recordings.id, transcriptions.recordingId))
-        .where(
-            and(
-                eq(transcriptions.transcriptionType, "server"),
-                gte(transcriptions.createdAt, d14),
-                lt(transcriptions.createdAt, d7),
-            ),
-        );
-
-    // AI enhancements 7d + prior 7d.
-    const [enhancements7] = await db
-        .select({ n: count() })
-        .from(aiEnhancements)
-        .where(gte(aiEnhancements.createdAt, d7));
-    const [enhancementsPrior7] = await db
-        .select({ n: count() })
-        .from(aiEnhancements)
-        .where(
-            and(
-                gte(aiEnhancements.createdAt, d14),
-                lt(aiEnhancements.createdAt, d7),
-            ),
-        );
-
-    // Transcription coverage. Anti-join via leftJoin + isNull -- the
-    // canonical Drizzle pattern for "parent rows with no matching child."
-    // A recording may have multiple transcription rows, but rows that have
-    // *no* match yield exactly one (null) join row, so count(recordings.id)
-    // is safe here. Excludes tombstoned recordings to match the rest of
-    // this file's conventions.
-    const [missingTxAll] = await db
-        .select({ n: count(recordings.id) })
-        .from(recordings)
-        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
-        .where(and(isNull(recordings.deletedAt), isNull(transcriptions.id)));
-    const [missingTx7] = await db
-        .select({ n: count(recordings.id) })
-        .from(recordings)
-        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
-        .where(
-            and(
-                isNull(recordings.deletedAt),
-                isNull(transcriptions.id),
-                gte(recordings.createdAt, d7),
-            ),
-        );
-    const [missingTxPrior7] = await db
-        .select({ n: count(recordings.id) })
-        .from(recordings)
-        .leftJoin(transcriptions, eq(transcriptions.recordingId, recordings.id))
-        .where(
-            and(
-                isNull(recordings.deletedAt),
-                isNull(transcriptions.id),
-                gte(recordings.createdAt, d14),
-                lt(recordings.createdAt, d7),
-            ),
-        );
+    // All 30 queries below are independent counts/sums. Race them in one
+    // Promise.all so the dashboard renders at the speed of the slowest
+    // aggregate (typically the storage sum), not the sum of every query.
+    //
+    // Each `.then(rows => rows[0])` extracts the single-row result so the
+    // destructure below stays readable. Group-by queries return arrays as
+    // usual.
+    //
+    // Notes:
+    // - countDistinct(userId) on plaud_connections because legacy deployments
+    //   may have multiple connection rows per user (would otherwise overcount
+    //   the active-user metric).
+    // - The missingTx* queries use leftJoin + isNull(transcriptions.id) as
+    //   the canonical Drizzle anti-join pattern ("parent rows with no
+    //   matching child"). A recording may have multiple transcription rows
+    //   but rows with NO match yield exactly one (null) join row, so
+    //   count(recordings.id) is safe.
+    // - Server audio MINUTES (joined transcriptions -> recordings on
+    //   recording_id) is the real Whisper cost driver; row count alone is
+    //   too coarse.
+    const [
+        userTotal,
+        signups7,
+        signupsPrior7,
+        signups30,
+        plaudConn7,
+        plaudConnPrior7,
+        activeIn7,
+        activeIn30,
+        suspended,
+        suspensions7,
+        suspensionsPrior7,
+        recordingTotal,
+        storageBytes,
+        storageByTypeRows,
+        transcriptionByType,
+        enhancementTotal,
+        recordingsLast7,
+        recordingsPrior7,
+        bytesLast7,
+        bytesPrior7,
+        transcriptionsLast30,
+        serverTx7,
+        serverTxPrior7,
+        serverAudioMs7,
+        serverAudioMsPrior7,
+        enhancements7,
+        enhancementsPrior7,
+        missingTxAll,
+        missingTx7,
+        missingTxPrior7,
+    ] = await Promise.all([
+        db
+            .select({ n: count() })
+            .from(users)
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(gte(users.createdAt, d7))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(and(gte(users.createdAt, d14), lt(users.createdAt, d7)))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(gte(users.createdAt, d30))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(plaudConnections)
+            .where(gte(plaudConnections.createdAt, d7))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(plaudConnections)
+            .where(
+                and(
+                    gte(plaudConnections.createdAt, d14),
+                    lt(plaudConnections.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: countDistinct(plaudConnections.userId) })
+            .from(plaudConnections)
+            .where(gte(plaudConnections.lastSync, d7))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: countDistinct(plaudConnections.userId) })
+            .from(plaudConnections)
+            .where(gte(plaudConnections.lastSync, d30))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(isNotNull(users.suspendedAt))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(gte(users.suspendedAt, d7))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(users)
+            .where(and(gte(users.suspendedAt, d14), lt(users.suspendedAt, d7)))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(recordings)
+            .where(isNull(recordings.deletedAt))
+            .then((rows) => rows[0]),
+        db
+            .select({ b: sum(recordings.filesize) })
+            .from(recordings)
+            .where(isNull(recordings.deletedAt))
+            .then((rows) => rows[0]),
+        db
+            .select({
+                type: recordings.storageType,
+                b: sum(recordings.filesize),
+            })
+            .from(recordings)
+            .where(isNull(recordings.deletedAt))
+            .groupBy(recordings.storageType),
+        db
+            .select({
+                type: transcriptions.transcriptionType,
+                n: count(),
+            })
+            .from(transcriptions)
+            .groupBy(transcriptions.transcriptionType),
+        db
+            .select({ n: count() })
+            .from(aiEnhancements)
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(recordings)
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    gte(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(recordings)
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    gte(recordings.createdAt, d14),
+                    lt(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ b: sum(recordings.filesize) })
+            .from(recordings)
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    gte(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ b: sum(recordings.filesize) })
+            .from(recordings)
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    gte(recordings.createdAt, d14),
+                    lt(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.transcriptionType, "server"),
+                    gte(transcriptions.createdAt, d30),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.transcriptionType, "server"),
+                    gte(transcriptions.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.transcriptionType, "server"),
+                    gte(transcriptions.createdAt, d14),
+                    lt(transcriptions.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ ms: sum(recordings.duration) })
+            .from(transcriptions)
+            .innerJoin(
+                recordings,
+                eq(recordings.id, transcriptions.recordingId),
+            )
+            .where(
+                and(
+                    eq(transcriptions.transcriptionType, "server"),
+                    gte(transcriptions.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ ms: sum(recordings.duration) })
+            .from(transcriptions)
+            .innerJoin(
+                recordings,
+                eq(recordings.id, transcriptions.recordingId),
+            )
+            .where(
+                and(
+                    eq(transcriptions.transcriptionType, "server"),
+                    gte(transcriptions.createdAt, d14),
+                    lt(transcriptions.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(aiEnhancements)
+            .where(gte(aiEnhancements.createdAt, d7))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(aiEnhancements)
+            .where(
+                and(
+                    gte(aiEnhancements.createdAt, d14),
+                    lt(aiEnhancements.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count(recordings.id) })
+            .from(recordings)
+            .leftJoin(
+                transcriptions,
+                eq(transcriptions.recordingId, recordings.id),
+            )
+            .where(and(isNull(recordings.deletedAt), isNull(transcriptions.id)))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count(recordings.id) })
+            .from(recordings)
+            .leftJoin(
+                transcriptions,
+                eq(transcriptions.recordingId, recordings.id),
+            )
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    isNull(transcriptions.id),
+                    gte(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count(recordings.id) })
+            .from(recordings)
+            .leftJoin(
+                transcriptions,
+                eq(transcriptions.recordingId, recordings.id),
+            )
+            .where(
+                and(
+                    isNull(recordings.deletedAt),
+                    isNull(transcriptions.id),
+                    gte(recordings.createdAt, d14),
+                    lt(recordings.createdAt, d7),
+                ),
+            )
+            .then((rows) => rows[0]),
+    ]);
 
     return {
         userTotal: userTotal?.n ?? 0,
@@ -512,6 +578,8 @@ export interface UserDetail {
 export async function getUserDetail(
     userId: string,
 ): Promise<UserDetail | null> {
+    // Gate everything on the user existing -- saves six queries when an
+    // admin opens a stale detail link and the user was deleted.
     const [u] = await db
         .select({
             id: users.id,
@@ -526,62 +594,68 @@ export async function getUserDetail(
         .limit(1);
     if (!u) return null;
 
-    // Legacy deployments may have multiple plaud_connections per user.
-    // Pick the most-recently-updated one deterministically so the detail
-    // view is reproducible across reloads.
-    const [pc] = await db
-        .select({
-            id: plaudConnections.id,
-            apiBase: plaudConnections.apiBase,
-            plaudEmail: plaudConnections.plaudEmail,
-            lastSync: plaudConnections.lastSync,
-        })
-        .from(plaudConnections)
-        .where(eq(plaudConnections.userId, userId))
-        .orderBy(desc(plaudConnections.updatedAt))
-        .limit(1);
-
-    const [recAgg] = await db
-        .select({ n: count(), b: sum(recordings.filesize) })
-        .from(recordings)
-        .where(
-            and(eq(recordings.userId, userId), isNull(recordings.deletedAt)),
-        );
-
-    const txByType = await db
-        .select({ type: transcriptions.transcriptionType, n: count() })
-        .from(transcriptions)
-        .where(eq(transcriptions.userId, userId))
-        .groupBy(transcriptions.transcriptionType);
+    // Six independent reads, one round-trip per row. Run them in parallel
+    // so the detail page renders at the speed of the slowest query, not
+    // the sum of all of them. Legacy deployments may have multiple
+    // plaud_connections per user -- pick the most-recently-updated one
+    // deterministically so the detail view is reproducible across reloads.
+    const [pc, recAgg, txByType, enhAgg, credAgg, recent] = await Promise.all([
+        db
+            .select({
+                id: plaudConnections.id,
+                apiBase: plaudConnections.apiBase,
+                plaudEmail: plaudConnections.plaudEmail,
+                lastSync: plaudConnections.lastSync,
+            })
+            .from(plaudConnections)
+            .where(eq(plaudConnections.userId, userId))
+            .orderBy(desc(plaudConnections.updatedAt))
+            .limit(1)
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count(), b: sum(recordings.filesize) })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.userId, userId),
+                    isNull(recordings.deletedAt),
+                ),
+            )
+            .then((rows) => rows[0]),
+        db
+            .select({ type: transcriptions.transcriptionType, n: count() })
+            .from(transcriptions)
+            .where(eq(transcriptions.userId, userId))
+            .groupBy(transcriptions.transcriptionType),
+        db
+            .select({ n: count() })
+            .from(aiEnhancements)
+            .where(eq(aiEnhancements.userId, userId))
+            .then((rows) => rows[0]),
+        db
+            .select({ n: count() })
+            .from(apiCredentials)
+            .where(eq(apiCredentials.userId, userId))
+            .then((rows) => rows[0]),
+        db
+            .select({
+                id: recordings.id,
+                createdAt: recordings.createdAt,
+                startTime: recordings.startTime,
+                durationMs: recordings.duration,
+                filesize: recordings.filesize,
+                deviceSn: recordings.deviceSn,
+                storageType: recordings.storageType,
+                deletedAt: recordings.deletedAt,
+            })
+            .from(recordings)
+            .where(eq(recordings.userId, userId))
+            .orderBy(desc(recordings.startTime))
+            .limit(50),
+    ]);
     const txTotalServer = txByType.find((r) => r.type === "server")?.n ?? 0;
     const txTotalBrowser = txByType.find((r) => r.type === "browser")?.n ?? 0;
     const txTotal = txByType.reduce((acc, r) => acc + r.n, 0);
-
-    const [enhAgg] = await db
-        .select({ n: count() })
-        .from(aiEnhancements)
-        .where(eq(aiEnhancements.userId, userId));
-
-    const [credAgg] = await db
-        .select({ n: count() })
-        .from(apiCredentials)
-        .where(eq(apiCredentials.userId, userId));
-
-    const recent = await db
-        .select({
-            id: recordings.id,
-            createdAt: recordings.createdAt,
-            startTime: recordings.startTime,
-            durationMs: recordings.duration,
-            filesize: recordings.filesize,
-            deviceSn: recordings.deviceSn,
-            storageType: recordings.storageType,
-            deletedAt: recordings.deletedAt,
-        })
-        .from(recordings)
-        .where(eq(recordings.userId, userId))
-        .orderBy(desc(recordings.startTime))
-        .limit(50);
 
     return {
         id: u.id,
@@ -737,28 +811,30 @@ export async function pricingSnapshot() {
     // Left-join from `users` so users with zero live recordings appear as 0
     // in the CDF instead of being dropped. Aggregating off `recordings`
     // alone would bias every percentile high.
-    const storage = await db.execute<{ bytes: number }>(sql`
-        select coalesce(sum(r.filesize) filter (where r.deleted_at is null), 0)::bigint as bytes
-        from users u
-        left join recordings r on r.user_id = u.id
-        group by u.id
-        order by bytes asc
-    `);
-    const recordingCounts = await db.execute<{ n: number }>(sql`
-        select (count(r.id) filter (where r.deleted_at is null))::int as n
-        from users u
-        left join recordings r on r.user_id = u.id
-        group by u.id
-        order by n asc
-    `);
-    const serverTx = await db.execute<{ n: number }>(sql`
-        select count(*)::int as n
-        from transcriptions
-        where transcription_type = 'server'
-          and created_at >= ${since30}
-        group by user_id
-        order by n asc
-    `);
+    const [storage, recordingCounts, serverTx] = await Promise.all([
+        db.execute<{ bytes: number }>(sql`
+            select coalesce(sum(r.filesize) filter (where r.deleted_at is null), 0)::bigint as bytes
+            from users u
+            left join recordings r on r.user_id = u.id
+            group by u.id
+            order by bytes asc
+        `),
+        db.execute<{ n: number }>(sql`
+            select (count(r.id) filter (where r.deleted_at is null))::int as n
+            from users u
+            left join recordings r on r.user_id = u.id
+            group by u.id
+            order by n asc
+        `),
+        db.execute<{ n: number }>(sql`
+            select count(*)::int as n
+            from transcriptions
+            where transcription_type = 'server'
+              and created_at >= ${since30}
+            group by user_id
+            order by n asc
+        `),
+    ]);
     return {
         storageBytesPerUser: storage.map((r) => Number(r.bytes)),
         recordingsPerUser: recordingCounts.map((r) => Number(r.n)),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -128,10 +128,10 @@ export const envSchema = z.object({
         .string()
         .optional()
         .transform((val) =>
-            (val ?? "")
-                .split(",")
-                .map((s) => s.trim().toLowerCase())
-                .filter(Boolean),
+            (val ?? "").split(",").flatMap((s) => {
+                const trimmed = s.trim().toLowerCase();
+                return trimmed ? [trimmed] : [];
+            }),
         ),
 
     // ADMIN_IP_ALLOWLIST: optional comma-separated CIDR list. When set, admin
@@ -141,10 +141,10 @@ export const envSchema = z.object({
         .string()
         .optional()
         .transform((val) =>
-            (val ?? "")
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean),
+            (val ?? "").split(",").flatMap((s) => {
+                const trimmed = s.trim();
+                return trimmed ? [trimmed] : [];
+            }),
         ),
 
     // ADMIN_REAUTH_TTL_MINUTES: how long an admin's elevated cookie is valid

--- a/src/lib/notifications/email-templates/new-recording-email.tsx
+++ b/src/lib/notifications/email-templates/new-recording-email.tsx
@@ -20,9 +20,11 @@ interface NewRecordingEmailProps {
     settingsUrl: string;
 }
 
+const EMPTY_NAMES: string[] = [];
+
 export function NewRecordingEmail({
     count,
-    recordingNames = [],
+    recordingNames = EMPTY_NAMES,
     dashboardUrl,
     settingsUrl,
 }: NewRecordingEmailProps) {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -30,11 +30,12 @@ function bucketKey(rawKey: string): string {
 }
 
 function firstForwardedForIp(value: string | null): string | null {
-    const parts = value
-        ?.split(",")
-        .map((part) => part.trim())
-        .filter(Boolean);
-    return parts?.[0] ?? null;
+    if (!value) return null;
+    for (const part of value.split(",")) {
+        const trimmed = part.trim();
+        if (trimmed) return trimmed;
+    }
+    return null;
 }
 
 export function getClientIp(request: Request): string {


### PR DESCRIPTION
## Description

Cleanup pass against the react-doctor warning list: mechanical lint fixes, copy/visual nits, React 19 API migration, server-async parallelization, two real hydration bugs, and structural splits of the seven giant client components. 21 commits, each tightly scoped so bisecting is trivial. No behavior changes; the deploy surface (DB schema, env vars, route paths) is untouched.

## Type of Change

- [x] Code refactoring
- [x] Performance improvement
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

**Mechanical / safe lint fixes**
- `w-N h-N` → `size-N`, `px-N py-N` → `p-N` across 25 files (`c0eab31`, plus `8407f65` for the CVA/sizeMap stragglers).
- Module-level `EMPTY_PROVIDERS`/`EMPTY_NAMES` constants and a hoisted `Intl.NumberFormat` to stop busting memoization (`8c4b8ff`).
- `.map().filter(Boolean)` → `.flatMap`, `array.includes` in a loop → `Set` lookup, `cache: "no-store"` on the OpenRouter models fetch (`398be9f`).
- `Metadata` exports for `/` and `/suspended` (`26e8a3c`).
- `oxlint-disable-next-line jsx-a11y/no-autofocus` on the three intentional modal-entry inputs (OTP, Plaud email, admin re-auth) with rationale comments (`b610bde`).

**Copy / visual**
- `font-bold` → `font-semibold` on every display `<h1>`/`<h2>`; em-dashes replaced with commas/colons/periods in user-facing JSX (legal pages and admin n/a glyphs preserved) (`09fe713`).
- En-dash for Reddit quote attribution after iteration (`0d36737`).

**React 19 / hook patterns**
- `forwardRef` removed across `Progress`, `Breadcrumb`, `Panel`, `MetalButton`, `OnboardingDialog` primitives, `RecordingList`. `useContext` → `use()` in `confirm-dialog` and `form` (`483488c`).
- `const { push, refresh } = useRouter()` destructure across 12 files (`df1e706`).
- `providers-section`: drop the mirrored-prop effect, switch to functional setState (`eff2ec6`).
- `<LocalTime>` component fixes the `new Date(...).toLocaleString()` SSR/CSR hydration mismatch in `recording-workstation`; `theme-toggle` kept (next-themes doesn't expose a store) with the intent documented inline (`5a805fc`).

**Server async**
- `src/lib/admin/queries.ts`: `fleetOverview` (30 independent reads), `getUserDetail` (6 reads gated by a user-existence check), `pricingSnapshot` (3 independent CDFs) all wrapped in `Promise.all` (`46843de`).

**Component splits (the big chunk)**
- `WebhooksSection` (481 → 216) → `webhook-types`, `webhook-editor-dialog`, `webhook-deliveries-dialog` (`f0456b1`).
- `CommandPalette` (580 → 189) → `command-palette-parts` with `RecordingsGroup`, `ActionsGroup`, `ThemeGroup`, `PaletteFooter`, plus the `Row`/`Kbd`/`transcriptSnippet` primitives (`1b4fa56`).
- `SettingsDialog` (339 → 104) → `settings-nav-config`, `useSettingsNav` hook, `SettingsNavSidebar`, `SettingsNavMobile` (`2ca79fa`).
- `useTranscriptionSummary` hook dedups the summary fetch/handlers between `dashboard/transcription-panel` and `recordings/transcription-section`. Render stays distinct because the dashboard's shadcn chrome and the recording page's `Panel`/`MetalButton` chrome are intentionally different (`ca213f4`).
- `RecordingPlayer` (435 → 124) → `use-playback-engine`, `use-playback-keyboard`, `recording-player-header`, `recording-player-controls`. Slider seek goes through the same `seekToRatio` API as waveform-click now (`fd7171b`).
- `OnboardingDialog` (429 → 200) → four step components in `onboarding-steps`. Hand-rolled `getStepIndex`/`getPrevStep`/`getNextStep` collapsed into one `STEP_ORDER` array (`535ce84`).
- `ProvidersSection` (710 → 286) → `prompt-manager` owns the prompts tab end-to-end; local `<ProvidersList>` for the provider list rendering (`af7dca7`).
- `Workstation` (631 → 430) → `use-upload-queue`, `use-transcribe-queue`, `workstation-header`, `workstation-detail-pane`, `workstation-empty-state`. Delete handler stays in the parent on purpose because it needs `currentRecording` + `visibleRecordings` to pick the next selection (`d36314b`).

## Screenshots (if applicable)

n/a — pure refactor, no visual change beyond the heading-weight and em-dash copy tweak already smoke-tested.

## Testing

### Test Environment
- OS: macOS
- Node version: v22
- Browser: not exercised in this PR (no visual changes beyond Phase 2 copy edits, already eyeballed)

### Test Steps
1. `pnpm install`
2. `pnpm type-check` — clean
3. `pnpm format-and-lint:fix` — clean (only the 2 pre-existing biome infos remain)
4. `pnpm test` — 321 passed, 3 skipped (Plaud integration, opt-in via `PLAUD_BEARER_TOKEN`)

Reviewer smoke test (recommended before merge — covers the structural splits the test suite can't):
1. `/dashboard` — scroll the list, select a recording, play it, transcribe it, delete it, open the command palette, sync, upload an audio file.
2. `/recordings/[id]` — same flow, single-page view.
3. Settings dialog — open, keyboard-navigate sections, save a provider, edit/create a custom prompt, view a preset prompt.
4. Onboarding — re-run onboarding, step through all 4 screens + skip + previous.
5. Webhooks settings — create webhook, view deliveries, redeliver one, edit, delete.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, internal refactor
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, behavior is unchanged; existing 321 tests cover the API surface
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None. Internal-only refactor. No DB schema, env var, route path, or `docker-compose.yml` changes.

## Additional Notes

- `theme-toggle.tsx` keeps its `useEffect(setMounted, [])` pattern: next-themes doesn't expose a store, so `useSyncExternalStore` isn't viable. The placeholder branch already prevents the icon flash — documented inline.
- Some react-doctor warnings are false positives and were intentionally left alone with rationale: `rerender-state-only-in-handlers` flags (state IS read in render), `no-derived-useState` for `initialX` uncontrolled-with-initial-prop patterns, `rendering-usetransition-loading` for real `fetch()` calls, `async-await-in-loop` in `sync-recordings`/migration code (sequential by design), and transactional awaits in DELETE handlers (single PG connection serializes anyway).

## For Reviewers

- The `Workstation` and `ProvidersSection` splits touch the most surface area. If you only smoke-test one path, make it `/dashboard` (sync/upload/transcribe/delete) and the Providers settings tab (add/edit/delete a provider + custom prompt CRUD).
- `LocalTime` is a new shared component — worth confirming the SSR ISO → CSR locale swap matches your expectation on the recording detail page.
- `admin/queries.ts` Promise.all refactor: every flagged query was independent (counts/sums against different tables or different time windows). Worth a scan but I'm confident on correctness.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve react-doctor warnings with a broad cleanup: migrate to React 19 APIs, split oversized components, hoist constants, tighten copy/heading weight, and parallelize server reads. Fixed two hydration issues; behavior is unchanged and there are no DB, env, or route changes.

- **Refactors**
  - React 19: drop `forwardRef` in favor of `ref` props and replace `useContext` with `use()` in primitives.
  - Split giant components into focused modules: Workstation (header/detail/empty-state + upload/transcribe queues), Providers (extract `PromptManager`), Webhooks (editor + deliveries dialogs), Command Palette (groups + footer), Recording Player (header + controls + engine + keyboard), Settings Dialog (nav hook + sidebar + mobile picker), Onboarding (step components).
  - Shared hooks: `use-playback-engine`, `use-playback-keyboard`, `use-upload-queue`, `use-transcribe-queue`, `use-transcription-summary`, `use-settings-nav`.
  - Lint/copy/UI nits: `font-bold` → `font-semibold`, class shorthands (`size-*`, `p-*`), em-dashes replaced with commas/colons/periods; minor spacing tweaks.
  - Router usage: destructure `useRouter()` methods at call sites (`push`, `refresh`, `replace`).
  - Server async: parallelize independent admin queries with `Promise.all`; tighten loops (`flatMap`, Sets); add `cache: "no-store"` to OpenRouter model catalog fetch; hoist `Intl.NumberFormat`.
  - SEO: add `Metadata` exports for `/` and `/suspended`.

- **Bug Fixes**
  - Hydration: replace server `toLocaleString()` with a `LocalTime` component to avoid SSR/CSR mismatches; document intentional `next-themes` mount pattern to prevent icon flicker.
  - Robustness: per-recording action map prevents races during concurrent transcribes; unified seek path in the player avoids slider/waveform drift.

<sup>Written for commit d36314b0814c04d2e5c5faa6e482e900217ce2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

