### PR TITLE
refactor(auth): adopt base62 + CRC32 checksum for new API keys

### DIFF
--- a/src/lib/auth-request.ts
+++ b/src/lib/auth-request.ts
@@ -1,6 +1,5 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomInt } from "node:crypto";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
-import { nanoid } from "nanoid";
 import { db } from "@/db";
 import { apiKeys, users } from "@/db/schema";
 import { auth } from "@/lib/auth";
@@ -16,11 +15,110 @@ export type AuthenticatedRequest = {
 export type ApiKeyRow = typeof apiKeys.$inferSelect;
 
 const API_KEY_PREFIX = "op_";
-const API_KEY_RANDOM_LENGTH = 24;
 const DISPLAY_PREFIX_LENGTH = 12;
+const DEFAULT_PAYLOAD_LENGTH = 30;
+const MIN_PAYLOAD_LENGTH = 20;
+const MAX_PAYLOAD_LENGTH = 64;
+const CHECKSUM_LENGTH = 4;
 
-export function createApiKey(): string {
-    return `${API_KEY_PREFIX}${nanoid(API_KEY_RANDOM_LENGTH)}`;
+const B62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function randomBase62(n: number): string {
+    let out = "";
+    for (let i = 0; i < n; i++) {
+        out += B62[randomInt(0, 62)];
+    }
+    return out;
+}
+
+function crc32(str: string): number {
+    let c = ~0 >>> 0;
+    for (let i = 0; i < str.length; i++) {
+        c ^= str.charCodeAt(i);
+        for (let k = 0; k < 8; k++) {
+            const mask = -(c & 1);
+            c = (c >>> 1) ^ (0xedb88320 & mask);
+        }
+    }
+    return ~c >>> 0;
+}
+
+function toBase62Checksum(num: number): string {
+    const n = num >>> 0;
+    if (n === 0) return "0".padStart(CHECKSUM_LENGTH, "0");
+    let out = "";
+    let temp = n;
+    while (temp > 0) {
+        const idx = temp % 62;
+        out = B62[idx] + out;
+        temp = Math.floor(temp / 62);
+    }
+    if (out.length < CHECKSUM_LENGTH) {
+        out = out.padStart(CHECKSUM_LENGTH, "0");
+    }
+    return out.slice(0, CHECKSUM_LENGTH);
+}
+
+/**
+ * Generate a new API key.
+ *
+ * Format: `op_{payload}{checksum}` where payload is random base62 and
+ * checksum is the CRC32 of `op_{payload}` encoded as 4 base62 chars
+ * (zero-padded). New keys are 37 chars by default (3 + 30 + 4).
+ *
+ * Keys issued under the previous `op_` + nanoid(24) scheme remain valid;
+ * authentication uses the stored HMAC hash, not the format.
+ */
+export function createApiKey(
+    payloadLen: number = DEFAULT_PAYLOAD_LENGTH,
+): string {
+    const payloadLength = Math.max(
+        MIN_PAYLOAD_LENGTH,
+        Math.min(MAX_PAYLOAD_LENGTH, payloadLen),
+    );
+    const payload = randomBase62(payloadLength);
+    const base = `${API_KEY_PREFIX}${payload}`;
+    const checksum = toBase62Checksum(crc32(base));
+    return `${base}${checksum}`;
+}
+
+/**
+ * Validate the format of a freshly issued API key by re-deriving its
+ * CRC32 checksum. Strict: legacy `op_` + nanoid keys (which may contain
+ * `-`/`_` and carry no checksum) will fail this check. NOT used in the
+ * auth path — `authenticateRequest` looks up by HMAC hash, which keeps
+ * legacy keys working. This helper is for tooling, tests, and any
+ * future UI that wants to give immediate feedback on a pasted key.
+ */
+export function validateApiKeyFormat(key: string): boolean {
+    if (!key.startsWith(API_KEY_PREFIX)) return false;
+
+    const body = key.slice(API_KEY_PREFIX.length);
+    if (body.length < MIN_PAYLOAD_LENGTH + CHECKSUM_LENGTH) return false;
+    if (body.length > MAX_PAYLOAD_LENGTH + CHECKSUM_LENGTH) return false;
+    if (!/^[0-9A-Za-z]+$/.test(body)) return false;
+
+    const payload = body.slice(0, -CHECKSUM_LENGTH);
+    const providedChecksum = body.slice(-CHECKSUM_LENGTH);
+    const expectedChecksum = toBase62Checksum(
+        crc32(`${API_KEY_PREFIX}${payload}`),
+    );
+    return providedChecksum === expectedChecksum;
+}
+
+/**
+ * Mask a full API key for display: keep the first 12 and last 4 chars,
+ * replace the middle with bullets. Not currently wired into any UI;
+ * the settings page renders the stored `keyPrefix` column directly.
+ */
+export function maskApiKey(key: string): string {
+    if (key.length < DISPLAY_PREFIX_LENGTH + CHECKSUM_LENGTH) return key;
+    const head = key.slice(0, DISPLAY_PREFIX_LENGTH);
+    const tail = key.slice(-CHECKSUM_LENGTH);
+    const middle = "\u2022".repeat(
+        key.length - DISPLAY_PREFIX_LENGTH - CHECKSUM_LENGTH,
+    );
+    return `${head}${middle}${tail}`;
 }
 
 export function hashApiKey(apiKey: string): string {

--- a/src/tests/api-keys.test.ts
+++ b/src/tests/api-keys.test.ts
@@ -30,7 +30,9 @@ import {
     getApiKeyPrefix,
     hashApiKey,
     isApiKeyActive,
+    maskApiKey,
     normalizeApiKeyScopes,
+    validateApiKeyFormat,
 } from "@/lib/auth-request";
 
 describe("API keys", () => {
@@ -39,11 +41,46 @@ describe("API keys", () => {
         mockEnv.API_TOKEN_HASH_SECRET = undefined;
     });
 
-    it("generates op-prefixed keys and display prefixes", () => {
+    it("generates op-prefixed base62 keys with a CRC32 checksum suffix", () => {
         const key = createApiKey();
 
-        expect(key).toMatch(/^op_[A-Za-z0-9_-]{24}$/);
+        // Default payload length is 30, checksum is 4 → 3 + 30 + 4 = 37.
+        expect(key).toMatch(/^op_[0-9A-Za-z]{34}$/);
+        expect(key).toHaveLength(37);
         expect(getApiKeyPrefix(key)).toBe(key.slice(0, 12));
+        expect(validateApiKeyFormat(key)).toBe(true);
+    });
+
+    it("rejects keys whose checksum does not match the payload", () => {
+        const key = createApiKey();
+        // Flip one payload character (anything in position 5 that is base62
+        // but not equal to the original).
+        const original = key[5];
+        const swapped = original === "a" ? "b" : "a";
+        const tampered = `${key.slice(0, 5)}${swapped}${key.slice(6)}`;
+
+        expect(tampered).not.toBe(key);
+        expect(validateApiKeyFormat(tampered)).toBe(false);
+    });
+
+    it("rejects legacy nanoid-shaped keys via validateApiKeyFormat", () => {
+        // Strict format check: legacy `op_` + nanoid keys (which may include
+        // `-` / `_` and carry no checksum) are not valid under the new scheme.
+        // Authentication still accepts them — it looks up by HMAC hash —
+        // this helper is intentionally stricter.
+        expect(validateApiKeyFormat("op_abc-def_ghijklmnopqrstuv")).toBe(false);
+        expect(validateApiKeyFormat("not-an-op-key")).toBe(false);
+        expect(validateApiKeyFormat("op_short")).toBe(false);
+    });
+
+    it("masks a full key while preserving prefix and checksum", () => {
+        const key = createApiKey();
+        const masked = maskApiKey(key);
+
+        expect(masked.startsWith(key.slice(0, 12))).toBe(true);
+        expect(masked.endsWith(key.slice(-4))).toBe(true);
+        expect(masked).toHaveLength(key.length);
+        expect(masked).not.toBe(key);
     });
 
     it("hashes keys deterministically without storing the raw key", () => {


### PR DESCRIPTION
## Description

Replace the `nanoid(24)` payload in `createApiKey()` with a base62 payload plus a 4-char CRC32 base62 checksum, ported from the oraiapi key generator. New keys look like `op_{30 base62 chars}{4 base62 checksum}` (37 chars total). Hashing and the auth path are unchanged — legacy keys remain valid.

## Type of Change

- [x] Code refactoring

## Related Issues

Fixes #
Relates to #

## Changes Made

- `createApiKey()` now emits `op_{base62 payload}{CRC32 base62 checksum}`, default payload 30 chars (clamped to 20–64). Drops the `nanoid` dependency from `src/lib/auth-request.ts`.
- Added `validateApiKeyFormat(key)` — strict CRC32-based format check, exported for tooling/tests. Not wired into `authenticateRequest()`, which still looks up by HMAC hash so legacy `op_` + nanoid keys keep authenticating.
- Added `maskApiKey(key)` — utility that masks the middle of a full key while preserving the 12-char display prefix and 4-char checksum tail.
- `hashApiKey()` left untouched (HMAC-SHA256 keyed off `API_TOKEN_HASH_SECRET ?? BETTER_AUTH_SECRET`) per the hosted-mode secrets-at-rest invariant. No DB schema change, no migration, no env var change.
- Updated `src/tests/api-keys.test.ts`: new format regex, positive checksum test, tampered-key negative test, legacy-key rejection test, and a `maskApiKey` test.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): n/a

### Test Steps
1. `pnpm test src/tests/api-keys.test.ts src/tests/regressions/108-api-keys-polish.test.ts src/tests/regressions/79-api-keys-v1.test.ts` — 14/14 pass.
2. `pnpm format-and-lint:fix` — no findings on the two modified files.
3. `pnpm type-check` — clean.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

No schema changes.

## Breaking Changes

None. Authentication looks up by HMAC hash, so every previously issued `op_` + nanoid(24) key continues to work. Only newly issued keys adopt the new shape.

## Additional Notes

The oraiapi snippet's `hash: sha256(key).hex` was intentionally not adopted. AGENTS.md ("Hosted mode invariants → Secrets at rest") requires HMAC keyed off a server-side secret for high-entropy tokens, and switching would (a) downgrade security against DB-only exfil and (b) invalidate every existing key in the DB. Only the key *format* is borrowed; hashing stays as-is.

The env-prefix segment (`live`/`test`) from oraiapi was stripped per the request — OpenPlaud has no notion of live-vs-test keys.

## For Reviewers

- Confirm the legacy-key compatibility argument: `authenticateRequest()` only does `bearerToken.startsWith("op_")` + DB lookup by `hashApiKey()`, so format changes don't affect existing rows.
- `validateApiKeyFormat()` is intentionally strict (rejects legacy nanoid keys). It is not used in the auth path; this is documented in the JSDoc and asserted by a test.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch new API keys to a base62 payload plus a 4-char CRC32 base62 checksum (default 30+4). Auth hashing and lookup are unchanged, so existing `op_` + `nanoid(24)` keys keep working.

- **Refactors**
  - `createApiKey()` now emits `op_{base62 payload}{4-char base62 checksum}`; payload defaults to 30 chars (clamped 20–64).
  - Auth still uses HMAC hash lookup; no DB or env changes; no migration.
  - Dropped `nanoid` usage in `src/lib/auth-request.ts`.

- **New Features**
  - `validateApiKeyFormat(key)` checks the CRC32-based checksum (not used in auth).
  - `maskApiKey(key)` keeps the 12-char display prefix and 4-char checksum tail while masking the middle.

<sup>Written for commit 63a749ca45bbbb7c9d0d1a904f5585690a47ef9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

