### PR TITLE
fix(docker): install git in builder so fumadocs-mdx lastModified plugin works

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,7 +40,12 @@ next-env.d.ts
 /drizzle
 
 # git
-.git
+# NOTE: `.git/` is intentionally NOT ignored. The `fumadocs-mdx`
+# `lastModified` plugin (see source.config.ts) shells out to `git log`
+# to stamp each MDX page with its last-commit time. Without history
+# present in the builder stage the plugin errors and `next build`
+# fails. `.git` only lands in the `builder` stage; the `runner` stage
+# does not copy it, so the published image is unaffected.
 .gitignore
 
 # IDE

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,14 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
+# `fumadocs-mdx`'s `lastModified` plugin shells out to `git log` for every
+# MDX page (see source.config.ts). The base `oven/bun:1` image is Debian
+# slim and ships without `git`, so install it here. Builder-stage only --
+# the `runner` stage below does not inherit this layer.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Compile MDX docs into `src/.source/` before `next build` -- this is what
 # the postinstall hook would have done on a non-Docker install.
 RUN bunx fumadocs-mdx source.config.ts src/.source

--- a/source.config.ts
+++ b/source.config.ts
@@ -12,12 +12,14 @@ export const docs = defineDocs({
 
 export default defineConfig({
     // `lastModified` reads `git log` for each MDX file and exports a
-    // `lastModified` field on every page. The plugin no-ops cleanly when
-    // git history is missing, which is the case inside our Docker build
-    // (`.git` is in `.dockerignore`) -- self-hosters running the published
-    // image will see no timestamp. Dev and source-checkout builds get the
-    // real value. If we ever want timestamps in the image, drop `.git`
-    // from `.dockerignore`; cost is +a few MB of build context.
+    // `lastModified` field on every page. It requires BOTH the `git`
+    // binary on $PATH AND a `.git/` repo present at build time -- the
+    // plugin spawns `git` unconditionally and propagates any error.
+    // The Docker build satisfies both: the builder stage `apt-get`s
+    // git (see Dockerfile) and `.git/` is no longer dockerignored
+    // (see .dockerignore). The runner stage doesn't carry either, so
+    // the published image stays slim. Consumers: `src/app/sitemap.ts`
+    // (sitemap <lastmod>) and the docs page footer.
     plugins: [lastModified()],
     mdxOptions: {
         // Warm dual-theme shiki palette that lives close to the OpenPlaud


### PR DESCRIPTION
## Description

The Docker workflow on `main` has been failing since PR #131 landed the `/docs` site. Every push triggers `next build` to crash with `Executable not found in $PATH: "git"` for every file under `content/docs/`, because `fumadocs-mdx`'s `lastModified` plugin shells out to `git log` and the `oven/bun:1` base image is Debian-slim without `git`.

Latest failed run: https://github.com/openplaud/openplaud/actions/runs/25880698816

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

CI fix for the Docker workflow failures introduced by #131.

## Changes Made

- `Dockerfile`: `apt-get install -y --no-install-recommends git` in the `builder` stage, right before `bunx fumadocs-mdx`. Cleans `/var/lib/apt/lists/*`. Runner image unaffected (it doesn't inherit builder layers).
- `.dockerignore`: drop `.git` so the plugin actually finds repo history at build time and can stamp real timestamps into the published image. `.gitignore` stays ignored. The `runner` stage does not copy `.git`, so the final image size is unaffected (only the builder stage is heavier).
- `source.config.ts`: the existing comment claimed the plugin "no-ops cleanly when git history is missing" — it doesn't, it propagates the spawn error. Comment rewritten to describe the actual requirements (binary + repo) and the two consumers (`src/app/sitemap.ts`, docs page footer).

## Testing

### Test Environment
- OS: macOS (worktree); CI runs Ubuntu + buildx (linux/amd64 + linux/arm64)
- Node version: n/a (Bun)

### Test Steps
1. `pnpm format-and-lint:fix` — clean (2 pre-existing infos in an unrelated test file).
2. `docker build .` — **not run locally**: Docker daemon was not available in the worktree. CI will exercise both `linux/amd64` and `linux/arm64` builds on this PR.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — not applicable; the fix is a Dockerfile/dockerignore change, exercised by the existing Docker workflow on this PR.
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`) — not run; no app code changed.
- [ ] Type checking passes (`pnpm type-check`) — not run cleanly locally (`node_modules` not installed in this worktree); no TS source changed.

## Database Changes

None.

## Breaking Changes

None. Self-host operators pulling the published image see no change at runtime; the only effect is that `lastModified` values in the sitemap and on `/docs/*` pages will now reflect real commit timestamps in the published image (previously they were absent there by design).

## For Reviewers

- Confirm you're OK with the trade documented in `.dockerignore`: the builder stage now pulls the full `.git` directory into context (`+a few MB`, per the original comment in `source.config.ts`). The runner stage does not copy it, so the published image is unaffected.
- Verify the Docker job goes green on this PR before merging.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker builds by installing `git` in the builder and including repo history so `fumadocs-mdx` `lastModified` can run. The final image stays slim; sitemap and `/docs/*` now get real last-modified timestamps.

- **Bug Fixes**
  - Install `git` in the builder stage of `Dockerfile` and clean apt lists.
  - Remove `.git` from `.dockerignore` so the plugin can read history; `.git` is not copied to the runner stage.
  - Update `source.config.ts` comments to document the requirement and where the timestamps are used.

<sup>Written for commit f27efded15b661320df1a224bfd8262f03ac663b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

