### PR TITLE
fix(plaud,errors): typed errors for upstream JSON-parse failures + in-app bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,10 +54,8 @@ body:
       label: Deployment Type
       description: How are you running OpenPlaud?
       options:
-        - Docker Compose (recommended)
-        - Docker
-        - Local development (pnpm dev)
-        - Other
+        - Self-hosted
+        - Hosted (openplaud.com)
     validations:
       required: true
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -28,6 +28,12 @@ status code; all other failures from this route still return the envelope.
 - **`details`** — optional. Whitelisted, named fields only — never splat
   in upstream objects (they may carry secrets). Examples:
   `{ field: "email" }`, `{ retryAfter: 30 }`, `{ plaudStatus: 422 }`.
+- **`details.errorId`** — present on every response with HTTP status
+  `>= 500`, omitted on `< 500`. Format `err_xxxxxxxx` (8 hex chars).
+  In-memory only; correlates a user report with the matching
+  `console.error` log line within a single server process. Clients
+  should surface it (toast, dialog) so users can quote it when filing
+  a bug report.
 
 The HTTP status code mirrors the class of failure:
 
@@ -42,7 +48,7 @@ The HTTP status code mirrors the class of failure:
 |  `416` | Range not satisfiable (audio streaming)                                |
 |  `429` | Rate limited (self or upstream)                                        |
 |  `500` | Our bug                                                                |
-|  `502` | Upstream (Plaud, AI provider) returned a 5xx after our retry budget    |
+|  `502` | Upstream (Plaud, AI provider) returned a 5xx, or returned an unreadable body |
 |  `503` | Service unavailable (e.g. background job queue down)                   |
 
 Clients should switch on `code`, not `error`. The text of `error` may be
@@ -137,11 +143,12 @@ rephrased between releases without notice; `code` will not.
 
 ## Generic
 
-| Code                  | Status | When                                                                       |
-| --------------------- | -----: | -------------------------------------------------------------------------- |
-| `INTERNAL_ERROR`      |   500  | Unmapped server error. `error` is always `"An unexpected error occurred"`. |
-| `SERVICE_UNAVAILABLE` |   503  | Background dependency down (job queue, etc.).                              |
-| `RATE_LIMITED`        |   429  | Self-imposed rate limit (e.g. `/api/v1/*` per-token quota).                |
+| Code                    | Status | When                                                                       |
+| ----------------------- | -----: | -------------------------------------------------------------------------- |
+| `INTERNAL_ERROR`        |   500  | Unmapped server error. `error` is always `"An unexpected error occurred"`. |
+| `SERVICE_UNAVAILABLE`   |   503  | Background dependency down (job queue, etc.).                              |
+| `RATE_LIMITED`          |   429  | Self-imposed rate limit (e.g. `/api/v1/*` per-token quota).                |
+| `UPSTREAM_BAD_RESPONSE` |   502  | Upstream (Plaud, AI provider, S3, mail relay) returned a body we couldn't parse — typically an HTML page or empty payload where JSON was expected. Distinct from `INTERNAL_ERROR` (our bug) and `PLAUD_UPSTREAM_ERROR` (Plaud-specific). |
 
 ---
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -148,9 +148,30 @@ rephrased between releases without notice; `code` will not.
 | `INTERNAL_ERROR`        |   500  | Unmapped server error. `error` is always `"An unexpected error occurred"`. |
 | `SERVICE_UNAVAILABLE`   |   503  | Background dependency down (job queue, etc.).                              |
 | `RATE_LIMITED`          |   429  | Self-imposed rate limit (e.g. `/api/v1/*` per-token quota).                |
-| `UPSTREAM_BAD_RESPONSE` |   502  | Upstream (Plaud, AI provider, S3, mail relay) returned a body we couldn't parse — typically an HTML page or empty payload where JSON was expected. Distinct from `INTERNAL_ERROR` (our bug) and `PLAUD_UPSTREAM_ERROR` (Plaud-specific). |
+| `UPSTREAM_BAD_RESPONSE` |   502  | Upstream (Plaud, AI provider, S3, mail relay) returned a body we couldn't parse — typically an HTML page or empty payload where JSON was expected. Distinct from `INTERNAL_ERROR` (our bug) and `PLAUD_UPSTREAM_ERROR` (Plaud-specific). **Throw this explicitly from your helper after you've detected a parse failure on an upstream response.** Not auto-mapped from raw `SyntaxError` — see note below. |
 
 ---
+
+### A note on raw `SyntaxError`
+
+`mapErrorToAppError` deliberately does **not** classify bare `SyntaxError`s
+from `JSON.parse` / `Response.json()` / `Request.json()`. The two callers
+are indistinguishable at the error level: a malformed *upstream* body
+(Cloudflare HTML challenge) and a malformed *client* request body throw
+the identical exception, so any blanket mapping mis-classifies one of
+them (either a `502` for a 400 case, or vice versa).
+
+Instead:
+
+- Helpers that read **upstream** JSON wrap parsing themselves
+  (see `safeParseJson` in `src/lib/plaud/parse.ts`) and throw a typed
+  `AppError` (`UPSTREAM_BAD_RESPONSE`, `PLAUD_API_ERROR`, ...).
+- Route handlers reading **client** request bodies use
+  `await request.json().catch(() => null)` and surface
+  `MISSING_REQUIRED_FIELD` / `INVALID_INPUT` (`400`).
+
+A `SyntaxError` that still reaches `mapErrorToAppError` is genuinely
+unmapped and falls through to `INTERNAL_ERROR` (`500`) by design.
 
 ## Versioning
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { Github } from "@/components/icons/icons";
 import { Logo } from "@/components/icons/logo";
+import { ReportBugButton } from "@/components/report-bug-dialog";
 import { UpdateBadge } from "@/components/update-badge";
 import { env } from "@/lib/env";
 import { APP_RELEASE_URL, APP_VERSION_TAG } from "@/lib/version";
@@ -72,14 +73,18 @@ export function Footer() {
                         >
                             Docs
                         </Link>
-                        {env.IS_HOSTED ? (
-                            <Link
-                                href="mailto:support@openplaud.com"
-                                className="hover:text-foreground transition-colors"
-                            >
-                                Support
-                            </Link>
-                        ) : null}
+                        {/* Single bug-report entry point for both modes.
+                            Self-host → GitHub-only dialog. Hosted →
+                            GitHub + mailto. Replaces the old
+                            hosted-only "Support" mailto link — hosted
+                            users now get the same dialog with the
+                            mailto button included inside it, and self-
+                            hosters get a proper reporting path that
+                            previously didn't exist. */}
+                        <ReportBugButton
+                            isHosted={env.IS_HOSTED}
+                            className="hover:text-foreground transition-colors"
+                        />
                         <Link
                             href="https://github.com/openplaud/openplaud"
                             target="_blank"

--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -22,7 +22,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { parseApiError } from "@/lib/api-errors";
+import { toastApiError } from "@/lib/api-errors";
 import {
     DEFAULT_SERVER_KEY,
     PLAUD_SERVERS,
@@ -188,12 +188,19 @@ function ConnectorPane({
                 }),
             });
             if (!res.ok) {
-                const err = await parseApiError(res);
-                throw new Error(err.error || "Failed to connect Plaud");
+                await toastApiError(res, {
+                    fallback: "Failed to connect Plaud",
+                    errorContext: "connect Plaud via connector extension",
+                });
+                return;
             }
             toast.success("Plaud account connected");
             onConnected();
         } catch (err) {
+            // Reachable only for client-side throws (extension bridge
+            // failure, network blow-up before `fetch` returns). Server
+            // errors went through `toastApiError` above and already
+            // toasted with the `Report` action when applicable.
             toast.error(
                 err instanceof Error ? err.message : "Failed to connect",
             );
@@ -327,8 +334,11 @@ function EmailCodePane({
                 body: JSON.stringify({ email: trimmed }),
             });
             if (!res.ok) {
-                const err = await parseApiError(res);
-                throw new Error(err.error || "Failed to send code");
+                await toastApiError(res, {
+                    fallback: "Failed to send code",
+                    errorContext: "send Plaud verification code",
+                });
+                return;
             }
             const data = await res.json();
             setOtpToken(data.otpToken);
@@ -337,6 +347,8 @@ function EmailCodePane({
             setStep("code");
             toast.success("Verification code sent — check your email");
         } catch (err) {
+            // Network blow-up before `fetch` returns. Server errors were
+            // handled by `toastApiError` above.
             toast.error(
                 err instanceof Error ? err.message : "Failed to send code",
             );
@@ -364,8 +376,11 @@ function EmailCodePane({
                 }),
             });
             if (!res.ok) {
-                const err = await parseApiError(res);
-                throw new Error(err.error || "Verification failed");
+                await toastApiError(res, {
+                    fallback: "Verification failed",
+                    errorContext: "verify Plaud OTP code",
+                });
+                return;
             }
             toast.success("Plaud account connected");
             onConnected();
@@ -535,8 +550,11 @@ function PasteTokenPane({
                 }),
             });
             if (!res.ok) {
-                const err = await parseApiError(res);
-                throw new Error(err.error || "Failed to connect Plaud");
+                await toastApiError(res, {
+                    fallback: "Failed to connect Plaud",
+                    errorContext: "connect Plaud via pasted access token",
+                });
+                return;
             }
             toast.success("Plaud account connected");
             onConnected();

--- a/src/components/report-bug-dialog.tsx
+++ b/src/components/report-bug-dialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Mail } from "lucide-react";
+import { useState } from "react";
+import { Github } from "@/components/icons/icons";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    buildReportBugBodyPreview,
+    buildReportBugMailto,
+    buildReportBugUrl,
+} from "@/lib/report-bug";
+
+interface ReportBugDialogProps {
+    isHosted: boolean;
+    /** Optional correlation id from `details.errorId` on a 5xx response. */
+    errorId?: string;
+    /** Optional one-line summary of what the user was doing. */
+    errorContext?: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Renders the bug-report dialog with two action buttons:
+ *   - "Report on GitHub" \u2014 always.
+ *   - "Email us" \u2014 hosted only. Self-hosters aren't our customers and
+ *     `support@openplaud.com` would just confuse them; they should file
+ *     on GitHub.
+ *
+ * The preview is shown so users see exactly what gets sent before
+ * clicking. Both buttons open in a new tab via `<a target="_blank">`
+ * (the mailto opens the user's mail client; effectively the same UX).
+ */
+export function ReportBugDialog({
+    isHosted,
+    errorId,
+    errorContext,
+    open,
+    onOpenChange,
+}: ReportBugDialogProps) {
+    const page =
+        typeof window !== "undefined" ? window.location.pathname : undefined;
+    const opts = { isHosted, errorId, errorContext, page };
+    const githubUrl = buildReportBugUrl(opts);
+    const mailtoUrl = buildReportBugMailto(opts);
+    const preview = buildReportBugBodyPreview(opts);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Report a bug</DialogTitle>
+                    <DialogDescription>
+                        {errorId
+                            ? "Something went wrong. The details below will be pre-filled \u2014 add what you were doing and we'll take a look."
+                            : "Pick how you'd like to report this. Your version and deployment mode are pre-filled to save you typing."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground">
+                        Preview
+                    </p>
+                    <pre className="max-h-48 overflow-auto rounded-md border bg-muted/50 p-3 text-xs whitespace-pre-wrap break-words">
+                        {preview}
+                    </pre>
+                </div>
+
+                <DialogFooter className="flex-col-reverse sm:flex-row gap-2">
+                    {isHosted ? (
+                        <Button variant="outline" asChild>
+                            <a
+                                href={mailtoUrl}
+                                rel="noopener noreferrer"
+                                onClick={() => onOpenChange(false)}
+                            >
+                                <Mail className="size-4" />
+                                Email us
+                            </a>
+                        </Button>
+                    ) : null}
+                    <Button asChild>
+                        <a
+                            href={githubUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={() => onOpenChange(false)}
+                        >
+                            <Github className="size-4" />
+                            Report on GitHub
+                        </a>
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+interface ReportBugButtonProps {
+    isHosted: boolean;
+    /** Optional className for the trigger \u2014 lets the footer style it inline. */
+    className?: string;
+}
+
+/**
+ * Footer trigger for the bug-report dialog. Kept as a thin wrapper so the
+ * server-rendered footer can mount it without itself becoming a client
+ * component beyond this leaf.
+ *
+ * The button is reset to look like the surrounding inline `<Link>` siblings
+ * (no border, no padding, no background, inherited font) so it doesn't get
+ * the browser-default button chrome.
+ */
+const RESET_BUTTON_CLASSES =
+    "appearance-none border-0 bg-transparent p-0 m-0 font-inherit text-inherit cursor-pointer";
+
+export function ReportBugButton({ isHosted, className }: ReportBugButtonProps) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen(true)}
+                className={`${RESET_BUTTON_CLASSES} ${className ?? ""}`}
+            >
+                Report a bug
+            </button>
+            <ReportBugDialog
+                isHosted={isHosted}
+                open={open}
+                onOpenChange={setOpen}
+            />
+        </>
+    );
+}

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -12,7 +12,9 @@
  * See `docs/error-codes.md` for the full code reference.
  */
 
+import { toast } from "sonner";
 import type { ErrorCode } from "@/lib/errors";
+import { buildReportBugUrl } from "@/lib/report-bug";
 
 export interface ApiErrorBody {
     error: string;
@@ -60,4 +62,66 @@ export async function getApiErrorMessage(
 ): Promise<string> {
     const body = await parseApiError(response);
     return body.error || fallback;
+}
+
+export interface ToastApiErrorOptions {
+    /** Fallback message if the server didn't send a human-readable `error`. */
+    fallback?: string;
+    /**
+     * Short label describing what the user was doing when the error fired
+     * ("connect Plaud", "send verification code", ...). Pre-fills the bug
+     * report description so we don't have to guess from the errorId alone.
+     */
+    errorContext?: string;
+}
+
+/**
+ * Toast a non-OK API response and — when the server attached an
+ * `errorId` (i.e. it was a 5xx through `apiHandler`) — expose a one-click
+ * "Report" action that opens a pre-filled GitHub issue with the errorId
+ * baked in. For 4xx responses the toast renders without the action.
+ *
+ * Returns the parsed envelope so callers can still branch on `code` for
+ * UI-specific recovery (e.g. routing to the reconnect flow on
+ * `PLAUD_INVALID_TOKEN`).
+ *
+ * The Report action always opens GitHub directly — no dialog — because
+ * the toast is a 5-second UI moment and the goal is single-click reporting.
+ * Hosted users who prefer email discover the mailto option via the
+ * footer "Report a bug" button, which opens the full dialog.
+ */
+export async function toastApiError(
+    response: Response,
+    opts: ToastApiErrorOptions = {},
+): Promise<ApiErrorBody> {
+    const body = await parseApiError(response);
+    const message = body.error || opts.fallback || "Request failed";
+    const errorId =
+        typeof body.details?.errorId === "string"
+            ? body.details.errorId
+            : undefined;
+
+    if (errorId) {
+        const url = buildReportBugUrl({
+            errorId,
+            errorContext: opts.errorContext,
+            page:
+                typeof window !== "undefined"
+                    ? window.location.pathname
+                    : undefined,
+        });
+        toast.error(message, {
+            description: errorId,
+            action: {
+                label: "Report",
+                onClick: () => {
+                    window.open(url, "_blank", "noopener,noreferrer");
+                },
+            },
+        });
+    } else {
+        toast.error(message);
+    }
+
+    return body;
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -247,24 +247,19 @@ export function mapErrorToAppError(error: unknown): AppError {
     }
 
     if (error instanceof Error) {
-        // Raw `SyntaxError` from `JSON.parse` / `Response.json()` means an
-        // upstream returned a body that wasn't valid JSON (HTML challenge
-        // page, empty body, truncated stream, ...). Classify as
-        // `UPSTREAM_BAD_RESPONSE` (502) rather than letting it fall through
-        // to the generic `INTERNAL_ERROR` (500) catch-all — "their problem"
-        // vs "our bug" is the whole point of having a 502/500 split.
-        //
-        // Domain-specific helpers (`safeParseJson` in `src/lib/plaud/parse.ts`)
-        // should throw structured `AppError`s directly and bypass this branch.
-        // This is the safety net for any third-party SDK / unhandled fetch
-        // site that lets a raw `SyntaxError` escape.
-        if (error instanceof SyntaxError && /json/i.test(error.message)) {
-            return new AppError(
-                ErrorCode.UPSTREAM_BAD_RESPONSE,
-                "An upstream service returned an unreadable response. Please try again later.",
-                502,
-            );
-        }
+        // Note: raw `SyntaxError`s (from `JSON.parse`, `Response.json()`,
+        // or `Request.json()`) are NOT auto-mapped here. The two callers
+        // are indistinguishable at the error level — a malformed *upstream*
+        // body (HTML challenge page) and a malformed *client* request body
+        // throw the identical exception shape — so any blanket mapping
+        // mis-classifies one of them. Helpers that read upstream JSON must
+        // wrap parsing themselves (see `safeParseJson` in
+        // `src/lib/plaud/parse.ts`) and throw a typed `AppError`
+        // (`UPSTREAM_BAD_RESPONSE`, `PLAUD_API_ERROR`, ...) before it
+        // reaches this layer. Route handlers reading client bodies must
+        // `.catch(() => null)` and surface `MISSING_REQUIRED_FIELD` /
+        // `INVALID_INPUT`. Anything that still escapes is genuinely
+        // unmapped and falls through to `INTERNAL_ERROR` (500) below.
 
         if (error.message.includes("path traversal")) {
             return new AppError(

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -90,6 +90,13 @@ export enum ErrorCode {
     INTERNAL_ERROR = "INTERNAL_ERROR",
     SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE",
     RATE_LIMITED = "RATE_LIMITED",
+    /**
+     * Upstream (Plaud, AI provider, S3, mail relay, ...) returned a
+     * response we couldn't parse — typically an HTML body or empty
+     * payload where JSON was expected. Surfaced as 502 to distinguish
+     * "their problem" from `INTERNAL_ERROR` (our bug).
+     */
+    UPSTREAM_BAD_RESPONSE = "UPSTREAM_BAD_RESPONSE",
 }
 
 export interface AppErrorJSON {
@@ -144,6 +151,10 @@ export function createErrorResponse(error: AppError | Error | unknown): {
  */
 export function errorResponse(error: AppError | Error | unknown): NextResponse {
     const app = mapErrorToAppError(error);
+    if (app.statusCode >= 500) {
+        const errorId = attachErrorId(app);
+        console.error(`[api] [${errorId}]`, app.code, error);
+    }
     return NextResponse.json(app.toJSON(), { status: app.statusCode });
 }
 
@@ -182,11 +193,37 @@ export function apiHandler<Ctx = unknown>(
         } catch (error) {
             const app = mapErrorToAppError(error);
             if (app.statusCode >= 500) {
-                console.error("[api]", app.code, error);
+                const errorId = attachErrorId(app);
+                console.error(`[api] [${errorId}]`, app.code, error);
             }
             return NextResponse.json(app.toJSON(), { status: app.statusCode });
         }
     };
+}
+
+/**
+ * Generate a short, quotable correlation id and attach it to `app.details`
+ * so it appears in the JSON envelope. In-memory only — the value
+ * correlates a user-reported error with a single log line within a single
+ * process. Format: `err_` + 8 hex chars from `crypto.randomUUID()`.
+ *
+ * Only call on 5xx — 4xx responses are already actionable and an errorId
+ * would just add noise. Returns the id so the log line can include it.
+ *
+ * Idempotent: if the same `AppError` instance flows through this function
+ * twice (e.g. a route uses `errorResponse` in a `catch` and the same
+ * instance later reaches `apiHandler`), the existing id is preserved so
+ * the response envelope and log line agree. Re-stamping would silently
+ * desync them.
+ */
+function attachErrorId(app: AppError): string {
+    const existing = app.details?.errorId;
+    if (typeof existing === "string" && existing.startsWith("err_")) {
+        return existing;
+    }
+    const errorId = `err_${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
+    app.details = { ...(app.details ?? {}), errorId };
+    return errorId;
 }
 
 /**
@@ -210,6 +247,25 @@ export function mapErrorToAppError(error: unknown): AppError {
     }
 
     if (error instanceof Error) {
+        // Raw `SyntaxError` from `JSON.parse` / `Response.json()` means an
+        // upstream returned a body that wasn't valid JSON (HTML challenge
+        // page, empty body, truncated stream, ...). Classify as
+        // `UPSTREAM_BAD_RESPONSE` (502) rather than letting it fall through
+        // to the generic `INTERNAL_ERROR` (500) catch-all — "their problem"
+        // vs "our bug" is the whole point of having a 502/500 split.
+        //
+        // Domain-specific helpers (`safeParseJson` in `src/lib/plaud/parse.ts`)
+        // should throw structured `AppError`s directly and bypass this branch.
+        // This is the safety net for any third-party SDK / unhandled fetch
+        // site that lets a raw `SyntaxError` escape.
+        if (error instanceof SyntaxError && /json/i.test(error.message)) {
+            return new AppError(
+                ErrorCode.UPSTREAM_BAD_RESPONSE,
+                "An upstream service returned an unreadable response. Please try again later.",
+                502,
+            );
+        }
+
         if (error.message.includes("path traversal")) {
             return new AppError(
                 ErrorCode.PATH_TRAVERSAL_DETECTED,

--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -14,6 +14,7 @@
 
 import { AppError, ErrorCode } from "@/lib/errors";
 import { DEFAULT_PLAUD_API_BASE } from "./client";
+import { safeParseJson } from "./parse";
 import { PLAUD_USER_AGENT } from "./servers";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -70,7 +71,11 @@ export async function plaudSendCode(
         body: JSON.stringify({ username: email }),
     });
 
-    const body = (await res.json()) as PlaudSendCodeResponse;
+    // Use `safeParseJson` so a Cloudflare HTML challenge body (which
+    // Plaud returns on WAF rejection) surfaces as a typed `PLAUD_API_ERROR`
+    // / `PLAUD_UPSTREAM_ERROR` instead of a raw `SyntaxError` that
+    // `apiHandler` would flatten to `INTERNAL_ERROR` (500). See #142.
+    const body = await safeParseJson<PlaudSendCodeResponse>(res);
 
     // Region mismatch → retry against the correct regional server
     if (body.status === -302 && body.data?.domains?.api) {
@@ -116,7 +121,7 @@ export async function plaudVerifyOtp(
         body: JSON.stringify({ code, token: otpToken }),
     });
 
-    const body = (await res.json()) as PlaudOtpLoginResponse;
+    const body = await safeParseJson<PlaudOtpLoginResponse>(res);
 
     // Tokens can appear at root or nested under data
     const accessToken =

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -5,6 +5,7 @@ import type {
     PlaudRecordingsResponse,
     PlaudTempUrlResponse,
 } from "@/types/plaud";
+import { safeParseJson } from "./parse";
 import { DEFAULT_SERVER_KEY, PLAUD_SERVERS, PLAUD_USER_AGENT } from "./servers";
 import { resolveWorkspaceToken } from "./workspace";
 
@@ -216,7 +217,14 @@ export class PlaudClient {
                 throw plaudHttpError(response.status, upstreamMsg);
             }
 
-            return (await response.json()) as T;
+            // Use `safeParseJson` instead of bare `.json()` so an HTML
+            // body (Cloudflare challenge after a future WAF tightening)
+            // surfaces as a typed Plaud error rather than a raw
+            // `SyntaxError`. The outer `try/catch` below would catch the
+            // `SyntaxError` and map it to `PLAUD_UPSTREAM_ERROR` anyway,
+            // but `safeParseJson` produces the correct code+message in
+            // one step and includes a body snippet in `details`.
+            return await safeParseJson<T>(response);
         } catch (error) {
             if (
                 error instanceof TypeError &&

--- a/src/lib/plaud/parse.ts
+++ b/src/lib/plaud/parse.ts
@@ -1,0 +1,133 @@
+/**
+ * Defensive JSON parsing for Plaud API responses.
+ *
+ * Plaud's API sits behind Cloudflare. When the WAF rejects a request
+ * (datacenter IP scoring, missing/wrong User-Agent, future-tightened
+ * fingerprint rules, ...) the response body is HTML, not JSON. A bare
+ * `await res.json()` throws `SyntaxError: Unexpected token '<'` which
+ * `apiHandler` would then surface as `INTERNAL_ERROR` (500) \u2014 misleading,
+ * since it isn't our bug.
+ *
+ * This helper:
+ *   - reads the body as text
+ *   - attempts `JSON.parse`
+ *   - on parse failure or empty body, throws a structured `AppError`
+ *     keyed off `res.status` so the route boundary surfaces the right
+ *     status code and error code
+ *   - includes a 200-char `bodySnippet` in `details` so server logs
+ *     have something to grep when Plaud's response shape changes again
+ *
+ * Callers that need a typed result on the success path can still call
+ * `safeParseJson<MyShape>(res)` and get a typed value back; failures
+ * always throw.
+ */
+
+import { AppError, ErrorCode } from "@/lib/errors";
+
+const BODY_SNIPPET_MAX = 200;
+
+/**
+ * Parse a Plaud API `Response` as JSON, or throw a structured
+ * `AppError` if the body isn't valid JSON.
+ *
+ * Note: this does *not* check `res.ok` \u2014 callers may legitimately want
+ * to parse a 200-body with `status: -N` business-level errors (the Plaud
+ * `-302` regional redirect is one such case). The status-code branching
+ * here only fires when the body itself is unparseable; if Plaud returns
+ * a clean JSON error envelope at HTTP 422, this helper returns it and
+ * the caller decides what to do.
+ */
+export async function safeParseJson<T = unknown>(res: Response): Promise<T> {
+    // Prefer `.text()` because it lets us snippet the body for diagnostics
+    // when the parse fails. Real `Response` objects always implement both
+    // `.text()` and `.json()`; the `typeof` guard exists so test mocks
+    // that only stub `.json()` keep working (the loss of the body snippet
+    // in a test mock is uninteresting — the test already controls the
+    // body).
+    let text = "";
+    let parsed: unknown;
+    let didParse = false;
+    let bodyReadFailed = false;
+    if (typeof res.text === "function") {
+        try {
+            text = await res.text();
+        } catch {
+            // `.text()` can itself throw on aborted / killed connections
+            // (Cloudflare drops the socket mid-body, undici raises a
+            // TypeError, etc.). Treat it as upstream-unavailable rather
+            // than letting the raw TypeError escape to `INTERNAL_ERROR`.
+            bodyReadFailed = true;
+        }
+        if (!bodyReadFailed && text.length > 0) {
+            try {
+                parsed = JSON.parse(text) as T;
+                didParse = true;
+            } catch {
+                // fall through to the structured error below
+            }
+        }
+    } else {
+        try {
+            parsed = await (res.json() as Promise<T>);
+            didParse = true;
+        } catch {
+            // fall through to the structured error below
+        }
+    }
+    if (didParse) {
+        return parsed as T;
+    }
+
+    // Body-read failure (socket drop, abort) is unambiguously transient
+    // upstream-side. Surface as 502 regardless of the HTTP status we may
+    // have seen on the headers — the response is unusable.
+    if (bodyReadFailed) {
+        throw new AppError(
+            ErrorCode.PLAUD_UPSTREAM_ERROR,
+            "Plaud closed the connection before sending a response. Please try again later.",
+            502,
+            { plaudStatus: res.status },
+        );
+    }
+
+    // Map HTTP status -> our error taxonomy. Mirrors the mapping in
+    // `client.ts:plaudHttpError` so callers see consistent codes whether
+    // the failure was an HTTP-level error or a JSON-parse failure.
+    const status = res.status;
+    let code: ErrorCode;
+    let message: string;
+    let statusCode: number;
+    if (status === 401) {
+        code = ErrorCode.PLAUD_INVALID_TOKEN;
+        message =
+            "Plaud rejected the access token. Reconnect your Plaud account.";
+        statusCode = 401;
+    } else if (status === 429) {
+        code = ErrorCode.PLAUD_RATE_LIMITED;
+        message = "Too many requests to Plaud. Please try again later.";
+        statusCode = 429;
+    } else if (status >= 500) {
+        code = ErrorCode.PLAUD_UPSTREAM_ERROR;
+        message = "Plaud is temporarily unavailable. Please try again later.";
+        statusCode = 502;
+    } else if (status >= 400) {
+        // 4xx with non-JSON body \u2014 most commonly a Cloudflare 403
+        // challenge page. Surface as a Plaud-typed 400 so the UI can
+        // distinguish it from a generic server error, but include the
+        // upstream status in `details` for diagnostics.
+        code = ErrorCode.PLAUD_API_ERROR;
+        message = `Plaud returned an unreadable response (HTTP ${status}).`;
+        statusCode = 400;
+    } else {
+        // 2xx/3xx with a non-JSON body \u2014 shouldn't happen with Plaud
+        // but classify as upstream-bad-response (502) rather than 400.
+        code = ErrorCode.PLAUD_UPSTREAM_ERROR;
+        message = `Plaud returned an unreadable response (HTTP ${status}).`;
+        statusCode = 502;
+    }
+
+    throw new AppError(code, message, statusCode, {
+        plaudStatus: status,
+        bodySnippet: text.slice(0, BODY_SNIPPET_MAX),
+    });
+}

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -24,6 +24,7 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
+import { safeParseJson } from "./parse";
 import { PLAUD_USER_AGENT } from "./servers";
 
 /**
@@ -90,7 +91,10 @@ export async function listPlaudWorkspaces(
         );
     }
 
-    const body = (await res.json()) as PlaudWorkspaceListResponse;
+    // Defensive parse — if Plaud ever returns 200 with an HTML body (or
+    // any other non-JSON shape), `safeParseJson` throws a typed `AppError`
+    // instead of the raw `SyntaxError` that would flatten to 500. See #142.
+    const body = await safeParseJson<PlaudWorkspaceListResponse>(res);
     if (body.status !== 0 || !body.data?.workspaces) {
         throw new AppError(
             ErrorCode.PLAUD_API_ERROR,
@@ -188,7 +192,7 @@ export async function mintPlaudWorkspaceToken(
         });
     }
 
-    const body = (await res.json()) as PlaudWorkspaceTokenResponse;
+    const body = await safeParseJson<PlaudWorkspaceTokenResponse>(res);
     if (body.status !== 0 || !body.data?.workspace_token) {
         // 2xx response with a business-level error (status != 0) most
         // commonly means the workspace is no longer valid for this user

--- a/src/lib/report-bug.ts
+++ b/src/lib/report-bug.ts
@@ -1,0 +1,161 @@
+/**
+ * Bug-report URL builders.
+ *
+ * Two entry points, same payload:
+ *   - `buildReportBugUrl`     -> pre-filled GitHub Issue Form
+ *   - `buildReportBugMailto`  -> pre-filled mailto link to support
+ *
+ * GitHub Issue Forms support per-field query-string pre-filling via
+ * `?<field-id>=<value>`. The field IDs are taken from
+ * `.github/ISSUE_TEMPLATE/bug_report.yml` and must stay in sync with it:
+ *   - `description`, `deployment`, `version`, `additional`
+ *
+ * The mailto path is reserved for hosted users (self-hosters aren't
+ * our customers and `support@openplaud.com` would just confuse them).
+ * The caller decides whether to render the mailto button based on
+ * `isHosted`; this module just builds URLs.
+ *
+ * Pure and isomorphic \u2014 no DOM, no env. Callers pass `isHosted` in.
+ */
+
+import { APP_VERSION_TAG } from "@/lib/version";
+
+/** Hosted support inbox. Marketing surface, hardcoded by design. */
+export const SUPPORT_EMAIL = "support@openplaud.com";
+
+const GITHUB_NEW_ISSUE_URL =
+    "https://github.com/openplaud/openplaud/issues/new";
+const BUG_REPORT_TEMPLATE = "bug_report.yml";
+
+export interface ReportBugOptions {
+    /**
+     * Short correlation id from the error envelope (`details.errorId`).
+     * When present, included in the pre-filled body so support can grep
+     * server logs by this id.
+     */
+    errorId?: string;
+    /**
+     * Short label describing what the user was doing when the error
+     * fired ("connect Plaud", "send verification code", ...). Pre-fills
+     * the issue description.
+     */
+    errorContext?: string;
+    /**
+     * Current page path (e.g. `/dashboard`). Helps triage figure out
+     * which surface the user was on.
+     */
+    page?: string;
+    /**
+     * Whether this OpenPlaud instance is running in hosted mode.
+     * Passed in by the caller (server reads `env.IS_HOSTED`). Optional
+     * because client-side entry points (the error toast `[Report]`
+     * action) don't have `env.IS_HOSTED` available — in that case the
+     * deployment field is left unfilled and the user picks it from
+     * the GitHub form dropdown. Server-side entry points (the footer
+     * dialog) always pass it.
+     */
+    isHosted?: boolean;
+}
+
+/**
+ * Build a pre-filled GitHub Issue Form URL. The form remains user-driven
+ * (steps to reproduce, expected/actual behavior); we only pre-fill the
+ * fields we already know to save the user typing.
+ */
+export function buildReportBugUrl(opts: ReportBugOptions): string {
+    const params = new URLSearchParams({
+        template: BUG_REPORT_TEMPLATE,
+        version: APP_VERSION_TAG,
+    });
+
+    // Only pre-fill `description` when we have something concrete to put
+    // there (errorId, errorContext). For the footer "just want to report
+    // something" path, leaving description empty is better than seeding
+    // a placeholder string the user has to delete.
+    const description = buildDescription(opts);
+    if (description) {
+        params.set("description", description);
+    }
+
+    // Only pre-fill `deployment` when we know it. The GitHub Issue Form
+    // marks the dropdown as required, so an unset value just means the
+    // user picks it themselves — better than guessing wrong.
+    if (opts.isHosted !== undefined) {
+        params.set(
+            "deployment",
+            opts.isHosted ? "Hosted (openplaud.com)" : "Self-hosted",
+        );
+    }
+
+    const additional = buildAdditional(opts);
+    if (additional) {
+        params.set("additional", additional);
+    }
+
+    return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;
+}
+
+/**
+ * Build a pre-filled mailto URL. Only meaningful for hosted users \u2014
+ * self-hosters should use GitHub. Caller is responsible for not
+ * exposing this in self-host UI.
+ */
+export function buildReportBugMailto(opts: ReportBugOptions): string {
+    const subject = opts.errorId
+        ? `OpenPlaud bug report (${opts.errorId})`
+        : "OpenPlaud bug report";
+    const body = [buildDescription(opts), "", "---", buildAdditional(opts)]
+        .filter(Boolean)
+        .join("\n");
+
+    const params = new URLSearchParams({
+        subject,
+        body,
+    });
+    return `mailto:${SUPPORT_EMAIL}?${params.toString()}`;
+}
+
+/**
+ * Produces the prose preview the dialog shows the user before they
+ * click. Same content drives both GitHub `description` and mailto body.
+ */
+export function buildReportBugBodyPreview(opts: ReportBugOptions): string {
+    const parts = [buildDescription(opts), "", buildAdditional(opts)].filter(
+        Boolean,
+    );
+    return parts.join("\n");
+}
+
+// ---- helpers --------------------------------------------------------------
+
+/**
+ * Build the pre-filled `description` body. Returns an empty string when
+ * there's nothing concrete to seed (no errorId, no errorContext) so the
+ * caller can omit the param entirely and let the user start from a clean
+ * textarea.
+ */
+function buildDescription(opts: ReportBugOptions): string {
+    const lines: string[] = [];
+    if (opts.errorContext) {
+        lines.push(`While trying to: ${opts.errorContext}`);
+    }
+    if (opts.errorId) {
+        if (lines.length > 0) lines.push("");
+        lines.push(`Error id: \`${opts.errorId}\``);
+    }
+    return lines.join("\n");
+}
+
+function buildAdditional(opts: ReportBugOptions): string {
+    const lines: string[] = [];
+    if (opts.page) {
+        lines.push(`Page: \`${opts.page}\``);
+    }
+    lines.push(`Version: ${APP_VERSION_TAG}`);
+    if (opts.isHosted !== undefined) {
+        lines.push(
+            `Mode: ${opts.isHosted ? "Hosted (openplaud.com)" : "Self-hosted"}`,
+        );
+    }
+    return lines.join("\n");
+}

--- a/src/lib/report-bug.ts
+++ b/src/lib/report-bug.ts
@@ -108,11 +108,14 @@ export function buildReportBugMailto(opts: ReportBugOptions): string {
         .filter(Boolean)
         .join("\n");
 
-    const params = new URLSearchParams({
-        subject,
-        body,
-    });
-    return `mailto:${SUPPORT_EMAIL}?${params.toString()}`;
+    // RFC 6068 `mailto:` URIs require `%20` for spaces in the query.
+    // `URLSearchParams` emits `+` (application/x-www-form-urlencoded
+    // semantics), which several mail clients (notably some macOS Mail
+    // and Outlook builds) render literally instead of decoding to space,
+    // garbling the prefilled subject + body. Encode manually with the
+    // mailto-correct conventions.
+    const qs = `subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    return `mailto:${SUPPORT_EMAIL}?${qs}`;
 }
 
 /**

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -175,12 +175,27 @@ describe("errorResponse", () => {
     });
 
     it("falls back to 500 INTERNAL_ERROR for unknown thrown values", async () => {
-        const res = errorResponse({ weird: "shape" });
-        expect(res.status).toBe(500);
-        expect(await res.json()).toEqual({
-            error: "An unexpected error occurred",
-            code: ErrorCode.INTERNAL_ERROR,
-        });
+        // Silence the expected 5xx log line so the test output stays
+        // clean; the log itself is asserted in the dedicated errorId test.
+        const consoleErrorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+        try {
+            const res = errorResponse({ weird: "shape" });
+            expect(res.status).toBe(500);
+            const body = (await res.json()) as {
+                error: string;
+                code: string;
+                details?: { errorId?: string };
+            };
+            expect(body.error).toBe("An unexpected error occurred");
+            expect(body.code).toBe(ErrorCode.INTERNAL_ERROR);
+            // 5xx responses carry a correlation id; format checked in the
+            // dedicated errorId describe block below.
+            expect(body.details?.errorId).toMatch(/^err_[0-9a-f]{8}$/);
+        } finally {
+            consoleErrorSpy.mockRestore();
+        }
     });
 });
 
@@ -283,5 +298,99 @@ describe("apiHandler", () => {
         expect(body.code).toBe(ErrorCode.INTERNAL_ERROR);
         expect(JSON.stringify(body)).not.toContain("hunter2");
         expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+});
+
+describe("errorId correlation", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleErrorSpy = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("attaches details.errorId on >=500 (apiHandler)", async () => {
+        const handler = apiHandler(async () => {
+            throw new AppError(ErrorCode.INTERNAL_ERROR, "Boom", 500);
+        });
+        const res = await handler(new Request("http://x"), undefined);
+        const body = (await res.json()) as {
+            details?: { errorId?: string };
+        };
+        expect(body.details?.errorId).toMatch(/^err_[0-9a-f]{8}$/);
+    });
+
+    it("does NOT attach errorId on <500 (apiHandler)", async () => {
+        const handler = apiHandler(async () => {
+            throw new AppError(ErrorCode.NOT_FOUND, "gone", 404);
+        });
+        const res = await handler(new Request("http://x"), undefined);
+        const body = (await res.json()) as {
+            details?: Record<string, unknown>;
+        };
+        // No errorId, and no `details` object at all when nothing else
+        // populates it — the response stays minimal for 4xx.
+        expect(body.details).toBeUndefined();
+    });
+
+    it("preserves existing details fields when attaching errorId", async () => {
+        const handler = apiHandler(async () => {
+            throw new AppError(
+                ErrorCode.PLAUD_UPSTREAM_ERROR,
+                "Plaud is unavailable",
+                502,
+                { plaudStatus: 503 },
+            );
+        });
+        const res = await handler(new Request("http://x"), undefined);
+        const body = (await res.json()) as {
+            details?: { plaudStatus?: number; errorId?: string };
+        };
+        expect(body.details?.plaudStatus).toBe(503);
+        expect(body.details?.errorId).toMatch(/^err_[0-9a-f]{8}$/);
+    });
+
+    it("log line includes the errorId (apiHandler)", async () => {
+        const handler = apiHandler(async () => {
+            throw new Error("boom");
+        });
+        await handler(new Request("http://x"), undefined);
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        const firstArg = consoleErrorSpy.mock.calls[0][0] as string;
+        expect(firstArg).toMatch(/^\[api\] \[err_[0-9a-f]{8}\]$/);
+    });
+
+    it("errorResponse also attaches errorId on >=500", async () => {
+        const res = errorResponse(new Error("boom"));
+        const body = (await res.json()) as {
+            details?: { errorId?: string };
+        };
+        expect(body.details?.errorId).toMatch(/^err_[0-9a-f]{8}$/);
+    });
+});
+
+describe("UPSTREAM_BAD_RESPONSE (SyntaxError backstop)", () => {
+    it("maps SyntaxError mentioning JSON to UPSTREAM_BAD_RESPONSE 502", () => {
+        const r = mapErrorToAppError(
+            new SyntaxError(
+                "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON",
+            ),
+        );
+        expect(r.code).toBe(ErrorCode.UPSTREAM_BAD_RESPONSE);
+        expect(r.statusCode).toBe(502);
+    });
+
+    it("does NOT match a generic SyntaxError without 'JSON' in message", () => {
+        // Real-world JSON parse errors always include 'JSON' in the
+        // message; matching on it avoids accidentally classifying
+        // unrelated SyntaxErrors (e.g. from `eval`-shaped libraries) as
+        // upstream failures.
+        const r = mapErrorToAppError(new SyntaxError("unexpected token"));
+        expect(r.code).toBe(ErrorCode.INTERNAL_ERROR);
     });
 });

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -374,23 +374,22 @@ describe("errorId correlation", () => {
     });
 });
 
-describe("UPSTREAM_BAD_RESPONSE (SyntaxError backstop)", () => {
-    it("maps SyntaxError mentioning JSON to UPSTREAM_BAD_RESPONSE 502", () => {
+describe("raw SyntaxError handling", () => {
+    it("does NOT auto-map JSON SyntaxErrors at this layer", () => {
+        // A bare SyntaxError from `JSON.parse` / `Response.json()` /
+        // `Request.json()` is ambiguous: it could be a malformed
+        // upstream body OR a malformed client request body. Mapping it
+        // here would mis-classify one of them, so we deliberately let it
+        // fall through to `INTERNAL_ERROR` (500). Helpers that read
+        // upstream JSON wrap parsing in `safeParseJson` and throw a
+        // typed `AppError`; route handlers reading client bodies use
+        // `.catch(() => null)` and surface `MISSING_REQUIRED_FIELD`.
         const r = mapErrorToAppError(
             new SyntaxError(
                 "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON",
             ),
         );
-        expect(r.code).toBe(ErrorCode.UPSTREAM_BAD_RESPONSE);
-        expect(r.statusCode).toBe(502);
-    });
-
-    it("does NOT match a generic SyntaxError without 'JSON' in message", () => {
-        // Real-world JSON parse errors always include 'JSON' in the
-        // message; matching on it avoids accidentally classifying
-        // unrelated SyntaxErrors (e.g. from `eval`-shaped libraries) as
-        // upstream failures.
-        const r = mapErrorToAppError(new SyntaxError("unexpected token"));
         expect(r.code).toBe(ErrorCode.INTERNAL_ERROR);
+        expect(r.statusCode).toBe(500);
     });
 });

--- a/src/tests/regressions/132-plaud-user-agent.test.ts
+++ b/src/tests/regressions/132-plaud-user-agent.test.ts
@@ -69,12 +69,16 @@ const API_BASE = "https://api-apse1.plaud.ai";
 
 function mockJson(body: unknown, init?: { ok?: boolean; status?: number }) {
     const ok = init?.ok ?? true;
+    const serialised = JSON.stringify(body);
     return {
         ok,
         status: init?.status ?? (ok ? 200 : 400),
         statusText: ok ? "OK" : "Error",
         headers: { get: () => null },
         json: () => Promise.resolve(body),
+        // `safeParseJson` reads the body as text; mocks must mirror the
+        // real `Response` interface for both shapes to stay valid.
+        text: () => Promise.resolve(serialised),
     };
 }
 

--- a/src/tests/regressions/142-plaud-json-parse.test.ts
+++ b/src/tests/regressions/142-plaud-json-parse.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression test for issue #142 (and the OTP-flow path in #137):
+ *   "Plaud OTP Email - Failed to parse JSON"
+ *
+ * When Plaud's Cloudflare WAF 403s a request, the response body is an HTML
+ * challenge page rather than JSON. Pre-fix, `plaudSendCode` / `plaudVerifyOtp`
+ * called `await res.json()` unguarded \u2014 the raw `SyntaxError` escaped the
+ * helper, bypassed every `AppError` mapper, and `apiHandler` flattened it
+ * to `INTERNAL_ERROR` (500). The user saw "An unexpected error occurred"
+ * and the server logged `INTERNAL_ERROR SyntaxError: Failed to parse JSON`.
+ *
+ * The fix routes JSON parsing through `safeParseJson` (src/lib/plaud/parse.ts)
+ * which throws a status-mapped `AppError` instead of a raw `SyntaxError`.
+ *
+ * These tests assert the four affected helpers (`plaudSendCode`,
+ * `plaudVerifyOtp`, `listPlaudWorkspaces`, `mintPlaudWorkspaceToken`)
+ * convert a non-JSON 403 / 200 body into a structured `AppError` with the
+ * right `code`, HTTP `statusCode`, and a `bodySnippet` in `details`.
+ *
+ * Note: `client.ts:request` already had a catch-all that mapped raw errors
+ * to `PLAUD_UPSTREAM_ERROR` (502), so this test exists primarily for the
+ * auth + workspace helpers that lacked that net.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+import { AppError, ErrorCode } from "@/lib/errors";
+import { plaudSendCode, plaudVerifyOtp } from "@/lib/plaud/auth";
+import {
+    listPlaudWorkspaces,
+    mintPlaudWorkspaceToken,
+} from "@/lib/plaud/workspace";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+beforeAll(() => {
+    mockFetch = vi.fn() as Mock;
+    global.fetch = mockFetch as typeof global.fetch;
+});
+
+afterAll(() => {
+    global.fetch = originalFetch;
+});
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+const API_BASE = "https://api-euc1.plaud.ai";
+const HTML_BODY =
+    "<!DOCTYPE html><html><head><title>Attention Required! | Cloudflare</title></head><body>...</body></html>";
+
+/**
+ * Build a mock `Response` whose `.text()` returns a Cloudflare-shaped HTML
+ * body and whose `.json()` would throw \u2014 i.e. exactly what Plaud returns
+ * when its WAF rejects a request.
+ *
+ * `listPlaudWorkspaces` short-circuits on `!res.ok` *before* parsing the
+ * body and throws `PLAUD_API_ERROR` directly, so its assertion is on the
+ * code, not on a body snippet. The auth helpers parse the body
+ * unconditionally and route through `safeParseJson`.
+ */
+function mockCloudflare403() {
+    return {
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        headers: { get: () => null },
+        text: () => Promise.resolve(HTML_BODY),
+        json: () =>
+            Promise.reject(
+                new SyntaxError(
+                    "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON",
+                ),
+            ),
+    };
+}
+
+/**
+ * Same shape but HTTP 200 \u2014 simulates a WAF that returns a challenge
+ * page with a successful status (rare, but possible on some Cloudflare
+ * configurations). Exercises the success-path defensive parse.
+ */
+function mock200Html() {
+    return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { get: () => null },
+        text: () => Promise.resolve(HTML_BODY),
+        json: () =>
+            Promise.reject(
+                new SyntaxError(
+                    "Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON",
+                ),
+            ),
+    };
+}
+
+describe("issue #142: non-JSON Plaud response \u2192 structured AppError", () => {
+    it("plaudSendCode on Cloudflare 403 throws PLAUD_API_ERROR, not SyntaxError", async () => {
+        mockFetch.mockResolvedValueOnce(mockCloudflare403());
+        await expect(
+            plaudSendCode("user@example.com", API_BASE),
+        ).rejects.toMatchObject({
+            // Crucially NOT a `SyntaxError` \u2014 that's the pre-fix bug.
+            name: "AppError",
+            code: ErrorCode.PLAUD_API_ERROR,
+            statusCode: 400,
+            details: expect.objectContaining({
+                plaudStatus: 403,
+                bodySnippet: expect.stringContaining("<!DOCTYPE"),
+            }),
+        });
+    });
+
+    it("plaudSendCode on 200 with HTML body throws PLAUD_UPSTREAM_ERROR", async () => {
+        mockFetch.mockResolvedValueOnce(mock200Html());
+        try {
+            await plaudSendCode("user@example.com", API_BASE);
+            throw new Error("should have thrown");
+        } catch (err) {
+            expect(err).toBeInstanceOf(AppError);
+            expect((err as AppError).code).toBe(ErrorCode.PLAUD_UPSTREAM_ERROR);
+            expect((err as AppError).statusCode).toBe(502);
+        }
+    });
+
+    it("plaudVerifyOtp on Cloudflare 403 throws PLAUD_API_ERROR, not SyntaxError", async () => {
+        mockFetch.mockResolvedValueOnce(mockCloudflare403());
+        await expect(
+            plaudVerifyOtp("123456", "otp.token", API_BASE),
+        ).rejects.toMatchObject({
+            name: "AppError",
+            code: ErrorCode.PLAUD_API_ERROR,
+            statusCode: 400,
+        });
+    });
+
+    it("listPlaudWorkspaces on Cloudflare 403 throws PLAUD_API_ERROR (existing !res.ok branch)", async () => {
+        mockFetch.mockResolvedValueOnce(mockCloudflare403());
+        // This helper had a pre-existing `!res.ok` guard so it already
+        // produced `PLAUD_API_ERROR` before #142; the fix preserves that
+        // behavior and adds defensive parse on the success path.
+        await expect(
+            listPlaudWorkspaces("ut.token", API_BASE),
+        ).rejects.toMatchObject({
+            name: "AppError",
+            code: ErrorCode.PLAUD_API_ERROR,
+        });
+    });
+
+    it("mintPlaudWorkspaceToken on Cloudflare 403 throws WorkspaceTokenError (existing !res.ok branch)", async () => {
+        mockFetch.mockResolvedValueOnce(mockCloudflare403());
+        await expect(
+            mintPlaudWorkspaceToken("ut.token", "ws_x", API_BASE),
+        ).rejects.toMatchObject({
+            // Pre-existing typed error \u2014 same as listPlaudWorkspaces,
+            // here purely as a guard that the fix didn't regress the
+            // status-401 / stale-cache contract that downstream relies on.
+            name: "WorkspaceTokenError",
+        });
+    });
+});

--- a/src/tests/regressions/66-eu-otp-permissions.test.ts
+++ b/src/tests/regressions/66-eu-otp-permissions.test.ts
@@ -64,13 +64,20 @@ function mockResponse({ ok = true, status = 200, body }: MockResponseInit): {
     statusText: string;
     headers: { get: () => null };
     json: () => Promise<unknown>;
+    text: () => Promise<string>;
 } {
+    const serialised = JSON.stringify(body);
     return {
         ok,
         status,
         statusText: ok ? "OK" : "Error",
         headers: { get: () => null },
         json: () => Promise.resolve(body),
+        // Mirror the real `Response` interface — `safeParseJson` consumes
+        // the body via `.text()` and parses it manually so a non-JSON
+        // upstream body produces a typed `AppError` instead of a raw
+        // `SyntaxError`. See #142.
+        text: () => Promise.resolve(serialised),
     };
 }
 


### PR DESCRIPTION
## Description

Two related changes that together stop user-fixable upstream failures from being reported as opaque 500s, and give users a way to file bugs without leaving the app.

Independently verified that issues #137 and #142 reduce to the same Plaud Cloudflare WAF rejection: `await res.json()` on an HTML challenge body throws a raw `SyntaxError` that `apiHandler` flattens to `INTERNAL_ERROR` (500). The first half of the underlying fix (User-Agent header) already landed on `main` in #136 but hasn't shipped in a tagged release; this PR is the structural half so the next WAF tightening produces a meaningful error rather than mystery.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #142
Refs #137 (OTP-flow path)

## Changes Made

Three commits, in dependency order:

**1. `fix(errors)` — errorId on 5xx + UPSTREAM_BAD_RESPONSE backstop**
- `details.errorId` (`err_xxxxxxxx`) attached to every `>=500` response and prefixed in the matching `console.error` log line. In-memory only, no schema. Idempotent so the response envelope and log line agree even when an `AppError` flows through both `errorResponse` and `apiHandler`.
- New `UPSTREAM_BAD_RESPONSE` (502) error code. `mapErrorToAppError` now backstops raw `SyntaxError`s mentioning JSON to this code instead of `INTERNAL_ERROR`.
- `docs/error-codes.md` updated.

**2. `fix(plaud)` — defensive JSON parsing**
- New `src/lib/plaud/parse.ts` exporting `safeParseJson<T>(res)`. Reads body via `.text()` (with `.json()` fallback for legacy mocks), parses manually, throws a status-mapped `AppError` (`PLAUD_INVALID_TOKEN` / `PLAUD_RATE_LIMITED` / `PLAUD_UPSTREAM_ERROR` / `PLAUD_API_ERROR`) with `plaudStatus` and a 200-char `bodySnippet` in `details`.
- Applied to `plaudSendCode`, `plaudVerifyOtp`, `listPlaudWorkspaces`, `mintPlaudWorkspaceToken`, and the success path of `PlaudClient.request`.
- `.text()` itself throwing (aborted/killed connection) is classified as `PLAUD_UPSTREAM_ERROR` 502 rather than letting a raw `TypeError` escape.

**3. `feat(reporting)` — in-app bug-report path**
- `toastApiError(response, opts?)` in `src/lib/api-errors.ts` — extends the existing `parseApiError` chokepoint. When `details.errorId` is present (5xx), the toast renders a one-click `[Report]` action that opens GitHub with the errorId pre-filled. Single-click reporting, no dialog.
- New `src/components/report-bug-dialog.tsx` mounted from the footer. "Report on GitHub" always; "Email us" (`support@openplaud.com`) on hosted only. Preview shows exactly what's being sent before the user clicks.
- `src/lib/report-bug.ts` builds the URLs (GitHub Issue Form query-string pre-fill + `mailto:`).
- `plaud-connect-tabs.tsx` four error sites migrated to `toastApiError` so connect/verify/paste-token failures immediately benefit.
- `bug_report.yml` `deployment` dropdown collapsed from 4 install-method options to 2 surface options: `Self-hosted` / `Hosted (openplaud.com)`. Install method is secondary triage noise.

## Testing

```
$ pnpm format-and-lint:fix
Checked 341 files. No fixes applied. (2 pre-existing info-level lint suggestions in admin/elevated-cookie.test.ts, untouched here)

$ pnpm type-check
clean

$ pnpm test
Test Files  44 passed | 1 skipped (45)
     Tests  336 passed | 3 skipped (339)
```

New tests:
- `src/tests/regressions/142-plaud-json-parse.test.ts` — pins the four helpers' behavior on a Cloudflare-shaped HTML 403. Asserts structured `AppError` (not `SyntaxError`) with correct `code`, `statusCode`, `details.plaudStatus`, and a `bodySnippet`.
- `src/tests/errors.test.ts` — new `errorId correlation` and `UPSTREAM_BAD_RESPONSE (SyntaxError backstop)` describe blocks. Verifies errorId present on `>=500`, absent on `<500`, preserves existing details, included in log line, and `errorResponse` also attaches it.

Updated tests:
- `132-plaud-user-agent.test.ts`, `66-eu-otp-permissions.test.ts` mock helpers now mirror the real `Response` interface (`.text()` + `.json()`) since `safeParseJson` prefers `.text()` for body snippeting.

Verified Node-side repro (matches reporter symptom byte-for-byte) before this fix:

```
Node fetch NO UA  → 403, content-type: text/html, body: <!DOCTYPE html>...
                    JSON.parse: PARSE FAIL: Unexpected token '<'
```

Plus issue template renders correctly: `?template=bug_report.yml&description=...&deployment=Self-hosted&version=v0.4.2` query-string pre-fill verified against GitHub Issue Form docs and the existing field IDs in `bug_report.yml`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/error-codes.md`)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. `UPSTREAM_BAD_RESPONSE` is additive to the `ErrorCode` enum. `details.errorId` is an additive field. The `bug_report.yml` deployment-dropdown change is GitHub metadata; old open issues keep their previous answer string unchanged.

## Deploy-surface impact

**None.** No schema, no env vars, no docker-compose change, no install-script change. `SUPPORT_EMAIL` is a hardcoded constant. `errorId` is in-memory and lost on process restart.

## For Reviewers

- The toast `[Report]` action opens GitHub directly (no dialog) because the toast is a 5-second moment and single-click matters. Hosted users who prefer email discover the mailto via the footer "Report a bug" → dialog.
- `isHosted` is optional in `ReportBugOptions` so the client-side toast (no `env.IS_HOSTED` access) doesn't lie about deployment mode. When unknown, the GitHub form just shows an empty dropdown the user picks.
- `attachErrorId` is idempotent on `app.details.errorId` so a rethrow through both `errorResponse` and `apiHandler` doesn't desync the response from the log.
- The `safeParseJson` fallback to `.json()` when `.text()` isn't a function exists purely so legacy test mocks keep working — production `Response` always implements both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defensively parses Plaud responses to stop opaque 500s when Cloudflare returns HTML, and adds a one‑click in‑app bug reporting flow. Fixes #142; improves the OTP path noted in #137.

- **Bug Fixes**
  - Add `details.errorId` to all 5xx responses and include it in the matching log line for easy correlation.
  - Parse Plaud JSON via `safeParseJson` (reads `.text()`, returns typed errors with `plaudStatus` and a `bodySnippet`); applied to auth/workspace helpers and `PlaudClient.request`. Aborted reads surface as `PLAUD_UPSTREAM_ERROR` (502). New regression tests cover Cloudflare‑shaped HTML bodies; mocks updated to expose `.text()`.
  - Do not auto‑map raw JSON `SyntaxError`s at the global layer; helpers throw typed errors instead. `UPSTREAM_BAD_RESPONSE` stays available for explicit use; docs updated.

- **New Features**
  - `toastApiError`: shows error toasts and, on 5xx with `errorId`, a one‑click Report action that opens a pre‑filled GitHub issue; used in `plaud-connect-tabs`. Mailto/GitHub URLs use RFC 6068‑correct encoding.
  - Footer “Report a bug” dialog with GitHub (always) and email (hosted) options and a pre‑send preview; replaces the hosted‑only “Support” mailto. Simplifies `bug_report.yml` deployment dropdown to “Self-hosted” / “Hosted (openplaud.com)”.

<sup>Written for commit c9035427b85c836a1b2f717f180b853fabf6a393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

