### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.0] - 2026-05-15
 
 ### Added
 - Automation API: versioned `/api/v1/recordings` namespace for external agents (list with cursor pagination + `created_since` / `updated_since` / `has_transcription` filters, get, transcript, metadata, audio redirect). Personal API keys (`op_...` prefix, HMAC-SHA256 hashed at rest keyed by `API_TOKEN_HASH_SECRET ?? BETTER_AUTH_SECRET`, revocable, with `source` / `name` / `lastUsedAt` metadata) managed from Settings. Per-IP and per-identity rate limits on `/api/v1/*` (1200/min IP, 600/min identity) with `Retry-After` and `X-RateLimit-*` headers. Signed webhooks (HMAC-SHA256, `t=...,v1=...` header) for `recording.synced`, `recording.updated`, `recording.deleted`, `transcription.completed`, `transcription.failed` with URL + secret encrypted at rest, exponential backoff (30s -> 6h, then dead), DB-leased worker, manual redelivery, and a deliveries inspector. Webhook target policy switches on `WEBHOOKS_REQUIRE_PUBLIC_TARGETS ?? IS_HOSTED`: self-host defaults permissive so docker-bridge URLs like `http://n8n:5678/webhook` keep working. Full reference in `docs/API.md` ([#118](https://github.com/openplaud/openplaud/pull/118)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.5.0] - 2026-05-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.5.0 + open [Unreleased] section for next cycle.

Pushed via branch because direct pushes to `main` are blocked by branch protection. Merge with **Create a merge commit** (not squash) so the `v0.5.0` tag points to a real commit on `main`. Tag will be pushed after merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.5.0: ships Automation API v1 (`/api/v1/recordings`) with filters, personal API keys, per‑IP/identity rate limits, and signed webhooks with retries and an inspector. Adds the docs site at `/docs` plus LLM routes (`/llms.txt`, `/llms-full.txt`), and opens [Unreleased] for the next cycle.

<sup>Written for commit 0984bc364169e922df835b265758a35fcd7615af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

