### PR TITLE
chore(release): rewrite release script to use PR flow

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -22,15 +22,36 @@ Every push to `main` additionally publishes `:dev` — opt-in rolling image for 
 
 ## Cutting a release
 
-1. Land the last PR into `main`. CI must be green.
-2. Update `CHANGELOG.md`: move items from `[Unreleased]` into a new `[X.Y.Z]` section with today's date. Commit to `main`.
-3. Tag and push:
-   ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
-   ```
-4. Wait for `docker.yml` and `release.yml` to finish.
-5. Review the draft release on GitHub, edit notes if needed, publish.
+`main` is protected with required status checks, so releases go through a PR like everything else. The release script handles this in two phases.
+
+### Phase 1 — open the release PR
+
+From a clean `main` that's in sync with `origin/main`:
+
+```bash
+bun scripts/release.ts <major|minor|patch>
+# or an explicit version:
+bun scripts/release.ts 0.6.0
+```
+
+This bumps `package.json`, rewrites `## [Unreleased]` → `## [X.Y.Z] - <date>` in `CHANGELOG.md`, re-adds an empty `[Unreleased]` section, commits both on a `release/vX.Y.Z` branch, pushes the branch, and opens a PR via `gh`. **No tag is created yet.** Local `main` is restored to `origin/main` before the script exits so the working tree stays clean while the PR is in review.
+
+### Phase 2 — finalize after merge
+
+Wait for the required checks to pass, then merge the PR. Merge-commit is preferred (preserves the release commit's SHA on `main`); squash also works because GitHub uses the PR title as the squash subject, which matches the pattern the finalize step greps for.
+
+Then:
+
+```bash
+bun scripts/release.ts finalize
+```
+
+This fetches `origin/main`, reads the merged version from `package.json`, finds the release commit by message, creates and pushes the `vX.Y.Z` tag, and deletes the `release/vX.Y.Z` branch. The tag push triggers `docker.yml` and `release.yml`.
+
+### After both phases
+
+1. Wait for `docker.yml` and `release.yml` to finish.
+2. Review the draft release on GitHub, edit notes if needed, publish.
 
 ## Hotfixes (when needed)
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -42,7 +42,9 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const TARGET = process.argv[2];
 const BUMP_TYPES = new Set(["major", "minor", "patch"]);
@@ -234,7 +236,11 @@ function phase1(target: string): void {
 
 	// Write the PR body to a temp file rather than passing it inline — long
 	// multiline strings on the shell command line get mangled by quoting.
-	const bodyPath = `/tmp/openplaud-release-pr-${version}.md`;
+	// Use mkdtempSync for a fresh, unpredictable directory so a pre-planted
+	// symlink in the system temp dir can't redirect the write
+	// (js/insecure-temporary-file).
+	const tmpDir = mkdtempSync(join(tmpdir(), "openplaud-release-"));
+	const bodyPath = join(tmpDir, `pr-body-v${version}.md`);
 	writeFileSync(bodyPath, prBody);
 	run(
 		`gh pr create --base main --head ${branch} --title "chore(release): v${version}" --body-file ${bodyPath}`,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -2,29 +2,43 @@
 /**
  * Release script for OpenPlaud.
  *
- * Usage:
+ * Two phases, because `main` is protected and direct pushes are
+ * rejected by required status checks.
+ *
+ * Phase 1 — open the release PR:
  *   bun scripts/release.ts <major|minor|patch>
  *   bun scripts/release.ts <x.y.z>
  *
- * Steps:
- *   1. Verify clean working tree on main
- *   2. Bump version in package.json
- *   3. Rewrite CHANGELOG.md: [Unreleased] -> [X.Y.Z] - <date>
- *   4. Commit (release commit), tag vX.Y.Z
- *   5. Re-add empty [Unreleased] section, commit
- *   6. Push main + tag in one atomic push
+ * Phase 2 — after the PR is merged, tag the release commit:
+ *   bun scripts/release.ts finalize
  *
- * The push is atomic on purpose: if `main` has diverged on the remote,
- * the whole push fails and the tag isn't published, so we never end up
- * in a state where the tag exists but `main` doesn't include the
- * version bump (that's how `package.json` drifted to `0.2.0` behind
- * `v0.4.1` before — see issue #123). Rebase locally and rerun.
+ * ---------------------------------------------------------------
+ * Phase 1 steps:
+ *   1. Verify clean working tree on main, in sync with origin/main.
+ *   2. Bump version in package.json.
+ *   3. Rewrite CHANGELOG.md: [Unreleased] -> [X.Y.Z] - <date>.
+ *   4. Branch to `release/vX.Y.Z`.
+ *   5. Commit `chore(release): vX.Y.Z`.
+ *   6. Re-add empty [Unreleased] section, commit.
+ *   7. Push branch (NO tag yet — tag is created in phase 2).
+ *   8. Open a PR via `gh` with merge-commit guidance.
+ *   9. Reset local main to origin/main so the maintainer isn't left
+ *      "2 ahead" while the PR is in review.
  *
- * After push, GitHub workflows (docker.yml, release.yml) take over.
- * Per AGENTS.md, agents do not invoke this — it's a maintainer action.
+ * Phase 2 steps:
+ *   1. Fetch origin.
+ *   2. Read target version from package.json on origin/main.
+ *   3. Refuse if the tag already exists locally or remotely.
+ *   4. Locate the release commit on origin/main via
+ *      `git log --grep="^chore(release): vX.Y.Z$"`.
+ *   5. Create the tag pointing at that commit, push it.
+ *   6. Delete the release/vX.Y.Z branch (local + remote).
  *
- * Files staged are explicitly listed (package.json, CHANGELOG.md). No
- * `git add -A` / `git add .` — see AGENTS.md.
+ * The tag push triggers docker.yml and release.yml. Per AGENTS.md,
+ * agents do not invoke this — it's a maintainer action.
+ *
+ * Staged files in phase 1 are an explicit allowlist (package.json,
+ * CHANGELOG.md). No `git add -A` / `git add .` — see AGENTS.md.
  */
 
 import { execSync } from "node:child_process";
@@ -35,10 +49,14 @@ const BUMP_TYPES = new Set(["major", "minor", "patch"]);
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 const STAGED_FILES = ["package.json", "CHANGELOG.md"];
 
-if (!TARGET || (!BUMP_TYPES.has(TARGET) && !SEMVER_RE.test(TARGET))) {
-	console.error("Usage: bun scripts/release.ts <major|minor|patch|x.y.z>");
+function usage(): never {
+	console.error("Usage:");
+	console.error("  bun scripts/release.ts <major|minor|patch|x.y.z>   # phase 1: open PR");
+	console.error("  bun scripts/release.ts finalize                    # phase 2: tag after merge");
 	process.exit(1);
 }
+
+if (!TARGET) usage();
 
 function run(cmd: string, opts: { silent?: boolean } = {}): string {
 	if (!opts.silent) console.log(`$ ${cmd}`);
@@ -50,8 +68,21 @@ function run(cmd: string, opts: { silent?: boolean } = {}): string {
 	}
 }
 
-function readPkg(): { version: string } {
-	return JSON.parse(readFileSync("package.json", "utf-8"));
+function tryRun(cmd: string, opts: { silent?: boolean } = {}): string | null {
+	try {
+		return execSync(cmd, { encoding: "utf-8", stdio: opts.silent ? "pipe" : "inherit" }) ?? "";
+	} catch {
+		return null;
+	}
+}
+
+function readPkgVersion(): string {
+	return JSON.parse(readFileSync("package.json", "utf-8")).version as string;
+}
+
+function readPkgVersionFromRef(ref: string): string {
+	const raw = run(`git show ${ref}:package.json`, { silent: true });
+	return JSON.parse(raw).version as string;
 }
 
 function compareVersions(a: string, b: string): number {
@@ -65,7 +96,7 @@ function compareVersions(a: string, b: string): number {
 }
 
 function bumpVersion(target: string): string {
-	const current = readPkg().version;
+	const current = readPkgVersion();
 	if (BUMP_TYPES.has(target)) {
 		run(`npm version ${target} --no-git-tag-version`);
 	} else {
@@ -75,7 +106,7 @@ function bumpVersion(target: string): string {
 		}
 		run(`npm version ${target} --no-git-tag-version`);
 	}
-	return readPkg().version;
+	return readPkgVersion();
 }
 
 function updateChangelogForRelease(version: string): void {
@@ -97,7 +128,15 @@ function stage(): void {
 	run(`git add -- ${STAGED_FILES.join(" ")}`);
 }
 
-function assertCleanOnMain(): void {
+function assertGhAvailable(): void {
+	const ok = tryRun("gh auth status", { silent: true });
+	if (ok === null) {
+		console.error("Error: `gh` CLI not available or not authenticated. Run `gh auth login`.");
+		process.exit(1);
+	}
+}
+
+function assertCleanOnMainInSync(): void {
 	const branch = run("git rev-parse --abbrev-ref HEAD", { silent: true }).trim();
 	if (branch !== "main") {
 		console.error(`Error: must release from main, currently on '${branch}'.`);
@@ -109,57 +148,180 @@ function assertCleanOnMain(): void {
 		console.error(status);
 		process.exit(1);
 	}
+	run("git fetch origin main --tags", { silent: true });
+	const local = run("git rev-parse main", { silent: true }).trim();
+	const remote = run("git rev-parse origin/main", { silent: true }).trim();
+	if (local !== remote) {
+		console.error("Error: local main is not in sync with origin/main.");
+		console.error(`  local : ${local}`);
+		console.error(`  remote: ${remote}`);
+		console.error("Run `git pull --rebase` (or reconcile manually) and retry.");
+		process.exit(1);
+	}
 }
 
-console.log("\n=== OpenPlaud Release ===\n");
+function phase1(target: string): void {
+	console.log("\n=== OpenPlaud Release — Phase 1 (open PR) ===\n");
+	assertGhAvailable();
+	assertCleanOnMainInSync();
 
-assertCleanOnMain();
+	console.log("Bumping version...");
+	const version = bumpVersion(target);
+	const branch = `release/v${version}`;
+	console.log(`  -> ${version}\n`);
 
-console.log("Bumping version...");
-const version = bumpVersion(TARGET);
-console.log(`  -> ${version}\n`);
+	// Bail early if the branch or tag already exists anywhere — otherwise
+	// we end up with a half-finished release and the user has to clean up
+	// twice. Cheaper to refuse up front.
+	if (tryRun(`git rev-parse --verify ${branch}`, { silent: true }) !== null) {
+		console.error(`Error: local branch '${branch}' already exists. Delete it or finish the prior release.`);
+		process.exit(1);
+	}
+	const remoteBranch = tryRun(`git ls-remote --exit-code --heads origin ${branch}`, { silent: true });
+	if (remoteBranch !== null) {
+		console.error(`Error: remote branch '${branch}' already exists on origin.`);
+		process.exit(1);
+	}
+	const localTag = tryRun(`git rev-parse --verify refs/tags/v${version}`, { silent: true });
+	if (localTag !== null) {
+		console.error(`Error: tag v${version} already exists locally.`);
+		process.exit(1);
+	}
+	const remoteTag = tryRun(`git ls-remote --exit-code --tags origin refs/tags/v${version}`, { silent: true });
+	if (remoteTag !== null) {
+		console.error(`Error: tag v${version} already exists on origin.`);
+		process.exit(1);
+	}
 
-console.log("Updating CHANGELOG.md...");
-updateChangelogForRelease(version);
+	console.log("Updating CHANGELOG.md...");
+	updateChangelogForRelease(version);
 
-console.log("Committing release...");
-stage();
-run(`git commit -m "chore(release): v${version}"`);
-run(`git tag v${version}`);
+	console.log(`Creating branch ${branch}...`);
+	run(`git checkout -b ${branch}`);
 
-console.log("Adding [Unreleased] section for next cycle...");
-addUnreleasedSection();
-stage();
-run(`git commit -m "chore: add [Unreleased] section for next cycle"`);
+	console.log("Committing release...");
+	stage();
+	run(`git commit -m "chore(release): v${version}"`);
 
-console.log("\nPushing main + tag atomically...");
-// `--atomic` makes the push a single transaction: either every ref
-// update lands or none of them do. Without it, git pushes refs
-// sequentially and the tag could be published while `main` is
-// rejected (or vice versa) -- the exact half-state we're trying to
-// prevent.
-//
-// If the push fails (diverged remote, server-side hook reject), the
-// local tag and the two new commits stay on the local main. We catch
-// the failure explicitly here so we can print recovery commands
-// rather than dying through run()'s generic handler -- otherwise the
-// maintainer's next attempt trips on `git tag` (already exists) and
-// `assertCleanOnMain` (the two commits are ahead of origin/main).
-try {
-	execSync(`git push --atomic origin main v${version}`, { stdio: "inherit" });
-} catch {
-	console.error("\nError: push failed. Local state still has:");
-	console.error(`  - tag v${version}`);
-	console.error("  - 2 commits ahead of origin/main (release + [Unreleased] cycle)");
-	console.error("\nTo retry after rebasing:");
-	console.error(`  git tag -d v${version}`);
-	console.error("  git reset --hard origin/main");
-	console.error("  git pull --rebase origin main");
-	console.error("  bun scripts/release.ts <target>");
-	process.exit(1);
+	console.log("Adding [Unreleased] section for next cycle...");
+	addUnreleasedSection();
+	stage();
+	run(`git commit -m "chore: add [Unreleased] section for next cycle"`);
+
+	console.log("\nPushing release branch...");
+	run(`git push -u origin ${branch}`);
+
+	console.log("\nOpening PR...");
+	const prBody = [
+		`Release v${version}.`,
+		"",
+		"**Merge instructions:**",
+		"",
+		'Use **"Create a merge commit"** (not squash). The release commit\'s message',
+		"is used by `bun scripts/release.ts finalize` to locate the commit to tag.",
+		"Squash-merge still works (GitHub uses the PR title as the squash subject),",
+		"but a merge commit preserves history more cleanly.",
+		"",
+		"After this PR is merged, run:",
+		"",
+		"```bash",
+		"bun scripts/release.ts finalize",
+		"```",
+		"",
+		"That will create and push the `v" + version + "` tag, which triggers",
+		"`docker.yml` and `release.yml`.",
+	].join("\n");
+
+	// Write the PR body to a temp file rather than passing it inline — long
+	// multiline strings on the shell command line get mangled by quoting.
+	const bodyPath = `/tmp/openplaud-release-pr-${version}.md`;
+	writeFileSync(bodyPath, prBody);
+	run(
+		`gh pr create --base main --head ${branch} --title "chore(release): v${version}" --body-file ${bodyPath}`,
+	);
+
+	// Restore local main so we aren't left "2 ahead" with stale package.json
+	// + CHANGELOG.md edits while the PR sits in review. The branch we pushed
+	// is the source of truth for the release commits now.
+	console.log("\nRestoring local main to origin/main...");
+	run("git checkout main");
+	run(`git branch -D ${branch}`);
+
+	console.log(`\n=== Phase 1 complete: PR opened for v${version} ===`);
+	console.log("Next steps:");
+	console.log("  1. Wait for required checks on the PR to pass.");
+	console.log("  2. Merge the PR (merge commit preferred; squash works too).");
+	console.log("  3. Run: bun scripts/release.ts finalize");
 }
 
-console.log(`\n=== Released v${version} ===`);
-console.log("Next steps:");
-console.log("  1. Wait for docker.yml + release.yml workflows");
-console.log("  2. Review and publish the draft GitHub Release");
+function phase2Finalize(): void {
+	console.log("\n=== OpenPlaud Release — Phase 2 (finalize) ===\n");
+
+	console.log("Fetching origin...");
+	run("git fetch origin main --tags", { silent: true });
+
+	const version = readPkgVersionFromRef("origin/main");
+	console.log(`Target version (from origin/main package.json): ${version}`);
+
+	const localTag = tryRun(`git rev-parse --verify refs/tags/v${version}`, { silent: true });
+	if (localTag !== null) {
+		console.error(`Error: tag v${version} already exists locally. Aborting to avoid double-tagging.`);
+		process.exit(1);
+	}
+	const remoteTag = tryRun(`git ls-remote --exit-code --tags origin refs/tags/v${version}`, { silent: true });
+	if (remoteTag !== null) {
+		console.error(`Error: tag v${version} already exists on origin. Aborting.`);
+		process.exit(1);
+	}
+
+	// Find the release commit on origin/main. The release commit's subject
+	// is `chore(release): vX.Y.Z`. GitHub's default squash subject is the
+	// PR title, which we set to the same string, so this --grep works for
+	// both merge-commit and squash-merge PRs.
+	const matches = run(
+		`git log origin/main --grep=^chore\\(release\\):\\ v${version}$ --extended-regexp --format=%H`,
+		{ silent: true },
+	)
+		.trim()
+		.split("\n")
+		.filter(Boolean);
+
+	if (matches.length === 0) {
+		console.error(`Error: no commit on origin/main matches 'chore(release): v${version}'.`);
+		console.error("Was the PR merged? Did the subject get rewritten?");
+		process.exit(1);
+	}
+	if (matches.length > 1) {
+		console.error(`Error: multiple commits on origin/main match 'chore(release): v${version}':`);
+		for (const sha of matches) console.error(`  ${sha}`);
+		console.error("Resolve manually with `git tag v" + version + " <sha> && git push origin v" + version + "`.");
+		process.exit(1);
+	}
+	const sha = matches[0];
+	console.log(`Release commit: ${sha}`);
+
+	console.log("Tagging and pushing...");
+	run(`git tag v${version} ${sha}`);
+	run(`git push origin v${version}`);
+
+	// Best-effort branch cleanup. Don't fail the whole finalize if these
+	// don't exist — the user may have already deleted them via the GitHub
+	// UI's "Delete branch" button after merge.
+	const branch = `release/v${version}`;
+	console.log(`\nCleaning up ${branch} (best effort)...`);
+	tryRun(`git branch -D ${branch}`, { silent: true });
+	tryRun(`git push origin --delete ${branch}`, { silent: true });
+
+	console.log(`\n=== Released v${version} ===`);
+	console.log("Next steps:");
+	console.log("  1. Wait for docker.yml + release.yml workflows.");
+	console.log("  2. Review and publish the draft GitHub Release.");
+}
+
+if (TARGET === "finalize") {
+	phase2Finalize();
+} else if (BUMP_TYPES.has(TARGET) || SEMVER_RE.test(TARGET)) {
+	phase1(TARGET);
+} else {
+	usage();
+}


### PR DESCRIPTION
Rewrites `scripts/release.ts` so it works against `main`'s branch protection (required status checks reject the current direct-push flow).

## Phase 1 — `bun scripts/release.ts <bump|x.y.z>`

- Bumps `package.json`, rewrites `## [Unreleased]` → `## [X.Y.Z] - <date>`, re-adds an empty `[Unreleased]` section.
- Commits both on a `release/vX.Y.Z` branch.
- Pushes the branch, opens a PR via `gh`. **No tag created yet.**
- Restores local `main` to `origin/main` before exit.
- Bails early if the branch or tag already exists.

## Phase 2 — `bun scripts/release.ts finalize`

- Fetches `origin/main`.
- Reads target version from the merged `package.json`.
- Finds the release commit by `git log --grep="^chore(release): vX.Y.Z$"` — works for both merge-commit and squash-merge PRs (GitHub uses the PR title as the squash subject).
- Tags the commit, pushes the tag (which triggers `docker.yml` + `release.yml`).
- Cleans up the `release/vX.Y.Z` branch.

## Docs

`BRANCHING.md` release section rewritten to document both phases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite `scripts/release.ts` to a two-phase, PR-based release that respects `main` branch protections and triggers workflows via tags. Docs updated in `BRANCHING.md`.

- **New Features**
  - Phase 1: `bun scripts/release.ts <major|minor|patch|x.y.z>` — bumps `package.json`, rewrites `CHANGELOG.md`, creates `release/vX.Y.Z`, pushes, opens a PR via `gh`; no tag; verifies clean, synced `main` and bails if branch/tag exists; restores local `main`.
  - Phase 2: `bun scripts/release.ts finalize` — reads version from `origin/main`, finds the `chore(release): vX.Y.Z` commit (merge or squash), creates and pushes the tag to trigger `docker.yml`/`release.yml`, then deletes the `release/vX.Y.Z` branch.

- **Bug Fixes**
  - Use `mkdtempSync` for the PR body temp file to avoid predictable paths and satisfy CodeQL’s insecure temporary file check.

<sup>Written for commit d319703f481fe053e80c8ca833b55a6f8090597b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

