### PR TITLE
fix(plaud): optional residential proxy for outbound calls (closes #137)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,19 @@ APP_URL=http://localhost:3000
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 
+# Plaud outbound proxy (HOSTED-ONLY in practice -- most self-hosters do
+# not need this). Plaud's API sits behind Cloudflare with aggressive
+# bot/datacenter-ASN filtering. From flagged VPS IPs (Contabo, OVH, ...)
+# every Plaud endpoint returns a 403 + Cloudflare HTML challenge at the
+# edge regardless of token, region, or headers. Setting WEBSHARE_API_KEY
+# routes Plaud-bound calls (api*.plaud.ai, resource.plaud.ai) through
+# a residential proxy from your Webshare account, with automatic
+# rotation on rejection. Unset (default) keeps every call on the direct
+# egress path -- the right default for residential / homelab IPs that
+# Cloudflare doesn't flag. No effect on non-Plaud outbound traffic
+# (S3, AI providers, SMTP, GitHub release check).
+# WEBSHARE_API_KEY=
+
 # Storage Configuration
 DEFAULT_STORAGE_TYPE=local
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Optional outbound proxy for Plaud API calls via Webshare residential proxies. When `WEBSHARE_API_KEY` is set, every request to `api*.plaud.ai` / `resource.plaud.ai` routes through a random valid proxy from the Webshare list, with automatic rotation on Cloudflare 403/407 responses. Unset (default) keeps the direct egress path. Required for hosted deployments on flagged datacenter ASNs where Cloudflare returns a 403 HTML challenge before requests reach Plaud's origin; not needed for residential / homelab self-hosts. No effect on non-Plaud outbound traffic. `scripts/plaud-egress-probe.sh` can validate proxy behavior end-to-end against a real account.
+
 ## [0.5.0] - 2026-05-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "react-hook-form": "^7.66.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
+        "undici": "^7.16.0",
         "vitest": "^4.0.12",
         "zod": "^4.1.12"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      undici:
+        specifier: ^7.16.0
+        version: 7.25.0
       vitest:
         specifier: ^4.0.12
         version: 4.0.12(@types/debug@4.1.13)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
@@ -4647,6 +4650,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -10051,6 +10058,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/scripts/plaud-egress-probe.sh
+++ b/scripts/plaud-egress-probe.sh
@@ -40,10 +40,11 @@ TOKEN_PREFIX="${TOKEN:0:12}..."
 WEBSHARE_PROXY_LABEL=""
 if [[ -n "${WEBSHARE_API_KEY:-}" ]]; then
     WEBSHARE_JSON_FILE="$(mktemp)"
-    curl -sS --max-time 15 \
+    WEBSHARE_HTTP_STATUS="$(curl -sS --max-time 15 \
         -H "Authorization: Token ${WEBSHARE_API_KEY}" \
         'https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=100' \
-        -o "$WEBSHARE_JSON_FILE" || true
+        -o "$WEBSHARE_JSON_FILE" \
+        -w '%{http_code}' || true)"
 
     # Pick a random valid proxy. Use node (already required by the app)
     # so we don't depend on jq or python on the host. Writes two lines:
@@ -74,13 +75,15 @@ JS
         WEBSHARE_PROXY_LABEL="$(sed -n '2p' "$WEBSHARE_PICK_FILE")"
         export HTTPS_PROXY
     else
-        echo "WEBSHARE_API_KEY set but Webshare returned no valid proxies (or node missing); continuing direct" >&2
-        # Show what Webshare returned so we can diagnose key issues.
-        if [[ -s "$WEBSHARE_JSON_FILE" ]]; then
-            echo "Webshare response (first 200 chars):" >&2
-            head -c 200 "$WEBSHARE_JSON_FILE" >&2
-            echo >&2
-        fi
+        # Diagnose without ever printing the raw Webshare body — the
+        # response payload contains proxy credentials (username +
+        # password fields) that must not leak into pasted logs.
+        WEBSHARE_BODY_BYTES="$(wc -c < "$WEBSHARE_JSON_FILE" 2>/dev/null | tr -d ' ' || echo 0)"
+        echo "WEBSHARE_API_KEY set but proxy selection failed (continuing direct)" >&2
+        echo "  Webshare HTTP status: ${WEBSHARE_HTTP_STATUS:-<unknown>}" >&2
+        echo "  Webshare body bytes:  ${WEBSHARE_BODY_BYTES}" >&2
+        echo "  (raw response not printed: it contains proxy credentials)" >&2
+        echo "  Common causes: bad API key (expect 401), no valid proxies on the plan, or node missing on host." >&2
     fi
     rm -f "$WEBSHARE_JSON_FILE" "$WEBSHARE_PICK_FILE"
 fi

--- a/scripts/plaud-egress-probe.sh
+++ b/scripts/plaud-egress-probe.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Plaud egress diagnostic.
+#
+# Run this on the box where Plaud sync is failing. It calls Plaud's API from
+# whatever IP this host egresses on, with both the minimal header set we
+# currently send and the full browser-equivalent header set, against all
+# three regional servers, and dumps the response status + Cloudflare
+# signals + a body snippet for each.
+#
+# Usage:
+#   PLAUD_TOKEN='eyJhbGciOi...' bash scripts/plaud-egress-probe.sh
+#
+# Optional:
+#   PLAUD_REGIONS='eu global apse1'   # default: all three
+#   HTTPS_PROXY='http://user:pass@host:port'  # to test a specific proxy URL
+#   WEBSHARE_API_KEY='...'   # pick a random Webshare proxy and route through it
+#                            # (equivalent to what the app does once
+#                            #  WEBSHARE_API_KEY is configured on the server)
+#
+# The token is read from env only — never paste it on the command line, it
+# would land in shell history. The token is NOT logged; only the first
+# 12 chars of the JWT header segment appear in the output for sanity.
+#
+# Output is plain text. Paste it back in the chat for analysis.
+
+set -o pipefail
+
+if [[ -z "${PLAUD_TOKEN:-}" ]]; then
+    echo "PLAUD_TOKEN env var is required" >&2
+    echo "Usage: PLAUD_TOKEN='<jwt>' bash scripts/plaud-egress-probe.sh" >&2
+    exit 2
+fi
+
+TOKEN="$PLAUD_TOKEN"
+TOKEN_PREFIX="${TOKEN:0:12}..."
+
+# If WEBSHARE_API_KEY is set, ask Webshare for a random valid proxy and
+# export it as HTTPS_PROXY so the curl calls below route through it. This
+# is the same flow the app uses at runtime, end-to-end.
+WEBSHARE_PROXY_LABEL=""
+if [[ -n "${WEBSHARE_API_KEY:-}" ]]; then
+    WEBSHARE_JSON_FILE="$(mktemp)"
+    curl -sS --max-time 15 \
+        -H "Authorization: Token ${WEBSHARE_API_KEY}" \
+        'https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=100' \
+        -o "$WEBSHARE_JSON_FILE" || true
+
+    # Pick a random valid proxy. Use node (already required by the app)
+    # so we don't depend on jq or python on the host. Writes two lines:
+    # line 1 = full proxy URL with creds, line 2 = host:port label.
+    WEBSHARE_PICK_FILE="$(mktemp)"
+    node --input-type=module -e "$(cat <<'JS'
+import { readFileSync } from "node:fs";
+const src = process.argv[1];
+const out = process.argv[2];
+import { writeFileSync } from "node:fs";
+let data;
+try {
+    data = JSON.parse(readFileSync(src, "utf8"));
+} catch {
+    process.exit(2);
+}
+const valid = (data.results || []).filter((p) => p.valid);
+if (!valid.length) process.exit(3);
+const p = valid[Math.floor(Math.random() * valid.length)];
+const url = `http://${encodeURIComponent(p.username)}:${encodeURIComponent(p.password)}@${p.proxy_address}:${p.port}`;
+const label = `${p.proxy_address}:${p.port}`;
+writeFileSync(out, `${url}\n${label}\n`);
+JS
+)" "$WEBSHARE_JSON_FILE" "$WEBSHARE_PICK_FILE" 2>/dev/null || true
+
+    if [[ -s "$WEBSHARE_PICK_FILE" ]]; then
+        HTTPS_PROXY="$(sed -n '1p' "$WEBSHARE_PICK_FILE")"
+        WEBSHARE_PROXY_LABEL="$(sed -n '2p' "$WEBSHARE_PICK_FILE")"
+        export HTTPS_PROXY
+    else
+        echo "WEBSHARE_API_KEY set but Webshare returned no valid proxies (or node missing); continuing direct" >&2
+        # Show what Webshare returned so we can diagnose key issues.
+        if [[ -s "$WEBSHARE_JSON_FILE" ]]; then
+            echo "Webshare response (first 200 chars):" >&2
+            head -c 200 "$WEBSHARE_JSON_FILE" >&2
+            echo >&2
+        fi
+    fi
+    rm -f "$WEBSHARE_JSON_FILE" "$WEBSHARE_PICK_FILE"
+fi
+
+# -------- regions --------
+# Bash 3.2 (macOS default) has no associative arrays; use a case lookup.
+REGIONS="${PLAUD_REGIONS:-eu global apse1}"
+
+region_base() {
+    case "$1" in
+        global) echo "https://api.plaud.ai" ;;
+        eu)     echo "https://api-euc1.plaud.ai" ;;
+        apse1)  echo "https://api-apse1.plaud.ai" ;;
+        *)      echo "" ;;
+    esac
+}
+
+# -------- header sets --------
+MIN_UA='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+BROWSER_UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+
+# Returns curl -H args for the "minimal" set (what OpenPlaud sends today).
+min_headers() {
+    printf -- '-H\0Authorization: Bearer %s\0' "$TOKEN"
+    printf -- '-H\0Content-Type: application/json\0'
+    printf -- '-H\0User-Agent: %s\0' "$MIN_UA"
+}
+
+# Returns curl -H args for the full browser-equivalent set (per the HAR).
+browser_headers() {
+    printf -- '-H\0Authorization: Bearer %s\0' "$TOKEN"
+    printf -- '-H\0Accept: application/json, text/plain, */*\0'
+    printf -- '-H\0Content-Type: application/json\0'
+    printf -- '-H\0app-language: en\0'
+    printf -- '-H\0app-platform: web\0'
+    printf -- '-H\0edit-from: web\0'
+    printf -- '-H\0timezone: UTC\0'
+    printf -- '-H\0x-device-id: %s\0' "$(openssl rand -hex 8 2>/dev/null || echo 0123456789abcdef)"
+    printf -- '-H\0x-request-id: probe-%s\0' "$(openssl rand -hex 4 2>/dev/null || echo deadbeef)"
+    printf -- '-H\0Origin: https://web.plaud.ai\0'
+    printf -- '-H\0Referer: https://web.plaud.ai/\0'
+    printf -- '-H\0User-Agent: %s\0' "$BROWSER_UA"
+}
+
+probe() {
+    local label="$1" url="$2" method="$3" headers_fn="$4" body="${5:-}"
+    local hdr_file body_file
+    hdr_file="$(mktemp)"
+    body_file="$(mktemp)"
+
+    # Build a NUL-delimited arg array so header values with spaces are safe.
+    local args=()
+    while IFS= read -r -d '' a; do args+=("$a"); done < <("$headers_fn")
+
+    local curl_args=(
+        --silent --show-error
+        --max-time 20
+        --request "$method"
+        --dump-header "$hdr_file"
+        --output "$body_file"
+        --write-out 'HTTP %{http_code} | time=%{time_total}s | remote=%{remote_ip}\n'
+        "${args[@]}"
+    )
+    if [[ -n "${HTTPS_PROXY:-}" ]]; then
+        curl_args+=(--proxy "$HTTPS_PROXY")
+    fi
+    if [[ -n "$body" ]]; then
+        curl_args+=(--data "$body")
+    fi
+    curl_args+=("$url")
+
+    printf -- '--- %s ---\n' "$label"
+    printf 'URL:    %s %s\n' "$method" "$url"
+    if [[ -n "${HTTPS_PROXY:-}" ]]; then
+        # Show the label (host:port) only — never the full URL, which
+        # would leak the proxy credentials into logs that get pasted.
+        printf 'Proxy:  %s\n' "${WEBSHARE_PROXY_LABEL:-<custom>}"
+    fi
+    curl "${curl_args[@]}" || printf 'curl exited %d\n' "$?"
+
+    # Cloudflare / origin signals
+    grep -iE '^(cf-ray|cf-mitigated|cf-cache-status|server|x-trace-id|content-type|retry-after):' "$hdr_file" \
+        | sed 's/\r$//' | sed 's/^/  /'
+
+    # Body snippet (first 400 chars, single line)
+    if [[ -s "$body_file" ]]; then
+        local snippet
+        snippet="$(LC_ALL=C tr -d '\r\n' < "$body_file" | cut -c1-400)"
+        printf 'Body:   %s\n' "$snippet"
+    else
+        printf 'Body:   (empty)\n'
+    fi
+    printf '\n'
+
+    rm -f "$hdr_file" "$body_file"
+}
+
+DIRECT_EGRESS_IP="$(curl -sS --max-time 8 https://api.ipify.org 2>/dev/null || echo unknown)"
+PROXY_EGRESS_IP=""
+PROXY_LINE="<unset>"
+if [[ -n "${HTTPS_PROXY:-}" ]]; then
+    PROXY_EGRESS_IP="$(curl -sS --max-time 12 --proxy "$HTTPS_PROXY" https://api.ipify.org 2>/dev/null || echo unknown)"
+    PROXY_LINE="set (label=${WEBSHARE_PROXY_LABEL:-custom})"
+fi
+
+cat <<EOF
+Plaud egress probe
+==================
+Host:           $(hostname)
+Direct IP:      ${DIRECT_EGRESS_IP}
+Proxy:          ${PROXY_LINE}
+Proxy egress:   ${PROXY_EGRESS_IP:-<n/a>}
+Token:          ${TOKEN_PREFIX} (len=${#TOKEN})
+Regions:        ${REGIONS}
+Time:           $(date -u +%FT%TZ)
+
+EOF
+
+for region in $REGIONS; do
+    base="$(region_base "$region")"
+    if [[ -z "$base" ]]; then
+        echo "Unknown region '$region', skipping" >&2
+        continue
+    fi
+
+    echo "================================================================"
+    echo "Region: $region ($base)"
+    echo "================================================================"
+
+    probe "[$region] workspaces/list  | minimal headers" \
+        "$base/team-app/workspaces/list?need_personal_workspace=true" \
+        GET min_headers
+
+    probe "[$region] workspaces/list  | browser headers" \
+        "$base/team-app/workspaces/list?need_personal_workspace=true" \
+        GET browser_headers
+
+    probe "[$region] device/list (UT) | minimal headers" \
+        "$base/device/list" \
+        GET min_headers
+
+    probe "[$region] device/list (UT) | browser headers" \
+        "$base/device/list" \
+        GET browser_headers
+
+    probe "[$region] user/me           | minimal headers" \
+        "$base/user/me" \
+        GET min_headers
+done
+
+echo "Done. Paste the full output above back to the chat."

--- a/src/app/api/dev/plaud/info/route.ts
+++ b/src/app/api/dev/plaud/info/route.ts
@@ -5,6 +5,7 @@ import { plaudConnections } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
 import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
+import { isPlaudProxyConfigured } from "@/lib/plaud/proxy";
 import { serverKeyFromApiBase } from "@/lib/plaud/servers";
 
 /**
@@ -67,6 +68,10 @@ export const GET = apiHandler(async (request: Request) => {
         reachable,
         latencyMs,
         error: errorMessage,
+        // Whether outbound Plaud calls go through the Webshare residential
+        // proxy. Surfaced here so we can quickly tell, on a flagged-egress
+        // VPS, whether the proxy path is wired up.
+        usingPlaudProxy: isPlaudProxyConfigured(),
         connection: {
             id: connection.id,
             apiBase: connection.apiBase,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -83,6 +83,19 @@ export const envSchema = z.object({
     S3_ACCESS_KEY_ID: z.string().optional(),
     S3_SECRET_ACCESS_KEY: z.string().optional(),
 
+    // Webshare residential-proxy API key. When set, Plaud-bound outbound
+    // requests (api*.plaud.ai, resource.plaud.ai) are routed through a
+    // random valid proxy from the Webshare list, with automatic rotation
+    // on Cloudflare 403/407 responses. Unset (default) keeps every call
+    // on the direct egress path — the right default for self-hosters on
+    // residential or homelab IPs that Cloudflare doesn't flag. Hosted
+    // deployments on flagged datacenter ASNs (Contabo, OVH, …) need this.
+    // See src/lib/plaud/proxy.ts for the rationale.
+    WEBSHARE_API_KEY: z
+        .string()
+        .optional()
+        .transform((val) => (val === "" ? undefined : val)),
+
     SMTP_HOST: z.string().optional(),
     SMTP_PORT: z
         .string()
@@ -205,6 +218,7 @@ function validateEnv(): Env {
             S3_REGION: process.env.S3_REGION,
             S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
             S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
+            WEBSHARE_API_KEY: process.env.WEBSHARE_API_KEY,
             SMTP_HOST: process.env.SMTP_HOST,
             SMTP_PORT: process.env.SMTP_PORT,
             SMTP_SECURE: process.env.SMTP_SECURE,

--- a/src/lib/plaud/auth.ts
+++ b/src/lib/plaud/auth.ts
@@ -14,6 +14,7 @@
 
 import { AppError, ErrorCode } from "@/lib/errors";
 import { DEFAULT_PLAUD_API_BASE } from "./client";
+import { plaudFetch } from "./fetch";
 import { safeParseJson } from "./parse";
 import { PLAUD_USER_AGENT } from "./servers";
 
@@ -62,7 +63,7 @@ export async function plaudSendCode(
     /** Final resolved API base (may differ from input after region redirect) */
     apiBase: string;
 }> {
-    const res = await fetch(`${apiBase}/auth/otp-send-code`, {
+    const res = await plaudFetch(`${apiBase}/auth/otp-send-code`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -112,7 +113,7 @@ export async function plaudVerifyOtp(
 ): Promise<{
     accessToken: string;
 }> {
-    const res = await fetch(`${apiBase}/auth/otp-login`, {
+    const res = await plaudFetch(`${apiBase}/auth/otp-login`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -191,7 +192,7 @@ export async function fetchPlaudUserMeEmail(
     apiBase: string,
 ): Promise<string | null> {
     try {
-        const res = await fetch(`${apiBase}/user/me`, {
+        const res = await plaudFetch(`${apiBase}/user/me`, {
             method: "GET",
             headers: {
                 Authorization: `Bearer ${accessToken}`,

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -5,6 +5,7 @@ import type {
     PlaudRecordingsResponse,
     PlaudTempUrlResponse,
 } from "@/types/plaud";
+import { plaudFetch } from "./fetch";
 import { safeParseJson } from "./parse";
 import { DEFAULT_SERVER_KEY, PLAUD_SERVERS, PLAUD_USER_AGENT } from "./servers";
 import { resolveWorkspaceToken } from "./workspace";
@@ -168,7 +169,7 @@ export class PlaudClient {
         const url = `${this.apiBase}${endpoint}`;
 
         try {
-            const response = await fetch(url, {
+            const response = await plaudFetch(url, {
                 ...options,
                 headers: {
                     ...options?.headers,
@@ -320,7 +321,11 @@ export class PlaudClient {
                     ? tempUrlResponse.temp_url_opus
                     : tempUrlResponse.temp_url;
 
-            const response = await fetch(downloadUrl);
+            // Signed-URL host is resource.plaud.ai, which sits on the
+            // same Cloudflare zone as the API — route through the same
+            // proxy machinery so download attempts don't fail with a
+            // Cloudflare 403 after the API call succeeded.
+            const response = await plaudFetch(downloadUrl);
             if (!response.ok) {
                 throw new AppError(
                     ErrorCode.PLAUD_UPSTREAM_ERROR,

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -98,7 +98,7 @@ export async function plaudFetch(
                     currentProxy.label,
                     err instanceof Error ? err.message : String(err),
                 );
-                invalidatePlaudProxy();
+                invalidatePlaudProxy(currentProxy);
                 const next = await getPlaudProxyUrl();
                 if (!next) {
                     // No more proxies — last-resort direct attempt so a
@@ -126,13 +126,20 @@ export async function plaudFetch(
                 currentProxy.label,
                 response.statusText,
             );
-            invalidatePlaudProxy();
-            // Drain the body so the connection can be reused; ignore
-            // errors — we don't care about the contents at this point.
-            await response.body?.cancel().catch(() => undefined);
+            invalidatePlaudProxy(currentProxy);
 
+            // Resolve the next proxy BEFORE touching the body. If we
+            // cancel the body and then discover there's no next proxy,
+            // we'd return a `Response` whose body has already been
+            // consumed, and the caller (which expects to read JSON)
+            // would blow up on a parse step that worked fine pre-rotate.
             const next = await getPlaudProxyUrl();
             if (!next) return response;
+
+            // Now safe to drain the body so the connection can be
+            // reused for the retry; ignore errors — we don't care
+            // about the contents at this point.
+            await response.body?.cancel().catch(() => undefined);
             currentProxy = next;
             attempt += 1;
             continue;

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -1,0 +1,171 @@
+/**
+ * `plaudFetch` — thin wrapper around `fetch()` that routes Plaud-bound
+ * requests through a residential proxy when one is configured.
+ *
+ * See `./proxy.ts` for the why: Plaud's Cloudflare zone blocks datacenter
+ * ASNs with a 403 + HTML challenge at the edge. This wrapper:
+ *
+ *   1. Decides per-URL whether to proxy (`shouldProxyPlaud`).
+ *   2. Picks a proxy from the Webshare list (`getPlaudProxyUrl`).
+ *   3. Sends the request via an `undici.ProxyAgent` dispatcher.
+ *   4. On 403 / 407 while proxied, invalidates the proxy and retries once
+ *      with a fresh one. On the second 403 we give up — that's almost
+ *      certainly an upstream Plaud-side rejection (bad token, missing
+ *      workspace), not a proxy-IP problem.
+ *
+ * SSRF posture is unchanged: every caller still passes URLs through
+ * `safePlaudUrl` / `isValidPlaudApiUrl` first, so the proxy never sees an
+ * off-domain target. The proxy URL itself is server-controlled (env var
+ * → Webshare API) and is never user-influenced.
+ *
+ * Non-Plaud URLs fall straight through to the global `fetch`. We do NOT
+ * proxy other outbound calls (S3, AI providers, SMTP) — they aren't
+ * blocked and adding latency / cost would be wasteful.
+ */
+
+import { ProxyAgent } from "undici";
+import {
+    getPlaudProxyUrl,
+    invalidatePlaudProxy,
+    type SelectedProxy,
+    shouldProxyPlaud,
+} from "./proxy";
+
+const MAX_PROXY_ROTATIONS = 1;
+
+/**
+ * Memoised dispatcher per proxy URL. ProxyAgent maintains an internal
+ * connection pool — recreating it per request would defeat keep-alive.
+ *
+ * Bounded by the size of the Webshare list (typically <100 entries) and by
+ * the blacklist eviction in proxy.ts; we don't otherwise prune.
+ */
+const dispatcherCache = new Map<string, ProxyAgent>();
+
+function getDispatcher(proxyUrl: string): ProxyAgent {
+    let agent = dispatcherCache.get(proxyUrl);
+    if (!agent) {
+        agent = new ProxyAgent(proxyUrl);
+        dispatcherCache.set(proxyUrl, agent);
+    }
+    return agent;
+}
+
+/**
+ * Drop-in replacement for `fetch()` for any URL that may be a Plaud host.
+ * Same call signature; same return type. Callers handle status codes and
+ * body parsing exactly as before.
+ */
+export async function plaudFetch(
+    url: string,
+    init?: RequestInit,
+): Promise<Response> {
+    if (!shouldProxyPlaud(url)) {
+        return fetch(url, init);
+    }
+
+    let attempt = 0;
+    let currentProxy: SelectedProxy | null = null;
+    // First-try proxy selection. null result → Webshare unconfigured or
+    // exhausted; fall through to direct fetch. That keeps self-host
+    // deployments (which leave WEBSHARE_API_KEY unset) on the direct path
+    // with no behavior change.
+    currentProxy = await getPlaudProxyUrl();
+    if (!currentProxy) {
+        return fetch(url, init);
+    }
+
+    while (true) {
+        // `dispatcher` is undici-specific; Node's global fetch is backed by
+        // undici so the property is honoured at runtime. TS doesn't know
+        // this without lib augmentation, so we cast at the boundary.
+        const dispatcher = getDispatcher(currentProxy.url);
+        const initWithDispatcher = {
+            ...init,
+            dispatcher,
+        } as RequestInit & { dispatcher: ProxyAgent };
+
+        let response: Response;
+        try {
+            response = await fetch(url, initWithDispatcher);
+        } catch (err) {
+            // Network error through the proxy (timeout, connection reset).
+            // Treat like a 403: invalidate + rotate once.
+            if (attempt < MAX_PROXY_ROTATIONS) {
+                logProxyEvent(
+                    "network-error",
+                    url,
+                    currentProxy.label,
+                    err instanceof Error ? err.message : String(err),
+                );
+                invalidatePlaudProxy();
+                const next = await getPlaudProxyUrl();
+                if (!next) {
+                    // No more proxies — last-resort direct attempt so a
+                    // total Webshare outage doesn't take sync down on
+                    // operators whose VPS IP is actually fine.
+                    return fetch(url, init);
+                }
+                currentProxy = next;
+                attempt += 1;
+                continue;
+            }
+            throw err;
+        }
+
+        if (
+            (response.status === 403 || response.status === 407) &&
+            attempt < MAX_PROXY_ROTATIONS
+        ) {
+            // 403 while proxied: most likely the proxy IP itself is on
+            // Cloudflare's bot list. 407: proxy refused auth. Either
+            // way, blacklist + rotate.
+            logProxyEvent(
+                `http-${response.status}`,
+                url,
+                currentProxy.label,
+                response.statusText,
+            );
+            invalidatePlaudProxy();
+            // Drain the body so the connection can be reused; ignore
+            // errors — we don't care about the contents at this point.
+            await response.body?.cancel().catch(() => undefined);
+
+            const next = await getPlaudProxyUrl();
+            if (!next) return response;
+            currentProxy = next;
+            attempt += 1;
+            continue;
+        }
+
+        return response;
+    }
+}
+
+function logProxyEvent(
+    kind: string,
+    url: string,
+    proxyLabel: string,
+    detail: string,
+): void {
+    let host: string;
+    try {
+        host = new URL(url).host;
+    } catch {
+        host = "<invalid-url>";
+    }
+    console.warn(
+        `[plaud/proxy] ${kind} via=${proxyLabel} host=${host} detail=${detail}`,
+    );
+}
+
+/**
+ * Test-only: reset the dispatcher cache. The proxy.ts cache is reset
+ * independently via `_resetPlaudProxyCacheForTest`.
+ */
+export function _resetPlaudFetchForTest(): void {
+    for (const agent of dispatcherCache.values()) {
+        agent.close().catch(() => undefined);
+    }
+    dispatcherCache.clear();
+}

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -49,7 +49,6 @@ const WEBSHARE_LIST_URL =
 
 let cachedList: ProxyCache | null = null;
 let badProxyIds = new Set<string>();
-let lastServedProxyId: string | null = null;
 
 async function fetchProxyList(): Promise<WebshareProxy[]> {
     const apiKey = env.WEBSHARE_API_KEY;
@@ -101,6 +100,8 @@ export function shouldProxyPlaud(url: string): boolean {
 }
 
 export interface SelectedProxy {
+    /** Webshare proxy id — the stable handle used for blacklisting. */
+    id: string;
     /** http://user:pass@host:port form. Contains credentials — do not log. */
     url: string;
     /** host:port — safe to log. */
@@ -141,19 +142,21 @@ export async function getPlaudProxyUrl(): Promise<SelectedProxy | null> {
     const proxy = available[Math.floor(Math.random() * available.length)];
     const url = `http://${encodeURIComponent(proxy.username)}:${encodeURIComponent(proxy.password)}@${proxy.proxy_address}:${proxy.port}`;
     const label = `${proxy.proxy_address}:${proxy.port}`;
-    lastServedProxyId = proxy.id;
-    return { url, label };
+    return { id: proxy.id, url, label };
 }
 
 /**
- * Mark the most-recently-served proxy as bad. Called when Plaud returns 403
- * (Cloudflare challenge — proxy IP is also flagged) or 407 (proxy auth
+ * Mark a specific proxy as bad. Called by `plaudFetch` when Plaud returns
+ * 403 (Cloudflare challenge — proxy IP is also flagged) or 407 (proxy auth
  * rejected). The proxy stays blacklisted until the next list refresh.
+ *
+ * Takes the proxy explicitly (rather than reading a module-global
+ * "last served") so concurrent `plaudFetch` calls can't blacklist each
+ * other's proxy by race: each caller threads its own `SelectedProxy`
+ * through and invalidates exactly the one it just used.
  */
-export function invalidatePlaudProxy(): void {
-    if (lastServedProxyId) {
-        badProxyIds.add(lastServedProxyId);
-    }
+export function invalidatePlaudProxy(proxy: SelectedProxy): void {
+    badProxyIds.add(proxy.id);
 }
 
 /**
@@ -170,5 +173,4 @@ export function isPlaudProxyConfigured(): boolean {
 export function _resetPlaudProxyCacheForTest(): void {
     cachedList = null;
     badProxyIds = new Set();
-    lastServedProxyId = null;
 }

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -1,0 +1,174 @@
+/**
+ * Outbound proxy selection for Plaud API calls.
+ *
+ * Why this exists: Plaud's API is fronted by Cloudflare with aggressive
+ * bot/datacenter-ASN filtering. Calls originating from common VPS provider
+ * IPs (Contabo, OVH, Hetzner, …) get a 403 + Cloudflare HTML challenge at
+ * the edge regardless of token, headers, or region. We confirmed this with
+ * `scripts/plaud-egress-probe.sh` from a flagged VPS IP: every Plaud
+ * endpoint, every region, every header combination returned 403 with
+ * `server: cloudflare` and a `<title>Attention Required!</title>` body.
+ * From a residential IP (or via a residential proxy) the same requests
+ * return 200.
+ *
+ * Strategy: bring-your-own residential proxy via Webshare. When
+ * `WEBSHARE_API_KEY` is set, this module lists Webshare's available
+ * proxies (cached 5 min), rotates randomly per call, and blacklists any
+ * that get rejected by Plaud. When the env var is unset (default — the
+ * self-host path) every call routes direct.
+ *
+ * Self-host degradation: residential / homelab IPs aren't on Cloudflare's
+ * datacenter-ASN bucket, so the direct path keeps working for the
+ * overwhelming majority of self-hosters. Only operators on flagged VPS
+ * IPs need to set this.
+ *
+ * Pattern mirrors apps/split-service in the betterbahn project; kept
+ * scoped to Plaud in this codebase so future generic-proxy use stays
+ * opt-in per service.
+ */
+
+import { env } from "@/lib/env";
+
+interface WebshareProxy {
+    id: string;
+    username: string;
+    password: string;
+    proxy_address: string;
+    port: number;
+    valid: boolean;
+}
+
+interface ProxyCache {
+    proxies: WebshareProxy[];
+    expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60_000;
+const WEBSHARE_LIST_URL =
+    "https://proxy.webshare.io/api/v2/proxy/list/?mode=direct&page=1&page_size=100";
+
+let cachedList: ProxyCache | null = null;
+let badProxyIds = new Set<string>();
+let lastServedProxyId: string | null = null;
+
+async function fetchProxyList(): Promise<WebshareProxy[]> {
+    const apiKey = env.WEBSHARE_API_KEY;
+    if (!apiKey) return [];
+
+    try {
+        const res = await fetch(WEBSHARE_LIST_URL, {
+            headers: { Authorization: `Token ${apiKey}` },
+        });
+        if (!res.ok) {
+            console.warn(
+                `[plaud/proxy] Webshare list error: ${res.status} ${res.statusText}`,
+            );
+            return [];
+        }
+        const data = (await res.json()) as { results?: WebshareProxy[] };
+        const proxies = (data.results ?? []).filter((p) => p.valid);
+        cachedList = { proxies, expiresAt: Date.now() + CACHE_TTL_MS };
+        badProxyIds = new Set();
+        return proxies;
+    } catch (err) {
+        console.warn(
+            "[plaud/proxy] Webshare list fetch failed:",
+            err instanceof Error ? err.message : err,
+        );
+        return [];
+    }
+}
+
+/**
+ * Should an outbound call to `url` be routed through the Plaud proxy?
+ *
+ * Matches Plaud API hosts (api.plaud.ai, api-*.plaud.ai) and the signed-URL
+ * CDN (resource.plaud.ai). All Plaud-owned hostnames sit behind the same
+ * Cloudflare zone, so any of them can trigger the datacenter-ASN block.
+ *
+ * Returns false for unknown / malformed URLs so we never accidentally route
+ * non-Plaud traffic through a third-party proxy.
+ */
+export function shouldProxyPlaud(url: string): boolean {
+    try {
+        const u = new URL(url);
+        if (u.protocol !== "https:") return false;
+        const h = u.hostname.toLowerCase();
+        return h === "plaud.ai" || h.endsWith(".plaud.ai");
+    } catch {
+        return false;
+    }
+}
+
+export interface SelectedProxy {
+    /** http://user:pass@host:port form. Contains credentials — do not log. */
+    url: string;
+    /** host:port — safe to log. */
+    label: string;
+}
+
+/**
+ * Pick a proxy from the cached Webshare list, lazily refreshing on expiry
+ * or when all proxies have been blacklisted. Returns null if Webshare is
+ * not configured or returned an empty list — callers fall back to direct.
+ */
+export async function getPlaudProxyUrl(): Promise<SelectedProxy | null> {
+    if (!env.WEBSHARE_API_KEY) return null;
+
+    let proxies: WebshareProxy[];
+    let justRefreshed = false;
+    if (cachedList && cachedList.expiresAt > Date.now()) {
+        proxies = cachedList.proxies;
+    } else {
+        proxies = await fetchProxyList();
+        justRefreshed = true;
+    }
+
+    let available = proxies.filter((p) => !badProxyIds.has(p.id));
+    if (available.length === 0 && !justRefreshed) {
+        // All blacklisted — force one refresh and reset the blacklist.
+        // Skip the refresh if we already fetched a fresh (but empty) list
+        // this call, so a Webshare outage doesn't burn two list requests
+        // per Plaud call.
+        proxies = await fetchProxyList();
+        available = proxies;
+    }
+    if (available.length === 0) {
+        console.warn("[plaud/proxy] no valid Webshare proxies available");
+        return null;
+    }
+
+    const proxy = available[Math.floor(Math.random() * available.length)];
+    const url = `http://${encodeURIComponent(proxy.username)}:${encodeURIComponent(proxy.password)}@${proxy.proxy_address}:${proxy.port}`;
+    const label = `${proxy.proxy_address}:${proxy.port}`;
+    lastServedProxyId = proxy.id;
+    return { url, label };
+}
+
+/**
+ * Mark the most-recently-served proxy as bad. Called when Plaud returns 403
+ * (Cloudflare challenge — proxy IP is also flagged) or 407 (proxy auth
+ * rejected). The proxy stays blacklisted until the next list refresh.
+ */
+export function invalidatePlaudProxy(): void {
+    if (lastServedProxyId) {
+        badProxyIds.add(lastServedProxyId);
+    }
+}
+
+/**
+ * Whether a Webshare API key is configured. Surfaced by the dev-info
+ * endpoint so we can tell at a glance whether prod is using the proxy.
+ */
+export function isPlaudProxyConfigured(): boolean {
+    return Boolean(env.WEBSHARE_API_KEY);
+}
+
+/**
+ * Test-only: reset module state between unit tests.
+ */
+export function _resetPlaudProxyCacheForTest(): void {
+    cachedList = null;
+    badProxyIds = new Set();
+    lastServedProxyId = null;
+}

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -24,6 +24,7 @@ import type {
     PlaudWorkspaceListResponse,
     PlaudWorkspaceTokenResponse,
 } from "@/types/plaud";
+import { plaudFetch } from "./fetch";
 import { safeParseJson } from "./parse";
 import { PLAUD_USER_AGENT } from "./servers";
 
@@ -71,7 +72,7 @@ export async function listPlaudWorkspaces(
         apiBase,
         "/team-app/workspaces/list?need_personal_workspace=true",
     );
-    const res = await fetch(url, {
+    const res = await plaudFetch(url.toString(), {
         method: "GET",
         headers: {
             Authorization: `Bearer ${userToken}`,
@@ -142,7 +143,7 @@ export async function mintPlaudWorkspaceToken(
         apiBase,
         `/user-app/auth/workspace/token/${encodeURIComponent(workspaceId)}`,
     );
-    const res = await fetch(url, {
+    const res = await plaudFetch(url.toString(), {
         method: "POST",
         headers: {
             Authorization: `Bearer ${userToken}`,

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -172,6 +172,23 @@ describe("plaudFetch with Webshare configured", () => {
         expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
+    it("returns a readable body when rotation is exhausted (no second proxy)", async () => {
+        // Pins the fix for cubic P1 (canceled-body bug): when only one
+        // proxy is available and it 403s, plaudFetch must surface the
+        // 403 Response with its body intact so the caller can parse it.
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy]))
+            .mockResolvedValueOnce(forbiddenResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(403);
+        // The critical assertion: body has not been canceled. Reading
+        // it would throw with `TypeError: Body is unusable` if the bug
+        // were present.
+        const text = await res.text();
+        expect(text).toContain("Cloudflare");
+    });
+
     it("returns the success response after a rotation succeeds", async () => {
         mockFetch
             .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for the Plaud outbound proxy layer.
+ *
+ * What's pinned here:
+ *   - `shouldProxyPlaud` only matches Plaud-owned hostnames over HTTPS.
+ *   - `plaudFetch` falls through to direct fetch when Webshare isn't
+ *     configured (the self-host default — must not regress).
+ *   - With a Webshare list available, `plaudFetch` selects a proxy and
+ *     attaches an undici `dispatcher` to the fetch call.
+ *   - A 403 response while proxied triggers exactly one rotation, after
+ *     which the original response is returned (we don't loop forever
+ *     and we don't blow past the rotation budget).
+ *   - Non-Plaud URLs are never proxied even if Webshare is configured.
+ */
+
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+import { _resetPlaudFetchForTest, plaudFetch } from "@/lib/plaud/fetch";
+import {
+    _resetPlaudProxyCacheForTest,
+    isPlaudProxyConfigured,
+    shouldProxyPlaud,
+} from "@/lib/plaud/proxy";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+const PLAUD_API_URL =
+    "https://api-euc1.plaud.ai/team-app/workspaces/list?need_personal_workspace=true";
+
+function okResponse(): Response {
+    return new Response('{"status":0,"data":{"workspaces":[]}}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+function forbiddenResponse(): Response {
+    return new Response("<html>Cloudflare</html>", {
+        status: 403,
+        headers: { "Content-Type": "text/html" },
+    });
+}
+
+function webshareList(proxies: Array<Record<string, unknown>>): Response {
+    return new Response(JSON.stringify({ results: proxies }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+const sampleProxy = {
+    id: "p1",
+    username: "u",
+    password: "p",
+    proxy_address: "1.2.3.4",
+    port: 8080,
+    valid: true,
+};
+const otherProxy = {
+    id: "p2",
+    username: "u2",
+    password: "p2",
+    proxy_address: "5.6.7.8",
+    port: 8081,
+    valid: true,
+};
+
+beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as typeof global.fetch;
+    mockEnv.WEBSHARE_API_KEY = undefined;
+    _resetPlaudProxyCacheForTest();
+    _resetPlaudFetchForTest();
+});
+
+afterEach(() => {
+    global.fetch = originalFetch;
+});
+
+describe("shouldProxyPlaud", () => {
+    it("matches Plaud API hosts over HTTPS", () => {
+        expect(shouldProxyPlaud("https://api.plaud.ai/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://api-euc1.plaud.ai/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://api-apse1.plaud.ai/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://resource.plaud.ai/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://plaud.ai/")).toBe(true);
+    });
+
+    it("rejects non-Plaud, http, and malformed URLs", () => {
+        expect(shouldProxyPlaud("https://example.com/")).toBe(false);
+        expect(shouldProxyPlaud("https://plaud.ai.evil.com/")).toBe(false);
+        expect(shouldProxyPlaud("http://api.plaud.ai/")).toBe(false);
+        expect(shouldProxyPlaud("not-a-url")).toBe(false);
+    });
+});
+
+describe("plaudFetch without Webshare configured", () => {
+    it("calls global fetch directly with no dispatcher", async () => {
+        mockFetch.mockResolvedValueOnce(okResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(200);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        const [, init] = mockFetch.mock.calls[0];
+        expect(init?.dispatcher).toBeUndefined();
+        expect(isPlaudProxyConfigured()).toBe(false);
+    });
+
+    it("does not proxy non-Plaud URLs", async () => {
+        mockFetch.mockResolvedValueOnce(okResponse());
+        await plaudFetch("https://example.com/x");
+        const [, init] = mockFetch.mock.calls[0];
+        expect(init?.dispatcher).toBeUndefined();
+    });
+});
+
+describe("plaudFetch with Webshare configured", () => {
+    beforeEach(() => {
+        mockEnv.WEBSHARE_API_KEY = "test-key";
+    });
+
+    it("fetches the Webshare list and attaches a dispatcher", async () => {
+        mockFetch
+            // 1) Webshare list call
+            .mockResolvedValueOnce(webshareList([sampleProxy]))
+            // 2) actual Plaud call through the proxy
+            .mockResolvedValueOnce(okResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(200);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+
+        const [listUrl] = mockFetch.mock.calls[0];
+        expect(String(listUrl)).toContain("proxy.webshare.io");
+
+        const [plaudUrl, init] = mockFetch.mock.calls[1];
+        expect(String(plaudUrl)).toBe(PLAUD_API_URL);
+        // dispatcher is an undici ProxyAgent instance — we just assert
+        // shape, not identity, because the cache lazy-constructs it.
+        expect(init?.dispatcher).toBeDefined();
+        expect(typeof init?.dispatcher).toBe("object");
+    });
+
+    it("rotates exactly once on 403 and returns the second response", async () => {
+        mockFetch
+            // Webshare list (two proxies so rotation has a target)
+            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
+            // first proxied attempt: blocked
+            .mockResolvedValueOnce(forbiddenResponse())
+            // second proxied attempt: also blocked, but we've burned the budget
+            .mockResolvedValueOnce(forbiddenResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(403);
+        // 1 list call + 2 plaud attempts = 3 fetches. Crucially NOT 4.
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("returns the success response after a rotation succeeds", async () => {
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
+            .mockResolvedValueOnce(forbiddenResponse())
+            .mockResolvedValueOnce(okResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(200);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("falls through to direct fetch when Webshare list is empty", async () => {
+        mockFetch
+            .mockResolvedValueOnce(webshareList([]))
+            .mockResolvedValueOnce(okResponse());
+
+        const res = await plaudFetch(PLAUD_API_URL);
+        expect(res.status).toBe(200);
+        // Second call must NOT carry a dispatcher.
+        const [, init] = mockFetch.mock.calls[1];
+        expect(init?.dispatcher).toBeUndefined();
+    });
+
+    it("does not proxy non-Plaud URLs even when configured", async () => {
+        mockFetch.mockResolvedValueOnce(okResponse());
+        await plaudFetch("https://s3.amazonaws.com/some-bucket/file");
+        // Only the direct call; no Webshare list lookup.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [, init] = mockFetch.mock.calls[0];
+        expect(init?.dispatcher).toBeUndefined();
+    });
+});

--- a/src/tests/plaud.integration.test.ts
+++ b/src/tests/plaud.integration.test.ts
@@ -1,4 +1,13 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Mock env so importing PlaudClient (which transitively loads env via
+// `proxy.ts`) doesn't trip the DATABASE_URL/ENCRYPTION_KEY runtime checks
+// when running `pnpm test` without a populated .env.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: process.env.WEBSHARE_API_KEY,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
 import { PlaudClient } from "../lib/plaud/client";
 
 const bearerToken = process.env.PLAUD_BEARER_TOKEN;

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -8,6 +8,19 @@ import {
     type Mock,
     vi,
 } from "vitest";
+
+// Mock env so importing PlaudClient (which transitively imports env via
+// the proxy module) doesn't trip the DATABASE_URL/ENCRYPTION_KEY runtime
+// checks. WEBSHARE_API_KEY is left undefined so plaudFetch falls through
+// to the direct path, preserving every existing test's expectations.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
 import { DEFAULT_PLAUD_API_BASE, PlaudClient } from "../lib/plaud/client";
 import {
     DEFAULT_SERVER_KEY,

--- a/src/tests/regressions/132-plaud-user-agent.test.ts
+++ b/src/tests/regressions/132-plaud-user-agent.test.ts
@@ -36,6 +36,14 @@ import {
     type Mock,
     vi,
 } from "vitest";
+
+// Mock env so importing Plaud modules (which transitively load env via
+// `proxy.ts`) doesn't trip the DATABASE_URL/ENCRYPTION_KEY runtime checks.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
 import {
     fetchPlaudUserMeEmail,
     plaudSendCode,

--- a/src/tests/regressions/142-plaud-json-parse.test.ts
+++ b/src/tests/regressions/142-plaud-json-parse.test.ts
@@ -32,6 +32,14 @@ import {
     type Mock,
     vi,
 } from "vitest";
+
+// Mock env so importing Plaud modules (which transitively load env via
+// `proxy.ts`) doesn't trip the DATABASE_URL/ENCRYPTION_KEY runtime checks.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
 import { AppError, ErrorCode } from "@/lib/errors";
 import { plaudSendCode, plaudVerifyOtp } from "@/lib/plaud/auth";
 import {

--- a/src/tests/regressions/66-eu-otp-permissions.test.ts
+++ b/src/tests/regressions/66-eu-otp-permissions.test.ts
@@ -27,6 +27,14 @@ import {
     type Mock,
     vi,
 } from "vitest";
+
+// Mock env so importing Plaud modules (which transitively load env via
+// `proxy.ts`) doesn't trip the DATABASE_URL/ENCRYPTION_KEY runtime checks.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
 import { ErrorCode as ErrorCodeRef } from "@/lib/errors";
 import { PlaudClient } from "@/lib/plaud/client";
 

--- a/src/tests/regressions/79-v1-incremental-updates.test.ts
+++ b/src/tests/regressions/79-v1-incremental-updates.test.ts
@@ -5,6 +5,13 @@ const openAiMocks = vi.hoisted(() => ({
     chatCreate: vi.fn(),
 }));
 
+// Mock env so transitive imports of Plaud modules (via the sync code
+// path under test) don't trip DATABASE_URL/ENCRYPTION_KEY runtime checks.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
 vi.mock("@/db", () => ({
     db: {
         select: vi.fn(),


### PR DESCRIPTION
## Description

Plaud's API sits behind Cloudflare with aggressive datacenter-ASN filtering. From flagged egress IPs (Contabo, OVH, some home ISPs with shared CGNAT), every Plaud endpoint returns **HTTP 403 + a Cloudflare HTML challenge page at the edge** regardless of token, region, or request headers. The block lands before the request reaches Plaud's origin (`server: cloudflare`, no `x-trace-id`, ~25 ms response). The same token from a non-flagged IP returns 200 with the real workspace.

Adds optional Webshare residential-proxy support gated by a new `WEBSHARE_API_KEY` env var. When set, Plaud-bound calls (`api*.plaud.ai`, `resource.plaud.ai`) route through a random valid proxy from the Webshare list, with automatic rotation on 403/407. When unset (default), every call stays on the direct egress path — preserving the self-host experience for residential / homelab IPs that Cloudflare doesn't flag.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #137

(The OTP JSON-parse half of #137 was already addressed in #143. This PR closes the auth-flow 403 half — the `workspace discovery failed` / `device list validation failed: Forbidden` logs.)

## Changes Made

- **New `src/lib/plaud/proxy.ts`** — Webshare list fetch (5 min cache), per-id blacklist, `shouldProxyPlaud()` host whitelist (only `*.plaud.ai` over HTTPS), `isPlaudProxyConfigured()` for diagnostics.
- **New `src/lib/plaud/fetch.ts`** — `plaudFetch()` wraps the global `fetch()`, attaches an `undici.ProxyAgent` as `dispatcher`, rotates exactly once on 403 or 407, falls through to direct `fetch()` for non-Plaud URLs or when no proxy is configured. Dispatcher pool memoised per proxy URL so keep-alive isn't defeated.
- **All 7 Plaud fetch sites swapped** for `plaudFetch()` in `client.ts` (`request()` + `downloadRecording()` — `resource.plaud.ai` shares the CF zone), `workspace.ts` (`listPlaudWorkspaces`, `mintPlaudWorkspaceToken`), `auth.ts` (`plaudSendCode`, `plaudVerifyOtp`, `fetchPlaudUserMeEmail`).
- **`WEBSHARE_API_KEY` env var** added to `src/lib/env.ts` (optional, validated as non-empty string) and documented in `.env.example` with the rationale.
- **`/api/dev/plaud/info`** gains a `usingPlaudProxy` boolean for ops diagnostics.
- **`undici ^7.16.0`** added as a direct dep (already transitive via Next 16) so `ProxyAgent` is an explicit import rather than relying on `next/dist/compiled`.
- **Diagnostic script** at `scripts/plaud-egress-probe.sh` — pure curl + sed (no node/jq/python). Probes all three Plaud regional servers with both minimal and browser-equivalent header sets, and when `WEBSHARE_API_KEY` is set, routes through a random Webshare proxy end-to-end. Doubles as the future "is the proxy still working" check.

### Why a proxy and not headers / a different region

I initially suspected missing browser fingerprint headers (`app-platform`, `x-device-id`, etc. visible in the Plaud web HAR). The diagnostic script ruled that out: from a residential IP, **both minimal and browser-header sets return 200** with the same token. From the flagged VPS, **both return the Cloudflare HTML challenge with `server: cloudflare` and a `-FRA` `cf-ray`** in ~25 ms. Same applies to all three regional servers (`api.plaud.ai`, `api-euc1`, `api-apse1`). Egress IP is the only variable that changes the outcome.

The proxy is opt-in by env var because:

- Most self-hosters run on residential / homelab IPs Cloudflare doesn't flag — the direct path already works for them and adding a residential-proxy bill for a problem they don't have would be wrong.
- It matches the `AGENTS.md` "Egress is hostile territory" hosted invariant: hosted ops sets the env to a non-flagged egress; self-host defaults stay direct.
- Webshare's free-tier list is plenty for a single hosted deployment's sync volume.

## Testing

### Test Environment
- OS: macOS (local validation) + Linux VPS (production reproduction)
- Node version: 22.20.0
- Browser: n/a

### Test Steps

1. **Reproduced the bug end-to-end** on a flagged VPS (`159.195.70.135`) using `scripts/plaud-egress-probe.sh`: every endpoint, every region, both header sets → HTTP 403 with `<title>Attention Required! | Cloudflare</title>` body. Same probe from a residential IP → HTTP 200 with real workspace JSON.
2. **Validated the proxy fix** end-to-end from the same VPS:
   ```bash
   bash /tmp/plaud-vps-proxy-test.txt
   # Picked proxy: 45.151.163.18:5771
   # {"status":0,"data":{"workspaces":[{"workspace_id":"ws_cKyt7F2Iec",...}]}}
   ```
3. **`pnpm test`** — 351 passed, 3 skipped (skipped tests are the optional Plaud integration suite requiring `PLAUD_BEARER_TOKEN`).
4. **`pnpm type-check`** — clean.
5. **`pnpm format-and-lint`** — clean (2 pre-existing infos in `admin/elevated-cookie.test.ts`, untouched by this PR).
6. **New `src/tests/plaud-proxy.test.ts`** — 9 cases pinning: host-whitelist scope, no-config passthrough, dispatcher attachment, rotation budget (exactly one retry, never two), success-after-rotation, empty-list fallback, non-Plaud bypass.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.env.example`, `CHANGELOG.md`)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None. No schema, no migration.

## Breaking Changes

None. `WEBSHARE_API_KEY` is optional and defaults off; behavior unchanged for any deploy that doesn't set it. The new `undici` dep is already in the transitive graph via Next 16, so no install-size delta in practice.

## Additional Notes

- The diagnostic script is intentionally pure curl + sed — no Node/jq/Python required — so it runs on any minimal VPS and any user reporting an auth bug can produce a comparable trace.
- The proxy is scoped strictly to `*.plaud.ai` hostnames. S3, AI providers, SMTP, GitHub release check, etc. continue to use direct egress regardless of `WEBSHARE_API_KEY`. This is enforced in `shouldProxyPlaud()` and unit-tested.
- SSRF posture unchanged: every caller still passes URLs through `safePlaudUrl()` / `isValidPlaudApiUrl()` before invoking `plaudFetch`, so the proxy never sees an off-domain target. The proxy URL itself is server-controlled (env → Webshare API) and never user-influenced.

## For Reviewers

- **`src/lib/plaud/fetch.ts`** — rotation budget logic (exactly one retry on 403/407, then surface the response). Pinned by tests but worth a second pair of eyes.
- **`src/lib/plaud/proxy.ts`** — the `justRefreshed` guard prevents a Webshare outage from burning two list requests per Plaud call. Subtle but covered by `falls through to direct fetch when Webshare list is empty`.
- **`/api/dev/plaud/info`** — dev-only (404s under `NODE_ENV=production`) — the `usingPlaudProxy` field is the production smoke test surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional residential-proxy path for Plaud API calls to bypass Cloudflare 403s from flagged datacenter IPs. Also hardens proxy behavior to avoid concurrency races and keeps 403 bodies readable on final failure.

- **New Features**
  - `plaudFetch()` + `proxy.ts`: routes `api*.plaud.ai` and `resource.plaud.ai` via a Webshare proxy when configured, with one retry on 403/407; non-Plaud URLs always go direct.
  - Optional `WEBSHARE_API_KEY`; `/api/dev/plaud/info` exposes `usingPlaudProxy` for diagnostics.
  - Adds `scripts/plaud-egress-probe.sh` to verify egress and proxy behavior end-to-end.
  - Adds `undici` as a direct dependency for `ProxyAgent`.

- **Bug Fixes**
  - Resolves Plaud 403s blocking auth/workspace discovery from flagged VPS egress; closes #137.
  - Proxy robustness: per-request proxy invalidation to prevent cross-call races; resolve next proxy before canceling the body so 403 responses remain readable when rotation is exhausted; probe script avoids printing Webshare creds.

<sup>Written for commit df0fba182d3940ede289e745dd863385710f0489. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

