### PR TITLE
docs(changelog): link PR #148 on Webshare proxy entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Optional outbound proxy for Plaud API calls via Webshare residential proxies. When `WEBSHARE_API_KEY` is set, every request to `api*.plaud.ai` / `resource.plaud.ai` routes through a random valid proxy from the Webshare list, with automatic rotation on Cloudflare 403/407 responses. Unset (default) keeps the direct egress path. Required for hosted deployments on flagged datacenter ASNs where Cloudflare returns a 403 HTML challenge before requests reach Plaud's origin; not needed for residential / homelab self-hosts. No effect on non-Plaud outbound traffic. `scripts/plaud-egress-probe.sh` can validate proxy behavior end-to-end against a real account.
+- Optional outbound proxy for Plaud API calls via Webshare residential proxies. When `WEBSHARE_API_KEY` is set, every request to `api*.plaud.ai` / `resource.plaud.ai` routes through a random valid proxy from the Webshare list, with automatic rotation on Cloudflare 403/407 responses. Unset (default) keeps the direct egress path. Required for hosted deployments on flagged datacenter ASNs where Cloudflare returns a 403 HTML challenge before requests reach Plaud's origin; not needed for residential / homelab self-hosts. No effect on non-Plaud outbound traffic. `scripts/plaud-egress-probe.sh` can validate proxy behavior end-to-end against a real account ([#148](https://github.com/openplaud/openplaud/pull/148)).
 
 ## [0.5.0] - 2026-05-15
 


### PR DESCRIPTION
## Description

Audited `CHANGELOG.md` against commits since `v0.5.0`. The `[Unreleased]` section already covers all user-facing work on `main` (the Webshare residential proxy feature plus its egress-probe script and pre-release fixes from PR #148). Release-tooling commits are non-user-facing and correctly omitted.

Only gap: the existing Added entry didn't link the PR that landed the fixes. Appended `[#148]` for traceability.

## Type of Change

- [x] Documentation update

## Related Issues

Relates to #148

## Changes Made

- Append PR link `([#148](https://github.com/openplaud/openplaud/pull/148))` to the Webshare proxy Added entry under `[Unreleased]`.

## Testing

- Not run (docs-only change).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes

Audit notes:

- `b03aeee` (feat: proxy), `3dfbcd7` (egress probe script), `df0fba1` (pre-release proxy fixes) — all covered by the existing Added entry; `df0fba1` folds into the in-flight feature per convention rather than getting a separate Fixed entry.
- `14a253f`, `d319703` — release tooling, correctly omitted.
- No deploy-surface (`src/db/schema.ts`, `src/lib/env.ts`, `docker-compose.yml`, installer) breakage; `WEBSHARE_API_KEY` is strictly additive and documented as default-off.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audited CHANGELOG.md since v0.5.0 and appended a link to PR #148 in the Webshare residential proxy entry under [Unreleased] for traceability. Documentation-only; no behavior changes.

<sup>Written for commit e47483e487b028c147fc0aa29a2f683a905e95a6. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/149?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

