### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.5.1] - 2026-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.1] - 2026-05-15
 
 ### Added
 - Optional outbound proxy for Plaud API calls via Webshare residential proxies. When `WEBSHARE_API_KEY` is set, every request to `api*.plaud.ai` / `resource.plaud.ai` routes through a random valid proxy from the Webshare list, with automatic rotation on Cloudflare 403/407 responses. Unset (default) keeps the direct egress path. Required for hosted deployments on flagged datacenter ASNs where Cloudflare returns a 403 HTML challenge before requests reach Plaud's origin; not needed for residential / homelab self-hosts. No effect on non-Plaud outbound traffic. `scripts/plaud-egress-probe.sh` can validate proxy behavior end-to-end against a real account ([#148](https://github.com/openplaud/openplaud/pull/148)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.5.1.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.5.1` tag, which triggers
`docker.yml` and `release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.5.1 adds optional outbound proxying for Plaud API calls using Webshare residential proxies to bypass Cloudflare challenges on some hosts. Default behavior is unchanged; version and changelog updated.

- **New Features**
  - Optional proxy egress for Plaud endpoints (`api*.plaud.ai`, `resource.plaud.ai`) when `WEBSHARE_API_KEY` is set, with auto-rotation on 403/407; non-Plaud traffic unaffected.
  - `scripts/plaud-egress-probe.sh` to validate proxy behavior end-to-end.

- **Migration**
  - No action needed unless your deployment is blocked by Cloudflare; set `WEBSHARE_API_KEY` to enable proxies.
  - After merge, run `bun scripts/release.ts finalize` to push the `v0.5.1` tag and trigger release workflows.

<sup>Written for commit 3cc500f57c48f051edb56e5e2a9a8bcc56aa66d5. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

