### PR TITLE
fix(plaud): impersonate Chrome JA3 via wreq-js so Bun fetch passes Cloudflare

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,14 @@ import type { NextConfig } from "next";
 // request time, in lockstep with `<RybbitAnalytics>`'s render gate.
 const nextConfig: NextConfig = {
     output: "standalone",
+    // `wreq-js` is a Rust napi addon used by `src/lib/plaud/fetch.ts` to
+    // emit a Chrome-shaped TLS handshake when calling Plaud through the
+    // Webshare proxy (see `src/lib/plaud/fetch.ts`). The package ships
+    // prebuilt `.node` binaries that Turbopack can't bundle into ESM
+    // chunks (`non-ecmascript placeable asset`). Externalise so Next
+    // leaves the require in place and node-file-trace pulls the binary
+    // into the standalone output at runtime.
+    serverExternalPackages: ["wreq-js"],
     // The `/install.sh` and `/[version]/install.sh` routes read
     // `scripts/install.sh` from disk at request time. The standalone
     // output only includes files reachable through the build graph, so

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "tailwind-merge": "^3.4.0",
         "undici": "^7.16.0",
         "vitest": "^4.0.12",
+        "wreq-js": "^2.3.0",
         "zod": "^4.1.12"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       vitest:
         specifier: ^4.0.12
         version: 4.0.12(@types/debug@4.1.13)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
+      wreq-js:
+        specifier: ^2.3.0
+        version: 2.3.0
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -4826,6 +4829,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  wreq-js@2.3.0:
+    resolution: {integrity: sha512-jROBpTUhVH40qG+cAvBhdduKPGDSx55jK1dIDmVuu29sux9i8KY0u0wb5tHkMzXKDy9hrfHP+bpvaSq25rGwEA==}
+    cpu: [x64, arm64]
+    os: [darwin, linux, win32]
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
@@ -10222,6 +10230,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  wreq-js@2.3.0: {}
 
   ws@8.17.1: {}
 

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -2,28 +2,47 @@
  * `plaudFetch` — thin wrapper around `fetch()` that routes Plaud-bound
  * requests through a residential proxy when one is configured.
  *
- * See `./proxy.ts` for the why: Plaud's Cloudflare zone blocks datacenter
- * ASNs with a 403 + HTML challenge at the edge. This wrapper:
+ * Why two layers of mitigation, not one: Plaud sits behind Cloudflare's
+ * Bot Management, which scores TWO signals independently:
  *
+ *   1. Source IP / ASN. Datacenter ASNs (Contabo, OVH, Hetzner, …) are
+ *      bucketed and blocked at the edge. Mitigated by routing through a
+ *      Webshare residential proxy — see `./proxy.ts`.
+ *   2. TLS / HTTP fingerprint (JA3, JA4, HTTP/2 SETTINGS, header order).
+ *      OpenPlaud runs on Bun in production (`Dockerfile` uses `oven/bun:1`),
+ *      and Bun's TLS handshake produces a fingerprint Cloudflare flags as
+ *      "lying client" when paired with a Chrome User-Agent — even from a
+ *      clean residential IP. Mitigated by `wreq-js`, a Rust-backed HTTP
+ *      client that emits a byte-identical Chrome `ClientHello` and HTTP/2
+ *      SETTINGS frame.
+ *
+ * The two mitigations compose: app → wreq-js (Chrome JA3) → Webshare
+ * (residential ASN) → Plaud. Both are required on flagged-VPS deploys.
+ *
+ * Behaviour summary:
  *   1. Decides per-URL whether to proxy (`shouldProxyPlaud`).
  *   2. Picks a proxy from the Webshare list (`getPlaudProxyUrl`).
- *   3. Sends the request via an `undici.ProxyAgent` dispatcher.
+ *   3. Sends the request via `wreq-js` with a Chrome browser profile and
+ *      the proxy URL.
  *   4. On 403 / 407 while proxied, invalidates the proxy and retries once
  *      with a fresh one. On the second 403 we give up — that's almost
  *      certainly an upstream Plaud-side rejection (bad token, missing
  *      workspace), not a proxy-IP problem.
  *
  * SSRF posture is unchanged: every caller still passes URLs through
- * `safePlaudUrl` / `isValidPlaudApiUrl` first, so the proxy never sees an
+ * `safePlaudUrl` / `isValidPlaudApiUrl` first, so wreq-js never sees an
  * off-domain target. The proxy URL itself is server-controlled (env var
  * → Webshare API) and is never user-influenced.
  *
  * Non-Plaud URLs fall straight through to the global `fetch`. We do NOT
- * proxy other outbound calls (S3, AI providers, SMTP) — they aren't
- * blocked and adding latency / cost would be wasteful.
+ * proxy or fingerprint-spoof other outbound calls (S3, AI providers,
+ * SMTP) — they aren't blocked and the cost would be wasteful.
  */
 
-import { ProxyAgent } from "undici";
+import {
+    type BodyInit as WreqBodyInit,
+    fetch as impersonateFetch,
+} from "wreq-js";
 import {
     getPlaudProxyUrl,
     invalidatePlaudProxy,
@@ -34,22 +53,14 @@ import {
 const MAX_PROXY_ROTATIONS = 1;
 
 /**
- * Memoised dispatcher per proxy URL. ProxyAgent maintains an internal
- * connection pool — recreating it per request would defeat keep-alive.
- *
- * Bounded by the size of the Webshare list (typically <100 entries) and by
- * the blacklist eviction in proxy.ts; we don't otherwise prune.
+ * Browser profile we present to Cloudflare. Chrome 142 on Windows is one
+ * of the most common live browser fingerprints; using a popular profile
+ * keeps us in the high-traffic JA4 buckets that Cloudflare's bot-score
+ * heuristics treat as normal browser noise. Profile name is from
+ * `wreq-js`'s `BrowserProfile` enum.
  */
-const dispatcherCache = new Map<string, ProxyAgent>();
-
-function getDispatcher(proxyUrl: string): ProxyAgent {
-    let agent = dispatcherCache.get(proxyUrl);
-    if (!agent) {
-        agent = new ProxyAgent(proxyUrl);
-        dispatcherCache.set(proxyUrl, agent);
-    }
-    return agent;
-}
+const IMPERSONATE_BROWSER = "chrome_142" as const;
+const IMPERSONATE_OS = "windows" as const;
 
 /**
  * Drop-in replacement for `fetch()` for any URL that may be a Plaud host.
@@ -76,18 +87,26 @@ export async function plaudFetch(
     }
 
     while (true) {
-        // `dispatcher` is undici-specific; Node's global fetch is backed by
-        // undici so the property is honoured at runtime. TS doesn't know
-        // this without lib augmentation, so we cast at the boundary.
-        const dispatcher = getDispatcher(currentProxy.url);
-        const initWithDispatcher = {
-            ...init,
-            dispatcher,
-        } as RequestInit & { dispatcher: ProxyAgent };
-
         let response: Response;
         try {
-            response = await fetch(url, initWithDispatcher);
+            // wreq-js's fetch is web-Response-compatible; cast to the
+            // global `Response` so the public signature is unchanged for
+            // callers (which only use `.status`, `.headers.get`,
+            // `.json()`, `.text()`, `.body`, `.arrayBuffer()`).
+            response = (await impersonateFetch(url, {
+                method: init?.method,
+                headers: init?.headers as Record<string, string> | undefined,
+                // wreq-js's `BodyInit` is narrower than the DOM's (no
+                // ReadableStream). Plaud calls only ever send
+                // JSON-string bodies (or no body at all), so the cast
+                // is safe in practice; if a caller ever passes a
+                // streamed body it'll surface here at the type level.
+                body: init?.body as WreqBodyInit | null | undefined,
+                signal: init?.signal ?? undefined,
+                proxy: currentProxy.url,
+                browser: IMPERSONATE_BROWSER,
+                os: IMPERSONATE_OS,
+            })) as unknown as Response;
         } catch (err) {
             // Network error through the proxy (timeout, connection reset).
             // Treat like a 403: invalidate + rotate once.
@@ -167,12 +186,12 @@ function logProxyEvent(
 }
 
 /**
- * Test-only: reset the dispatcher cache. The proxy.ts cache is reset
+ * Test-only: previously reset the undici dispatcher cache. wreq-js
+ * manages its own internal connection state per request — there is no
+ * module-level cache to reset on this side anymore. Kept as a no-op so
+ * existing test imports don't break; the proxy.ts cache is reset
  * independently via `_resetPlaudProxyCacheForTest`.
  */
 export function _resetPlaudFetchForTest(): void {
-    for (const agent of dispatcherCache.values()) {
-        agent.close().catch(() => undefined);
-    }
-    dispatcherCache.clear();
+    // intentionally empty
 }

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -40,8 +40,8 @@
  */
 
 import {
-    type BodyInit as WreqBodyInit,
     fetch as impersonateFetch,
+    type BodyInit as WreqBodyInit,
 } from "wreq-js";
 import {
     getPlaudProxyUrl,

--- a/src/tests/plaud-proxy.integration.test.ts
+++ b/src/tests/plaud-proxy.integration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * End-to-end integration test for `plaudFetch` over the wreq-js +
+ * Webshare path.
+ *
+ * Why this exists: unit tests in `plaud-proxy.test.ts` mock both the
+ * Webshare API and `wreq-js`, so they can't catch the failure mode that
+ * actually shipped — a runtime TLS fingerprint that Cloudflare flags
+ * even with a valid residential proxy IP. This file hits real Plaud
+ * through a real Webshare proxy from the current Bun runtime, which is
+ * the only configuration that reproduces the regression.
+ *
+ * Opt-in. Skipped unless BOTH env vars are set:
+ *   PLAUD_BEARER_TOKEN  — a valid Plaud JWT (any account; we only call
+ *                         /team-app/workspaces/list, a read-only endpoint
+ *                         that returns the user's own workspaces).
+ *   WEBSHARE_API_KEY    — a Webshare account with at least one valid
+ *                         residential proxy in its list.
+ *
+ * Run:
+ *   PLAUD_BEARER_TOKEN=eyJ... WEBSHARE_API_KEY=... \
+ *     bun test src/tests/plaud-proxy.integration.test.ts
+ *
+ * What's pinned:
+ *   1. The proxied path returns HTTP 200 from Cloudflare-fronted Plaud.
+ *      A 403 here means our TLS fingerprint regressed (e.g. the wreq-js
+ *      browser profile became stale or the Webshare proxies got flagged).
+ *   2. The response body parses as Plaud's standard `{status:0, data:...}`
+ *      JSON envelope — i.e. we got real Plaud, not a Cloudflare HTML
+ *      challenge masquerading as a 200.
+ *   3. Repeated calls succeed. Connection reuse / per-tunnel scoring
+ *      doesn't accumulate enough to start flagging us.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+// Mirror the pattern in `plaud.integration.test.ts`: mock env so importing
+// plaudFetch (which transitively pulls `proxy.ts` → `@/lib/env`) doesn't
+// trip the DATABASE_URL/ENCRYPTION_KEY runtime checks. The proxy code
+// only reads WEBSHARE_API_KEY off env, so passing that through is enough.
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: process.env.WEBSHARE_API_KEY,
+}));
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+import { plaudFetch } from "@/lib/plaud/fetch";
+
+const bearerToken = process.env.PLAUD_BEARER_TOKEN;
+const webshareKey = process.env.WEBSHARE_API_KEY;
+const hasCreds =
+    typeof bearerToken === "string" &&
+    bearerToken.length > 0 &&
+    typeof webshareKey === "string" &&
+    webshareKey.length > 0;
+
+if (!hasCreds) {
+    console.warn(
+        "Skipping plaudFetch+Webshare integration tests: set both PLAUD_BEARER_TOKEN and WEBSHARE_API_KEY to run.",
+    );
+}
+
+const describeIntegration = hasCreds ? describe : describe.skip;
+
+// EU region — chosen because the original 403 reports were all on
+// `api-euc1.plaud.ai`. Tests run there to keep the regression surface
+// covered. Other regions sit behind the same Cloudflare zone, so a
+// passing EU test is a strong indicator they all pass.
+const PLAUD_URL =
+    "https://api-euc1.plaud.ai/team-app/workspaces/list?need_personal_workspace=true";
+
+async function callPlaud(): Promise<Response> {
+    return plaudFetch(PLAUD_URL, {
+        headers: {
+            Authorization: `Bearer ${bearerToken}`,
+            "Content-Type": "application/json",
+        },
+    });
+}
+
+// Real network + Webshare list fetch + native binary load on the cold
+// path can comfortably exceed vitest's default 5s. 30s is what the
+// existing Plaud integration tests use for similar reasons.
+const REAL_NETWORK_TIMEOUT_MS = 30_000;
+
+describeIntegration("plaudFetch through wreq-js + Webshare", () => {
+    it(
+        "returns HTTP 200 with a real Plaud JSON body",
+        async () => {
+            const res = await callPlaud();
+            expect(res.status).toBe(200);
+
+            // Cloudflare challenge pages return text/html and a body that
+            // includes "Attention Required". The real Plaud envelope is
+            // application/json with a `status` field. Pin both.
+            const ct = res.headers.get("content-type") ?? "";
+            expect(ct).toContain("application/json");
+
+            const body = (await res.json()) as { status?: unknown };
+            expect(body.status).toBe(0);
+        },
+        REAL_NETWORK_TIMEOUT_MS,
+    );
+
+    it(
+        "returns 200 on three consecutive calls (connection reuse stable)",
+        async () => {
+            for (let i = 0; i < 3; i++) {
+                const res = await callPlaud();
+                expect(res.status).toBe(200);
+                // Drain so the underlying connection is reusable.
+                await res.text();
+            }
+        },
+        REAL_NETWORK_TIMEOUT_MS,
+    );
+});

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -5,8 +5,9 @@
  *   - `shouldProxyPlaud` only matches Plaud-owned hostnames over HTTPS.
  *   - `plaudFetch` falls through to direct fetch when Webshare isn't
  *     configured (the self-host default — must not regress).
- *   - With a Webshare list available, `plaudFetch` selects a proxy and
- *     attaches an undici `dispatcher` to the fetch call.
+ *   - With a Webshare list available, `plaudFetch` invokes `wreq-js`'s
+ *     fingerprint-impersonating fetch with the selected proxy URL, a
+ *     Chrome browser profile, and an OS hint.
  *   - A 403 response while proxied triggers exactly one rotation, after
  *     which the original response is returned (we don't loop forever
  *     and we don't blow past the rotation budget).
@@ -28,6 +29,14 @@ const mockEnv = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+const mockWreq = vi.hoisted(() => ({
+    fetch: vi.fn() as Mock,
+}));
+
+vi.mock("wreq-js", () => ({
+    fetch: mockWreq.fetch,
+}));
 
 import { _resetPlaudFetchForTest, plaudFetch } from "@/lib/plaud/fetch";
 import {
@@ -83,6 +92,7 @@ const otherProxy = {
 beforeEach(() => {
     mockFetch = vi.fn();
     global.fetch = mockFetch as typeof global.fetch;
+    mockWreq.fetch.mockReset();
     mockEnv.WEBSHARE_API_KEY = undefined;
     _resetPlaudProxyCacheForTest();
     _resetPlaudFetchForTest();
@@ -110,23 +120,20 @@ describe("shouldProxyPlaud", () => {
 });
 
 describe("plaudFetch without Webshare configured", () => {
-    it("calls global fetch directly with no dispatcher", async () => {
+    it("calls global fetch directly and never invokes wreq-js", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
         expect(mockFetch).toHaveBeenCalledTimes(1);
-
-        const [, init] = mockFetch.mock.calls[0];
-        expect(init?.dispatcher).toBeUndefined();
+        expect(mockWreq.fetch).not.toHaveBeenCalled();
         expect(isPlaudProxyConfigured()).toBe(false);
     });
 
     it("does not proxy non-Plaud URLs", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://example.com/x");
-        const [, init] = mockFetch.mock.calls[0];
-        expect(init?.dispatcher).toBeUndefined();
+        expect(mockWreq.fetch).not.toHaveBeenCalled();
     });
 });
 
@@ -135,69 +142,71 @@ describe("plaudFetch with Webshare configured", () => {
         mockEnv.WEBSHARE_API_KEY = "test-key";
     });
 
-    it("fetches the Webshare list and attaches a dispatcher", async () => {
-        mockFetch
-            // 1) Webshare list call
-            .mockResolvedValueOnce(webshareList([sampleProxy]))
-            // 2) actual Plaud call through the proxy
-            .mockResolvedValueOnce(okResponse());
+    it("fetches the Webshare list with global fetch and routes the Plaud call through wreq-js", async () => {
+        mockFetch.mockResolvedValueOnce(webshareList([sampleProxy]));
+        mockWreq.fetch.mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockFetch).toHaveBeenCalledTimes(2);
 
+        // Webshare list fetched via global fetch (NOT through wreq-js;
+        // we don't want to spoof Chrome at Webshare's API).
+        expect(mockFetch).toHaveBeenCalledTimes(1);
         const [listUrl] = mockFetch.mock.calls[0];
         expect(String(listUrl)).toContain("proxy.webshare.io");
 
-        const [plaudUrl, init] = mockFetch.mock.calls[1];
+        // Plaud call goes through wreq-js with proxy + browser profile.
+        expect(mockWreq.fetch).toHaveBeenCalledTimes(1);
+        const [plaudUrl, opts] = mockWreq.fetch.mock.calls[0];
         expect(String(plaudUrl)).toBe(PLAUD_API_URL);
-        // dispatcher is an undici ProxyAgent instance — we just assert
-        // shape, not identity, because the cache lazy-constructs it.
-        expect(init?.dispatcher).toBeDefined();
-        expect(typeof init?.dispatcher).toBe("object");
+        expect(opts.proxy).toBe(
+            `http://${sampleProxy.username}:${sampleProxy.password}@${sampleProxy.proxy_address}:${sampleProxy.port}`,
+        );
+        expect(typeof opts.browser).toBe("string");
+        expect(opts.browser).toMatch(/^chrome_/);
+        expect(opts.os).toBeDefined();
     });
 
     it("rotates exactly once on 403 and returns the second response", async () => {
-        mockFetch
-            // Webshare list (two proxies so rotation has a target)
-            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
-            // first proxied attempt: blocked
+        mockFetch.mockResolvedValueOnce(
+            webshareList([sampleProxy, otherProxy]),
+        );
+        mockWreq.fetch
             .mockResolvedValueOnce(forbiddenResponse())
-            // second proxied attempt: also blocked, but we've burned the budget
             .mockResolvedValueOnce(forbiddenResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(403);
-        // 1 list call + 2 plaud attempts = 3 fetches. Crucially NOT 4.
-        expect(mockFetch).toHaveBeenCalledTimes(3);
+        // 1 list call (global) + 2 plaud attempts (wreq) = exactly 3
+        // total. Crucially NOT 4 — the budget is one rotation.
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockWreq.fetch).toHaveBeenCalledTimes(2);
     });
 
     it("returns a readable body when rotation is exhausted (no second proxy)", async () => {
         // Pins the fix for cubic P1 (canceled-body bug): when only one
         // proxy is available and it 403s, plaudFetch must surface the
         // 403 Response with its body intact so the caller can parse it.
-        mockFetch
-            .mockResolvedValueOnce(webshareList([sampleProxy]))
-            .mockResolvedValueOnce(forbiddenResponse());
+        mockFetch.mockResolvedValueOnce(webshareList([sampleProxy]));
+        mockWreq.fetch.mockResolvedValueOnce(forbiddenResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(403);
-        // The critical assertion: body has not been canceled. Reading
-        // it would throw with `TypeError: Body is unusable` if the bug
-        // were present.
         const text = await res.text();
         expect(text).toContain("Cloudflare");
     });
 
     it("returns the success response after a rotation succeeds", async () => {
-        mockFetch
-            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
+        mockFetch.mockResolvedValueOnce(
+            webshareList([sampleProxy, otherProxy]),
+        );
+        mockWreq.fetch
             .mockResolvedValueOnce(forbiddenResponse())
             .mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(mockWreq.fetch).toHaveBeenCalledTimes(2);
     });
 
     it("falls through to direct fetch when Webshare list is empty", async () => {
@@ -207,17 +216,16 @@ describe("plaudFetch with Webshare configured", () => {
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        // Second call must NOT carry a dispatcher.
-        const [, init] = mockFetch.mock.calls[1];
-        expect(init?.dispatcher).toBeUndefined();
+        // Second call must hit global fetch (no impersonation), since
+        // there's no proxy to apply it through.
+        expect(mockWreq.fetch).not.toHaveBeenCalled();
     });
 
     it("does not proxy non-Plaud URLs even when configured", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://s3.amazonaws.com/some-bucket/file");
-        // Only the direct call; no Webshare list lookup.
+        // Only the direct call; no Webshare list lookup, no wreq-js.
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        const [, init] = mockFetch.mock.calls[0];
-        expect(init?.dispatcher).toBeUndefined();
+        expect(mockWreq.fetch).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Description

Plaud's Cloudflare zone scores two independent signals: source ASN and TLS/HTTP fingerprint. PR #148 fixed the ASN side via Webshare residential proxy. The fingerprint side broke separately: OpenPlaud runs on Bun (`oven/bun:1`), and Bun's TLS handshake produces a JA3 Cloudflare flags as "lying client" when paired with a Chrome `User-Agent` — even from a clean residential IP. Result: every proxied call returned a 403 + Cloudflare HTML challenge regardless of which Webshare IP was used.

This PR routes the proxied path through `wreq-js`, a Rust-backed HTTP client that emits a byte-identical Chrome `ClientHello` and HTTP/2 `SETTINGS` frame. The two mitigations now compose: `app → wreq-js (Chrome JA3) → Webshare (residential ASN) → Plaud`.

Diagnosis evidence (same Webshare proxy IP, same token, same target, same headers):

- macOS Node 22 + undici through Webshare → **200**
- container Bun fetch through Webshare → **403** + Cloudflare HTML challenge
- container `curl` through Webshare → **200**

The runtime — not the proxy IP, not the headers, not our code — is the cause.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Follow-up to #148 (residential proxy work). No tracking issue — the regression surfaced in production logs after #148 shipped.

## Changes Made

- Add `wreq-js@^2.3.0` dependency (Rust napi, fetch-style API, MIT, prebuilt binaries for `darwin-arm64`, `linux-x64`, `linux-arm64`).
- Replace `undici.ProxyAgent` + `dispatcherCache` with `wreq-js.fetch` (`browser: "chrome_142"`, `os: "windows"`) on the proxied path in `src/lib/plaud/fetch.ts`.
- Direct path unchanged: self-host installs without `WEBSHARE_API_KEY` keep using bare `global.fetch`. wreq-js's native binary is loaded at module init but never invoked when no proxy is configured.
- Preserve retry/blacklist semantics exactly: one rotation budget, body intact when rotation is exhausted (the cubic P1 fix from #148), network errors invalidate the proxy once before re-throwing.
- Update `src/tests/plaud-proxy.test.ts` to mock `wreq-js` instead of asserting on `init.dispatcher`. All 10 unit tests pass.
- Add `src/tests/plaud-proxy.integration.test.ts` — opt-in real-network regression that hits Plaud through Webshare via `plaudFetch`. Skipped unless both `PLAUD_BEARER_TOKEN` and `WEBSHARE_API_KEY` are set.

## Testing

### Test Environment

- macOS arm64 + Bun 1.3.2 (local dev)
- Docker `oven/bun:1` + Bun 1.3.14 + `linux/arm64` (matches base image)
- Docker `oven/bun:1` + Bun 1.3.14 + `linux/amd64` via qemu (matches prod arch)
- Real `api-euc1.plaud.ai` through real Webshare residential proxy `45.151.163.18:5771`

### Test Steps

1. `pnpm test` — full Vitest suite: **352 passed, 5 skipped (integration)**.
2. `pnpm format-and-lint src/lib/plaud/fetch.ts src/tests/plaud-proxy.test.ts src/tests/plaud-proxy.integration.test.ts` — clean.
3. `pnpm type-check` — clean for changed files. (One pre-existing error in `src/lib/source.ts` from missing `@/.source/server` fumadocs-generated file; reproduces on `main` without this PR.)
4. `WEBSHARE_API_KEY=… PLAUD_BEARER_TOKEN=… pnpm vitest run src/tests/plaud-proxy.integration.test.ts` — both tests **pass** with HTTP 200 + real Plaud JSON envelope.
5. `docker run --rm --platform linux/arm64 oven/bun:1 …` running a probe that mirrors `plaudFetch`'s wreq-js call — **3/3 HTTP 200**, no `cf-mitigated`.
6. `docker run --rm --platform linux/amd64 oven/bun:1 …` (matches prod arch via qemu) — **3/3 HTTP 200**, no `cf-mitigated`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (the two-layer Cloudflare scoring is explained in `fetch.ts`'s module docstring)
- [ ] I have made corresponding changes to the documentation — N/A; the proxy is server-internal, no user-facing docs surface
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (unit + opt-in integration)
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`) for changed files (one unrelated pre-existing error in `src/lib/source.ts` that reproduces on `main`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None on the deploy surface. wreq-js is added as a regular dependency; self-host operators without `WEBSHARE_API_KEY` see no behavioral change. Image size grows by the wreq-js prebuilt binary (~46 MB unpacked, single-arch slice in the final container).

## Additional Notes

- `wreq-js` is a Rust napi binding to the `wreq` HTTP client. 23k weekly downloads, MIT, actively maintained (latest release April 2026). Verified to load and run under Bun 1.3.14 in `oven/bun:1` on both arm64 and amd64.
- Two alternative mitigations were evaluated and rejected: (1) switching the runtime back to Node.js — bigger deploy-surface change than the problem warrants, and Cloudflare can later tighten on Node-undici's fingerprint too; (2) `curl-impersonate` sidecar container — operationally cleaner in isolation but adds a second service to `docker-compose.yml` for affected operators. wreq-js works in-process under Bun, which makes the sidecar overhead unnecessary.
- An earlier in-process candidate, `impers` (lexiforest's TypeScript port of `curl_cffi`), crashes Bun on `uv_poll_init_socket` ([oven-sh/bun#18546](https://github.com/oven-sh/bun/issues/18546)) and was ruled out.

## For Reviewers

- The proxied vs. direct branch in `plaudFetch` is the only behavior change. Please sanity-check that the direct path (returned by `if (!shouldProxyPlaud(url))` and by the `Webshare unconfigured / exhausted` fall-throughs) is unchanged.
- The unit test mock now intercepts `wreq-js.fetch` instead of dispatching off `init.dispatcher`. Confirm the mock setup matches your expectations for future tests against this surface.
- The new integration test is opt-in and won't run in CI by default — same pattern as the existing `plaud.integration.test.ts`. Run with `PLAUD_BEARER_TOKEN=... WEBSHARE_API_KEY=... pnpm vitest run src/tests/plaud-proxy.integration.test.ts` to reproduce the green result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloudflare 403s on Plaud proxy requests by impersonating Chrome’s TLS/HTTP fingerprint using `wreq-js` when a Webshare proxy is configured. Bun-based deploys now pass Cloudflare and return 200s; this composes with the residential proxy fix.

- **Bug Fixes**
  - Route Plaud-bound calls through `wreq-js.fetch` with `browser: "chrome_142"` and `os: "windows"` and the selected Webshare proxy.
  - Keep non-Plaud and unproxied paths on `global.fetch`; self-hosts without `WEBSHARE_API_KEY` are unchanged.
  - Preserve retry/rotation semantics: one rotation on 403/407; readable body when rotation is exhausted; network errors invalidate once before rethrow.
  - Replace undici `ProxyAgent` path; test helper reset is now a no-op. Unit tests updated to mock `wreq-js`; added opt-in integration test hitting Plaud via Webshare.

- **Dependencies**
  - Added `wreq-js@^2.3.0`.
  - Next.js build: externalize `wreq-js` via `serverExternalPackages` so Turbopack doesn’t bundle the napi addon and the standalone output includes the binary.

<sup>Written for commit d6e765d152a82a693ccf1123373c6ba174e6e62d. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

