### PR TITLE
docs(changelog): log PR #152 Cloudflare JA3 fix under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Plaud sync from hosted/VPS deploys whose ASN is flagged by Cloudflare: pair the Webshare residential proxy from v0.5.1 with a Chrome TLS/JA3 fingerprint via `wreq-js`, so Bun's default handshake stops getting a 403 + Cloudflare challenge even from a clean residential IP. Required because Cloudflare scores ASN and TLS fingerprint independently; #148 only addressed the ASN side. Direct path (no `WEBSHARE_API_KEY` set) is unchanged and does not load the new dependency at runtime ([#152](https://github.com/openplaud/openplaud/pull/152)).
+
 ## [0.5.1] - 2026-05-15
 
 ### Added


### PR DESCRIPTION
## Description

Maintainer changelog audit for the post-v0.5.1 cycle. Logs PR #152 (Cloudflare JA3 fix paired with v0.5.1's Webshare proxy) under `## [Unreleased]` -> `### Fixed`. No other commits since v0.5.1 are user-facing.

## Type of Change

- [x] Documentation update

## Related Issues

Relates to #152

## Changes Made

- Add `### Fixed` subsection under `## [Unreleased]` in `CHANGELOG.md` with one entry for PR #152, explaining why the JA3/TLS fingerprint fix is required alongside the Webshare ASN proxy from #148, and noting the direct path is unchanged.

## Testing

- Not run (docs-only change).

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Database Changes

None.

## Breaking Changes

None.

## For Reviewers

- Confirm the entry belongs under `Fixed` (not `Changed`) — the JA3 work is part of completing the v0.5.1 Webshare proxy fix on flagged ASNs, not a new capability.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Fixed" entry under [Unreleased] in the changelog to document the Cloudflare JA3/TLS fingerprint fix (PR #152) paired with v0.5.1’s Webshare proxy for flagged ASNs. Clarifies that the direct path is unchanged and `wreq-js` is only used when the Webshare proxy is enabled.

<sup>Written for commit 0533ead0f1a9e53e96813c227328828ddfc8e3cb. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

