### PR TITLE
chore(release): v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.2] - 2026-05-15
 
 ### Fixed
 - Plaud sync from hosted/VPS deploys whose ASN is flagged by Cloudflare: pair the Webshare residential proxy from v0.5.1 with a Chrome TLS/JA3 fingerprint via `wreq-js`, so Bun's default handshake stops getting a 403 + Cloudflare challenge even from a clean residential IP. Required because Cloudflare scores ASN and TLS fingerprint independently; #148 only addressed the ASN side. Direct path (no `WEBSHARE_API_KEY` set) is unchanged and does not load the new dependency at runtime ([#152](https://github.com/openplaud/openplaud/pull/152)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.5.2] - 2026-05-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.5.2.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.5.2` tag, which triggers
`docker.yml` and `release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.5.2 fixes Cloudflare blocks during Plaud sync on hosted/VPS deploys by pairing the Webshare residential proxy with a Chrome TLS/JA3 fingerprint via `wreq-js`. Direct path without `WEBSHARE_API_KEY` is unchanged; version and changelog updated.

- **Migration**
  - Merge with “Create a merge commit” (not squash).
  - After merge, run: `bun scripts/release.ts finalize` to push the `v0.5.2` tag and trigger `docker.yml` and `release.yml`.

<sup>Written for commit 99d730b833c71f4bcaa9dee8665a720400d30933. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

