### PR TITLE
fix(build): include wreq-js in standalone trace so Plaud proxy path boots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Plaud sync when `WEBSHARE_API_KEY` is set crashed the server with `Cannot find package 'wreq-js' from '.next/server/chunks/[turbopack]_runtime.js'` on Docker deploys. v0.5.2 listed `wreq-js` in `serverExternalPackages` so Turbopack would leave a runtime `externalImport`, but under Next 16 + Turbopack the standalone file tracer does not follow that dynamic import, so `node_modules/wreq-js` never landed in `.next/standalone/node_modules`. Add the package (and its prebuilt `.node` binaries) to `outputFileTracingIncludes` so it ships into the standalone output. Self-host without `WEBSHARE_API_KEY` was unaffected (the module is only required on the proxy path).
+
 ## [0.5.2] - 2026-05-15
 
 ### Fixed

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,9 +23,23 @@ const nextConfig: NextConfig = {
     // output only includes files reachable through the build graph, so
     // declare the script as an extra traced input or it won't ship in
     // the Docker image. See `src/lib/install-script.ts`.
+    //
+    // `wreq-js` is listed in `serverExternalPackages` above so Turbopack
+    // leaves a runtime `externalImport("wreq-js")` in the output. Under
+    // Next 16 + Turbopack, the file tracer does NOT follow that dynamic
+    // import, so `node_modules/wreq-js` is missing from
+    // `.next/standalone/node_modules` and the server boots into
+    //   `Cannot find package 'wreq-js' from '.next/server/chunks/[turbopack]_runtime.js'`
+    // the moment any Plaud helper loads (only when `WEBSHARE_API_KEY` is
+    // set — direct egress doesn't pull this module in). Pull the whole
+    // package, including its prebuilt `.node` binaries, into the trace
+    // explicitly. The `"/**/*"` route key applies the include to every
+    // route, since the Plaud fetch is reachable from sync, OTP, workspace
+    // token, recording mutations, and the dev probe.
     outputFileTracingIncludes: {
         "/install.sh": ["./scripts/install.sh"],
         "/[version]/install.sh": ["./scripts/install.sh"],
+        "/**/*": ["./node_modules/wreq-js/**/*"],
     },
     images: {
         loader: "custom",


### PR DESCRIPTION
Fixes the runtime crash users hit on v0.5.2 with `WEBSHARE_API_KEY` set:

```
Failed to load external module wreq-js: ResolveMessage:
  Cannot find package 'wreq-js' from '/app/.next/server/chunks/[turbopack]_runtime.js'
```

## What broke

v0.5.2 (PR #152) listed `wreq-js` in `serverExternalPackages` so Turbopack wouldn't try to bundle the napi `.node` prebuilds (`non-ecmascript placeable asset`). The commit assumed node-file-trace would then pick up the package and copy `node_modules/wreq-js` into `.next/standalone/node_modules` at build time.

Under Next 16 + Turbopack the tracer does **not** follow the `externalImport("wreq-js")` wrapper Turbopack emits for externalised packages, so the package never lands in standalone. The runtime image boots fine, but the first Plaud call through the proxy path tries to load `wreq-js` and throws.

Direct egress (no `WEBSHARE_API_KEY` set) was unaffected — that path never imports `wreq-js`.

## Fix

Add the package to `outputFileTracingIncludes` so the tracer explicitly ships it into standalone, prebuilt binaries and all:

```ts
outputFileTracingIncludes: {
    "/install.sh": ["./scripts/install.sh"],
    "/[version]/install.sh": ["./scripts/install.sh"],
    "/**/*": ["./node_modules/wreq-js/**/*"],
},
```

The `"/**/*"` route key applies the include to every route, since Plaud fetch is reachable from sync, OTP, workspace token, recording mutations, and the dev probe.

`serverExternalPackages: ["wreq-js"]` stays — bundling a `.node` file is still impossible. This PR only changes whether the package files ship into the standalone runtime, not how they're loaded.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the runtime crash on Docker deploys when `WEBSHARE_API_KEY` is set by shipping `wreq-js` in the standalone output. Ensures the Plaud proxy path boots under Next 16 + Turbopack.

- **Bug Fixes**
  - Added `"/**/*": ["./node_modules/wreq-js/**/*"]` to `outputFileTracingIncludes` so `wreq-js` and its prebuilt `.node` binaries are included in `.next/standalone/node_modules`.
  - Kept `serverExternalPackages: ["wreq-js"]`; this only changes what files ship, not how the module is loaded.

<sup>Written for commit 65034ecaa796d12a0d73a48d347896019a1c8f2c. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/155?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

