### PR TITLE
chore(release): v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.5.3] - 2026-05-15
 
 ### Fixed
 - Plaud sync when `WEBSHARE_API_KEY` is set crashed the server with `Cannot find package 'wreq-js' from '.next/server/chunks/[turbopack]_runtime.js'` on Docker deploys. v0.5.2 listed `wreq-js` in `serverExternalPackages` so Turbopack would leave a runtime `externalImport`, but under Next 16 + Turbopack the standalone file tracer does not follow that dynamic import, so `node_modules/wreq-js` never landed in `.next/standalone/node_modules`. Add the package (and its prebuilt `.node` binaries) to `outputFileTracingIncludes` so it ships into the standalone output. Self-host without `WEBSHARE_API_KEY` was unaffected (the module is only required on the proxy path).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.5.3] - 2026-05-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openplaud",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "OpenPlaud Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.5.3.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.5.3` tag, which triggers
`docker.yml` and `release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.5.3 to fix a Docker crash during Plaud sync when `WEBSHARE_API_KEY` is set by ensuring `wreq-js` is included in the Next standalone output. Also bumps the version and updates the changelog.

- **Bug Fixes**
  - Include `wreq-js` (and its prebuilt `.node` binaries) via output file tracing so Next 16 + Turbopack standalone deploys no longer fail with “Cannot find package 'wreq-js'”.

<sup>Written for commit 20d49cc9ebd79906f51f11e4def372276c1430c0. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

