### PR TITLE
chore(plaud): reduce webshare proxy load on sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,22 @@ ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 # (S3, AI providers, SMTP, GitHub release check).
 # WEBSHARE_API_KEY=
 
+# Scope of the Webshare proxy. "all" (default) routes every Plaud
+# outbound (api*.plaud.ai + resource.plaud.ai signed-URL audio CDN)
+# through the proxy. "api-only" skips proxying resource.plaud.ai
+# downloads -- audio bytes are the dominant proxy cost, so flipping
+# this can save most of your Webshare quota. ONLY enable this after
+# verifying with scripts/plaud-egress-probe.sh that resource.plaud.ai
+# serves direct from your egress IPs (a 403 in production would break
+# every download). Inert when WEBSHARE_API_KEY is unset.
+# PLAUD_PROXY_SCOPE=all
+
+# Per-user rate limit on POST /api/plaud/sync, requests per minute.
+# Backstops the in-app client throttling (manual-tap floor + cross-tab
+# dedup). Even a script hammering the endpoint is capped here before
+# any Plaud or Webshare call is issued. Default 10. Range 1..600.
+# PLAUD_SYNC_RATE_LIMIT_PER_MINUTE=10
+
 # Storage Configuration
 DEFAULT_STORAGE_TYPE=local
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- `PLAUD_PROXY_SCOPE` env var (`all` default | `api-only`) controlling whether `resource.plaud.ai` signed-URL audio downloads go through the Webshare residential proxy. Audio bytes dominate proxy bandwidth; operators who verify `resource.plaud.ai` serves direct from their egress IPs (via `scripts/plaud-egress-probe.sh`) can flip to `api-only` and save most of the Webshare quota without affecting API correctness. Default `all` preserves existing behavior.
+- `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` env var (default 10) capping per-user sync requests. Backstops the new client-side throttling at the route boundary so a script hammering `POST /api/plaud/sync` is rejected before any Plaud or Webshare call is issued.
+
+### Changed
+- Sync flow now coalesces concurrent calls for the same user inside one Next.js worker into a single Plaud round-trip; secondary callers receive the same result with an `inProgress: true` marker and the client renders it as a quiet no-op (no extra `router.refresh()`, no duplicate toast). Combined with a new client-side cross-tab `localStorage` in-flight stamp (90s TTL) and a 5s floor on manual sync taps, this collapses N-tab fan-out and rage-clicks before they reach the API. Reduces Webshare proxy load on hosted by suppressing redundant runs that were previously paginating Plaud and re-downloading recordings through the proxy.
+
 ## [0.5.1] - 2026-05-15
 
 ### Added

--- a/src/app/api/plaud/sync/route.ts
+++ b/src/app/api/plaud/sync/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from "next/server";
 import { requireApiSession } from "@/lib/auth-server";
 import { apiHandler } from "@/lib/errors";
+import { enforcePlaudSyncRateLimit } from "@/lib/plaud/sync-rate-limit";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
 
 export const POST = apiHandler(async (request: Request) => {
     const session = await requireApiSession(request);
+
+    // Backstop against spam-click + multi-tab fan-out. Defaults to 10/min
+    // per user; configurable via PLAUD_SYNC_RATE_LIMIT_PER_MINUTE. Returns
+    // before any Plaud/Webshare call is issued.
+    const limited = await enforcePlaudSyncRateLimit(session.user.id);
+    if (limited) return limited;
 
     const result = await syncRecordingsForUser(session.user.id);
 
@@ -13,5 +20,9 @@ export const POST = apiHandler(async (request: Request) => {
         newRecordings: result.newRecordings,
         updatedRecordings: result.updatedRecordings,
         errors: result.errors,
+        // `true` when this call coalesced into an already-running sync
+        // in the same process. Clients should treat as a no-op success
+        // (no router.refresh(), no "synced N" toast).
+        inProgress: result.inProgress,
     });
 });

--- a/src/hooks/use-auto-sync.ts
+++ b/src/hooks/use-auto-sync.ts
@@ -57,43 +57,77 @@ const STORAGE_KEY = "openplaud_last_sync";
  * each try to sync on mount / visibility-change; without coordination they
  * fan out into N concurrent server calls, each of which on hosted is one
  * round-trip through the Webshare residential proxy. The first tab to start
- * a sync writes `{ startedAt }` here; sibling tabs see a recent stamp and
- * skip their own call. Self-expiring after IN_FLIGHT_TTL_MS so a crashed
- * tab can't permanently block sync for the rest.
+ * a sync writes a token here; sibling tabs see a recent stamp and skip
+ * their own call. Self-expiring after IN_FLIGHT_TTL_MS so a crashed tab
+ * can't permanently block sync for the rest.
+ *
+ * Stamp format: `${startedAtMs}:${token}` where token is a unique per-call
+ * random string. The clearing side checks the current stored value still
+ * matches its own token before deleting -- otherwise a TOCTOU race between
+ * two tabs that both passed the read-then-write check could see the first
+ * tab to finish wipe a stamp that another tab is still relying on.
  */
 const IN_FLIGHT_KEY = "openplaud_sync_in_progress";
 const IN_FLIGHT_TTL_MS = 90_000;
 /** Floor between manual button taps. Stops rage-clicking before it hits the API. */
 const MANUAL_MIN_INTERVAL_MS = 5_000;
 
+function parseStamp(
+    raw: string | null,
+): { startedAt: number; token: string } | null {
+    if (!raw) return null;
+    const sep = raw.indexOf(":");
+    // Back-compat with the previous bare-timestamp format: treat a numeric
+    // body as a stamp with an empty token. The mismatch-on-clear check
+    // below will then refuse to delete it (empty token never matches a
+    // real one), and TTL will expire it instead. Safer than racing.
+    const startedAtStr = sep === -1 ? raw : raw.slice(0, sep);
+    const token = sep === -1 ? "" : raw.slice(sep + 1);
+    const startedAt = Number.parseInt(startedAtStr, 10);
+    if (!Number.isFinite(startedAt)) return null;
+    return { startedAt, token };
+}
+
 function readInFlightStamp(): number | null {
     try {
-        const raw = localStorage.getItem(IN_FLIGHT_KEY);
-        if (!raw) return null;
-        const parsed = Number.parseInt(raw, 10);
-        if (!Number.isFinite(parsed)) return null;
-        if (Date.now() - parsed > IN_FLIGHT_TTL_MS) return null;
-        return parsed;
+        const parsed = parseStamp(localStorage.getItem(IN_FLIGHT_KEY));
+        if (!parsed) return null;
+        if (Date.now() - parsed.startedAt > IN_FLIGHT_TTL_MS) return null;
+        return parsed.startedAt;
     } catch {
         // SSR / private mode / storage quota — fall through to no-stamp.
         return null;
     }
 }
 
-function writeInFlightStamp(): void {
+function writeInFlightStamp(token: string): void {
     try {
-        localStorage.setItem(IN_FLIGHT_KEY, Date.now().toString());
+        localStorage.setItem(IN_FLIGHT_KEY, `${Date.now()}:${token}`);
     } catch {
         // Ignore — best-effort cross-tab signal.
     }
 }
 
-function clearInFlightStamp(): void {
+/**
+ * Remove the stamp ONLY if it still carries our token. Prevents one tab
+ * from wiping another tab's active lock if both raced past the read check
+ * (TOCTOU). A stamp written by a sibling tab is left alone so its own TTL
+ * (or its own clear-on-finish) decides when to drop it.
+ */
+function clearInFlightStampIfOwned(token: string): void {
     try {
-        localStorage.removeItem(IN_FLIGHT_KEY);
+        const parsed = parseStamp(localStorage.getItem(IN_FLIGHT_KEY));
+        if (parsed && parsed.token === token) {
+            localStorage.removeItem(IN_FLIGHT_KEY);
+        }
     } catch {
         // Ignore.
     }
+}
+
+function newSyncToken(): string {
+    // Math.random is plenty here -- this is a non-security collision tag.
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 export function useAutoSync(options: UseAutoSyncOptions = {}) {
@@ -173,8 +207,9 @@ export function useAutoSync(options: UseAutoSyncOptions = {}) {
                 return;
             }
 
+            const token = newSyncToken();
             isSyncingRef.current = true;
-            writeInFlightStamp();
+            writeInFlightStamp(token);
             setStatus((prev) => ({ ...prev, isAutoSyncing: true }));
 
             try {
@@ -254,7 +289,7 @@ export function useAutoSync(options: UseAutoSyncOptions = {}) {
                 }
             } finally {
                 isSyncingRef.current = false;
-                clearInFlightStamp();
+                clearInFlightStampIfOwned(token);
                 setStatus((prev) => ({
                     ...prev,
                     isAutoSyncing: false,

--- a/src/hooks/use-auto-sync.ts
+++ b/src/hooks/use-auto-sync.ts
@@ -52,6 +52,49 @@ interface SyncStatus {
 }
 
 const STORAGE_KEY = "openplaud_last_sync";
+/**
+ * Cross-tab in-flight stamp. Multiple browser tabs running this hook will
+ * each try to sync on mount / visibility-change; without coordination they
+ * fan out into N concurrent server calls, each of which on hosted is one
+ * round-trip through the Webshare residential proxy. The first tab to start
+ * a sync writes `{ startedAt }` here; sibling tabs see a recent stamp and
+ * skip their own call. Self-expiring after IN_FLIGHT_TTL_MS so a crashed
+ * tab can't permanently block sync for the rest.
+ */
+const IN_FLIGHT_KEY = "openplaud_sync_in_progress";
+const IN_FLIGHT_TTL_MS = 90_000;
+/** Floor between manual button taps. Stops rage-clicking before it hits the API. */
+const MANUAL_MIN_INTERVAL_MS = 5_000;
+
+function readInFlightStamp(): number | null {
+    try {
+        const raw = localStorage.getItem(IN_FLIGHT_KEY);
+        if (!raw) return null;
+        const parsed = Number.parseInt(raw, 10);
+        if (!Number.isFinite(parsed)) return null;
+        if (Date.now() - parsed > IN_FLIGHT_TTL_MS) return null;
+        return parsed;
+    } catch {
+        // SSR / private mode / storage quota — fall through to no-stamp.
+        return null;
+    }
+}
+
+function writeInFlightStamp(): void {
+    try {
+        localStorage.setItem(IN_FLIGHT_KEY, Date.now().toString());
+    } catch {
+        // Ignore — best-effort cross-tab signal.
+    }
+}
+
+function clearInFlightStamp(): void {
+    try {
+        localStorage.removeItem(IN_FLIGHT_KEY);
+    } catch {
+        // Ignore.
+    }
+}
 
 export function useAutoSync(options: UseAutoSyncOptions = {}) {
     const {
@@ -100,15 +143,38 @@ export function useAutoSync(options: UseAutoSyncOptions = {}) {
                 return;
             }
 
+            const now = Date.now();
+
             if (silent) {
-                const now = Date.now();
                 const timeSinceLastSync = now - lastSyncTimeRef.current;
                 if (timeSinceLastSync < minInterval) {
                     return;
                 }
+            } else {
+                // Manual taps also honor a small floor so a rage-click
+                // can't shovel duplicate jobs at the proxy. The server
+                // rate limit (PLAUD_SYNC_RATE_LIMIT_PER_MINUTE) is the
+                // hard cap; this is the friendly client-side gate.
+                const timeSinceLastSync = now - lastSyncTimeRef.current;
+                if (timeSinceLastSync < MANUAL_MIN_INTERVAL_MS) {
+                    const waitSeconds = Math.ceil(
+                        (MANUAL_MIN_INTERVAL_MS - timeSinceLastSync) / 1000,
+                    );
+                    onErrorRef.current?.(
+                        `Just synced. Try again in ${waitSeconds}s.`,
+                    );
+                    return;
+                }
+            }
+
+            // Cross-tab coordination: if another tab in this browser is
+            // mid-sync, skip. Stamp self-expires after IN_FLIGHT_TTL_MS.
+            if (readInFlightStamp() !== null) {
+                return;
             }
 
             isSyncingRef.current = true;
+            writeInFlightStamp();
             setStatus((prev) => ({ ...prev, isAutoSyncing: true }));
 
             try {
@@ -121,6 +187,21 @@ export function useAutoSync(options: UseAutoSyncOptions = {}) {
                     const syncTime = new Date();
                     lastSyncTimeRef.current = syncTime.getTime();
                     localStorage.setItem(STORAGE_KEY, syncTime.toISOString());
+
+                    // Server coalesced this into a same-process in-flight
+                    // run. No new data was fetched on our behalf; render
+                    // as a quiet no-op so we don't double-toast or refresh.
+                    if (result.inProgress) {
+                        setStatus((prev) => ({
+                            ...prev,
+                            lastSyncTime: syncTime,
+                            lastSyncResult: {
+                                success: true,
+                                newRecordings: 0,
+                            },
+                        }));
+                        return;
+                    }
 
                     setStatus((prev) => ({
                         ...prev,
@@ -173,6 +254,7 @@ export function useAutoSync(options: UseAutoSyncOptions = {}) {
                 }
             } finally {
                 isSyncingRef.current = false;
+                clearInFlightStamp();
                 setStatus((prev) => ({
                     ...prev,
                     isAutoSyncing: false,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -96,6 +96,32 @@ export const envSchema = z.object({
         .optional()
         .transform((val) => (val === "" ? undefined : val)),
 
+    // Scope of the Webshare proxy. "all" (default) routes every Plaud
+    // outbound (API + signed-URL audio CDN) through the proxy. "api-only"
+    // skips proxying resource.plaud.ai signed-URL downloads, sending
+    // those direct from the server's egress IP. Audio bytes dominate
+    // proxy bandwidth, so flipping this to api-only on hosted can save
+    // most of the Webshare quota -- BUT only do so after verifying with
+    // scripts/plaud-egress-probe.sh that resource.plaud.ai actually
+    // serves direct from your egress IPs. Inert when WEBSHARE_API_KEY
+    // is unset (no proxy is used at all).
+    PLAUD_PROXY_SCOPE: z.enum(["all", "api-only"]).optional().default("all"),
+
+    // Per-user rate limit on POST /api/plaud/sync, in requests per minute.
+    // Defaults to 10. Backstops the client-side manual-sync floor and
+    // cross-tab dedup: even if a script hammers the endpoint, the bucket
+    // throttles it before any Plaud or Webshare call is issued. Set lower
+    // for tighter quotas, higher for power users. Range 1..600.
+    PLAUD_SYNC_RATE_LIMIT_PER_MINUTE: z
+        .string()
+        .regex(
+            /^\d+$/,
+            "PLAUD_SYNC_RATE_LIMIT_PER_MINUTE must be a positive integer",
+        )
+        .optional()
+        .transform((val) => (val ? Number(val) : 10))
+        .pipe(z.number().int().positive().max(600)),
+
     SMTP_HOST: z.string().optional(),
     SMTP_PORT: z
         .string()
@@ -219,6 +245,9 @@ function validateEnv(): Env {
             S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
             S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
             WEBSHARE_API_KEY: process.env.WEBSHARE_API_KEY,
+            PLAUD_PROXY_SCOPE: process.env.PLAUD_PROXY_SCOPE,
+            PLAUD_SYNC_RATE_LIMIT_PER_MINUTE:
+                process.env.PLAUD_SYNC_RATE_LIMIT_PER_MINUTE,
             SMTP_HOST: process.env.SMTP_HOST,
             SMTP_PORT: process.env.SMTP_PORT,
             SMTP_SECURE: process.env.SMTP_SECURE,

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -85,6 +85,12 @@ async function fetchProxyList(): Promise<WebshareProxy[]> {
  * CDN (resource.plaud.ai). All Plaud-owned hostnames sit behind the same
  * Cloudflare zone, so any of them can trigger the datacenter-ASN block.
  *
+ * When `PLAUD_PROXY_SCOPE="api-only"`, signed-URL downloads from
+ * resource.plaud.ai bypass the proxy (egress direct). Audio bytes dominate
+ * proxy bandwidth, so operators who have verified resource.plaud.ai serves
+ * direct from their egress IPs can save most of the Webshare quota.
+ * Default remains `"all"` so existing deploys do not regress.
+ *
  * Returns false for unknown / malformed URLs so we never accidentally route
  * non-Plaud traffic through a third-party proxy.
  */
@@ -93,7 +99,12 @@ export function shouldProxyPlaud(url: string): boolean {
         const u = new URL(url);
         if (u.protocol !== "https:") return false;
         const h = u.hostname.toLowerCase();
-        return h === "plaud.ai" || h.endsWith(".plaud.ai");
+        const isPlaud = h === "plaud.ai" || h.endsWith(".plaud.ai");
+        if (!isPlaud) return false;
+        if (env.PLAUD_PROXY_SCOPE === "api-only" && h === "resource.plaud.ai") {
+            return false;
+        }
+        return true;
     } catch {
         return false;
     }

--- a/src/lib/plaud/sync-rate-limit.ts
+++ b/src/lib/plaud/sync-rate-limit.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-user rate limit for POST /api/plaud/sync.
+ *
+ * Why: every sync request that reaches `syncRecordingsForUser` paginates
+ * Plaud and downloads any new/changed recordings, all of which go through
+ * the Webshare residential proxy on hosted (see `src/lib/plaud/proxy.ts`).
+ * A user spam-clicking the sync button, or N tabs auto-syncing in parallel,
+ * fans out into N concurrent proxy-bound runs. Backstop here: cap at
+ * `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` (default 10) per user per minute,
+ * 429 once exceeded, no Plaud or Webshare call issued.
+ *
+ * Multi-process safe: backed by the existing `apiRateLimitBuckets` Postgres
+ * table via `consumeRateLimitBucket`, so it works correctly across the
+ * hosted load-balanced Next.js workers.
+ *
+ * Complements two other layers:
+ *   1. Client-side dedup in `use-auto-sync.ts` (localStorage stamp +
+ *      manual-sync 5s floor) — keeps the common case off the wire entirely.
+ *   2. In-process promise dedup in `syncRecordingsForUser` — coalesces
+ *      same-process concurrent calls into one Plaud round-trip.
+ */
+
+import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
+import { ErrorCode } from "@/lib/errors";
+import { consumeRateLimitBucket } from "@/lib/rate-limit";
+
+const WINDOW_MS = 60_000;
+
+/**
+ * Consume one token from the per-user sync bucket. Returns null when the
+ * request is allowed; returns a 429 response when the bucket is exhausted.
+ *
+ * Caller pattern:
+ *
+ *     const limited = await enforcePlaudSyncRateLimit(userId);
+ *     if (limited) return limited;
+ *     // ...proceed with sync...
+ */
+export async function enforcePlaudSyncRateLimit(
+    userId: string,
+): Promise<NextResponse | null> {
+    const limit = env.PLAUD_SYNC_RATE_LIMIT_PER_MINUTE;
+    const result = await consumeRateLimitBucket(`plaud-sync:user:${userId}`, {
+        limit,
+        windowMs: WINDOW_MS,
+    });
+
+    if (result.allowed) return null;
+
+    const retryAfter = Math.max(
+        1,
+        Math.ceil((result.resetAt.getTime() - Date.now()) / 1000),
+    );
+    const resetAt = Math.ceil(result.resetAt.getTime() / 1000);
+
+    return NextResponse.json(
+        {
+            error: "You are syncing too often. Please wait a moment and try again.",
+            code: ErrorCode.RATE_LIMITED,
+            details: {
+                retryAfter,
+                limit: result.limit,
+                remaining: result.remaining,
+                resetAt,
+            },
+        },
+        {
+            status: 429,
+            headers: {
+                "Retry-After": retryAfter.toString(),
+                "X-RateLimit-Limit": result.limit.toString(),
+                "X-RateLimit-Remaining": result.remaining.toString(),
+                "X-RateLimit-Reset": resetAt.toString(),
+            },
+        },
+    );
+}

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -29,7 +29,25 @@ interface SyncResult {
     errors: string[];
     /** IDs of recordings that need transcription */
     pendingTranscriptionIds: string[];
+    /**
+     * True when this call coalesced into an already-running sync in the
+     * same process. Counts/IDs reflect that in-flight run, not a fresh
+     * one. Multi-process correctness is handled by the rate limiter at
+     * the route boundary (see `enforcePlaudSyncRateLimit`); this flag is
+     * only set within a single Node worker.
+     */
+    inProgress?: boolean;
 }
+
+/**
+ * Per-user in-flight sync promises. A second request for the same user
+ * while a sync is running in the same process awaits the existing promise
+ * rather than starting a parallel Plaud paginate + download pass. This is
+ * the cheapest possible dedup layer; the per-user rate limit in the route
+ * handler is the cross-process correctness backstop (AGENTS.md: in-memory
+ * locks must not be the only correctness mechanism).
+ */
+const inFlightSyncs = new Map<string, Promise<SyncResult>>();
 
 interface SyncContext {
     userId: string;
@@ -305,10 +323,32 @@ async function processBatch(
  * - Downloads concurrently in batches (5 at a time)
  * - Queues transcription for after sync completes
  * - Stops early if no new recordings found
+ * - In-process dedup: concurrent calls for the same user share one run
  */
 export async function syncRecordingsForUser(
     userId: string,
 ): Promise<SyncResult> {
+    const inFlight = inFlightSyncs.get(userId);
+    if (inFlight) {
+        const shared = await inFlight;
+        // Mark the coalesced response so the route handler / client can
+        // distinguish it from a fresh run. We deliberately do NOT mutate
+        // the in-flight result object (other awaiters share it).
+        return { ...shared, inProgress: true };
+    }
+
+    const run = runSyncRecordingsForUser(userId);
+    inFlightSyncs.set(userId, run);
+    try {
+        return await run;
+    } finally {
+        // Always clear, even on throw, so a failed sync doesn't wedge the
+        // user out of future attempts.
+        inFlightSyncs.delete(userId);
+    }
+}
+
+async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
     const result: SyncResult = {
         newRecordings: 0,
         updatedRecordings: 0,

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -25,6 +25,7 @@ import {
 
 const mockEnv = vi.hoisted(() => ({
     WEBSHARE_API_KEY: undefined as string | undefined,
+    PLAUD_PROXY_SCOPE: "all" as "all" | "api-only",
 }));
 
 vi.mock("@/lib/env", () => ({ env: mockEnv }));
@@ -84,6 +85,7 @@ beforeEach(() => {
     mockFetch = vi.fn();
     global.fetch = mockFetch as typeof global.fetch;
     mockEnv.WEBSHARE_API_KEY = undefined;
+    mockEnv.PLAUD_PROXY_SCOPE = "all";
     _resetPlaudProxyCacheForTest();
     _resetPlaudFetchForTest();
 });
@@ -106,6 +108,17 @@ describe("shouldProxyPlaud", () => {
         expect(shouldProxyPlaud("https://plaud.ai.evil.com/")).toBe(false);
         expect(shouldProxyPlaud("http://api.plaud.ai/")).toBe(false);
         expect(shouldProxyPlaud("not-a-url")).toBe(false);
+    });
+
+    it("skips resource.plaud.ai when PLAUD_PROXY_SCOPE=api-only", () => {
+        mockEnv.PLAUD_PROXY_SCOPE = "api-only";
+        // API still proxied.
+        expect(shouldProxyPlaud("https://api.plaud.ai/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://api-euc1.plaud.ai/foo")).toBe(true);
+        // Audio CDN bypassed.
+        expect(shouldProxyPlaud("https://resource.plaud.ai/file.mp3")).toBe(
+            false,
+        );
     });
 });
 

--- a/src/tests/plaud-sync-dedup.test.ts
+++ b/src/tests/plaud-sync-dedup.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins same-process in-flight dedup in `syncRecordingsForUser`.
+ *
+ * Why: two concurrent POST /api/plaud/sync calls for the same user that
+ * land in the same Next.js worker (multi-tab, retry, parallel curl) used to
+ * each paginate Plaud and download recordings through Webshare. They now
+ * share a single in-flight promise; the second call returns the same
+ * result with `inProgress: true` and triggers zero extra Plaud round-trips.
+ *
+ * Multi-process correctness (across hosted workers) is handled by the
+ * per-user rate limit at the route boundary, tested separately.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        uploadFile: vi.fn().mockResolvedValue(undefined),
+    }),
+}));
+
+vi.mock("@/lib/notifications/bark", () => ({
+    sendNewRecordingBarkNotification: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/notifications/email", () => ({
+    sendNewRecordingEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/transcription/transcribe-recording", () => ({
+    transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from "@/db";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
+import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
+
+const USER_ID = "user-dedup";
+
+/**
+ * Build a select() chain that always resolves to a non-empty connection
+ * but an empty user-settings + user lookup. Lets the sync proceed past the
+ * preamble and into the (mocked) plaud client.
+ */
+function wireSelectChain() {
+    const connectionRow = {
+        id: "conn-1",
+        userId: USER_ID,
+        bearerToken: "enc-token",
+        apiBase: "https://api.plaud.ai",
+        workspaceId: "ws-1",
+    };
+    let call = 0;
+    (db.select as Mock).mockImplementation(() => ({
+        from: () => ({
+            where: () => ({
+                limit: () => {
+                    call += 1;
+                    // 1: plaudConnections, 2: userSettings, 3: users
+                    if (call === 1) return Promise.resolve([connectionRow]);
+                    return Promise.resolve([]);
+                },
+            }),
+        }),
+    }));
+}
+
+function wireUpdateChain() {
+    (db.update as Mock).mockReturnValue({
+        set: () => ({ where: () => Promise.resolve() }),
+    });
+}
+
+describe("syncRecordingsForUser in-process dedup", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("coalesces concurrent calls into one Plaud round-trip", async () => {
+        wireSelectChain();
+        wireUpdateChain();
+
+        // Mock client: getRecordings returns one empty page, slowly, so
+        // both concurrent calls overlap on the same in-flight promise.
+        const getRecordings = vi.fn().mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    setTimeout(() => resolve({ data_file_list: [] }), 20);
+                }),
+        );
+        (createPlaudClient as Mock).mockResolvedValue({
+            getRecordings,
+            workspaceId: "ws-1",
+            usingUserTokenFallback: false,
+        });
+
+        const [a, b] = await Promise.all([
+            syncRecordingsForUser(USER_ID),
+            syncRecordingsForUser(USER_ID),
+        ]);
+
+        // Both callers got a result, but Plaud was only paginated once.
+        expect(getRecordings).toHaveBeenCalledTimes(1);
+        // createPlaudClient itself runs once for the shared run.
+        expect(createPlaudClient).toHaveBeenCalledTimes(1);
+
+        // Exactly one of the two carries `inProgress: true`. We don't
+        // pin which one (race) — only that the dedup marker is present
+        // on exactly the second-to-resolve caller's view.
+        const inProgressFlags = [a.inProgress, b.inProgress].filter(
+            (v) => v === true,
+        );
+        expect(inProgressFlags).toHaveLength(1);
+    });
+
+    it("releases the in-flight slot after completion so subsequent calls run fresh", async () => {
+        wireSelectChain();
+        wireUpdateChain();
+
+        const getRecordings = vi.fn().mockResolvedValue({ data_file_list: [] });
+        (createPlaudClient as Mock).mockResolvedValue({
+            getRecordings,
+            workspaceId: "ws-1",
+            usingUserTokenFallback: false,
+        });
+
+        const first = await syncRecordingsForUser(USER_ID);
+        // Re-wire the select chain — the first run consumed it.
+        wireSelectChain();
+        const second = await syncRecordingsForUser(USER_ID);
+
+        expect(first.inProgress).toBeUndefined();
+        expect(second.inProgress).toBeUndefined();
+        expect(createPlaudClient).toHaveBeenCalledTimes(2);
+    });
+
+    it("releases the in-flight slot on error so users are not wedged", async () => {
+        wireSelectChain();
+        // No update wire-up needed; the run errors before reaching it.
+        (createPlaudClient as Mock).mockRejectedValueOnce(new Error("boom"));
+
+        const errored = await syncRecordingsForUser(USER_ID);
+        expect(errored.errors.length).toBeGreaterThan(0);
+
+        // A subsequent call must start a fresh run, not get stuck on a
+        // dangling rejected promise.
+        wireSelectChain();
+        wireUpdateChain();
+        (createPlaudClient as Mock).mockResolvedValueOnce({
+            getRecordings: vi.fn().mockResolvedValue({ data_file_list: [] }),
+            workspaceId: "ws-1",
+            usingUserTokenFallback: false,
+        });
+        const next = await syncRecordingsForUser(USER_ID);
+        expect(next.inProgress).toBeUndefined();
+        expect(next.errors).toEqual([]);
+    });
+});

--- a/src/tests/plaud-sync-rate-limit.test.ts
+++ b/src/tests/plaud-sync-rate-limit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Pins the per-user rate limit on POST /api/plaud/sync.
+ *
+ * The Postgres-backed bucket is unit-tested in v1-rate-limit.test.ts; this
+ * file pins the Plaud-sync-specific wiring: env-configured limit, 429
+ * envelope shape, RATE_LIMITED code, and the rate-limit headers Retry-After
+ * + X-RateLimit-*.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+    API_TOKEN_HASH_SECRET: undefined as string | undefined,
+    PLAUD_SYNC_RATE_LIMIT_PER_MINUTE: 10,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+    },
+}));
+
+import { db } from "@/db";
+import { ErrorCode } from "@/lib/errors";
+import { enforcePlaudSyncRateLimit } from "@/lib/plaud/sync-rate-limit";
+
+function mockBucketCount(count: number, resetAt: Date) {
+    (db.insert as unknown as Mock).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+            onConflictDoUpdate: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ count, resetAt }]),
+            }),
+        }),
+    });
+}
+
+describe("enforcePlaudSyncRateLimit", () => {
+    beforeEach(() => {
+        mockEnv.PLAUD_SYNC_RATE_LIMIT_PER_MINUTE = 10;
+        vi.clearAllMocks();
+    });
+
+    it("returns null when the bucket is under the limit", async () => {
+        const resetAt = new Date(Date.now() + 60_000);
+        mockBucketCount(3, resetAt);
+
+        const result = await enforcePlaudSyncRateLimit("user-1");
+        expect(result).toBeNull();
+    });
+
+    it("returns a 429 envelope with rate-limit headers when exhausted", async () => {
+        const resetAt = new Date(Date.now() + 45_000);
+        mockBucketCount(11, resetAt);
+
+        const response = await enforcePlaudSyncRateLimit("user-1");
+        expect(response).not.toBeNull();
+        if (!response) return;
+
+        expect(response.status).toBe(429);
+        expect(response.headers.get("X-RateLimit-Limit")).toBe("10");
+        expect(response.headers.get("X-RateLimit-Remaining")).toBe("0");
+        expect(response.headers.get("X-RateLimit-Reset")).toBe(
+            Math.ceil(resetAt.getTime() / 1000).toString(),
+        );
+        expect(response.headers.get("Retry-After")).toBeTruthy();
+
+        const body = (await response.json()) as {
+            code: ErrorCode;
+            details: { limit: number; remaining: number };
+        };
+        expect(body.code).toBe(ErrorCode.RATE_LIMITED);
+        expect(body.details.limit).toBe(10);
+        expect(body.details.remaining).toBe(0);
+    });
+
+    it("honors the env-configured per-minute limit", async () => {
+        mockEnv.PLAUD_SYNC_RATE_LIMIT_PER_MINUTE = 3;
+        const resetAt = new Date(Date.now() + 30_000);
+        mockBucketCount(4, resetAt);
+
+        const response = await enforcePlaudSyncRateLimit("user-1");
+        expect(response).not.toBeNull();
+        if (!response) return;
+        expect(response.headers.get("X-RateLimit-Limit")).toBe("3");
+    });
+});


### PR DESCRIPTION
## Description

Reduces Webshare residential-proxy load on hosted by stopping redundant sync requests at four layers (client manual floor, cross-tab dedup, server rate limit, in-process promise dedup) and adds an operator opt-in to bypass the proxy for audio downloads.

Today, every `POST /api/plaud/sync` paginates Plaud and downloads any new/changed recordings — all through Webshare on hosted. A user with N tabs open, or spam-clicking the sync button, fans out into N concurrent proxied runs. There is no server-side rate limit and no in-flight dedup. Audio downloads (`resource.plaud.ai`) dominate proxy bandwidth.

## Type of Change

- [x] Performance improvement
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

None linked.

## Changes Made

- **Per-user rate limit on `POST /api/plaud/sync`.** New `src/lib/plaud/sync-rate-limit.ts` wraps the existing Postgres-backed `consumeRateLimitBucket`. Default 10 req/min/user via new `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` env var (range 1..600). Returns 429 with `Retry-After` + `X-RateLimit-*` headers before any Plaud or Webshare call.
- **In-process promise dedup in `syncRecordingsForUser`.** A `Map<userId, Promise<SyncResult>>` coalesces concurrent same-worker calls; secondary callers receive the same result with `inProgress: true`. The map entry is cleared in `finally` so failures don't wedge future syncs. Multi-process correctness is the rate limit; this is the in-process optimization (satisfies AGENTS.md "in-memory locks must not be the only correctness mechanism").
- **Client-side coordination in `use-auto-sync.ts`.** Cross-tab `localStorage` in-flight stamp with 90s TTL (self-expiring so a crashed tab can't wedge sync), 5s floor on manual taps with toast ("Just synced. Try again in Ns"), and quiet no-op handling when the server returns `inProgress: true` (no extra `router.refresh()`, no duplicate toast).
- **`PLAUD_PROXY_SCOPE` env (`all` default | `api-only`).** When set to `api-only`, `shouldProxyPlaud` skips `resource.plaud.ai` so signed-URL audio downloads go direct from server egress. Audio bytes dwarf API JSON, so this is the largest single bandwidth win for operators who verify direct works on their egress IPs (probe documented in `.env.example`). Default unchanged.
- `.env.example` + `CHANGELOG.md` ([Unreleased] Added/Changed) entries.

## Testing

### Test Environment
- OS: macOS
- Node: pnpm 10.18.1 (bun runtime per repo)

### Commands run
- `pnpm test src/tests/plaud-sync-rate-limit.test.ts src/tests/plaud-sync-dedup.test.ts src/tests/plaud-proxy.test.ts src/tests/v1-rate-limit.test.ts src/tests/sync.test.ts` — 24/24 pass.
- `pnpm format-and-lint:fix` — only pre-existing warnings outside this PR's scope.
- `pnpm type-check` — clean.

### What's covered by tests
- `plaud-sync-rate-limit.test.ts` — 429 envelope, rate-limit headers, env-configured limit.
- `plaud-sync-dedup.test.ts` — concurrent calls coalesce into one Plaud round-trip; in-flight slot releases on success and on error so users aren't wedged.
- `plaud-proxy.test.ts` — extended with `PLAUD_PROXY_SCOPE=api-only` matrix (API still proxied, `resource.plaud.ai` bypassed).
- Existing `sync.test.ts` continues to pass — the new dedup wrapper is transparent to single-call behavior.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.env.example`, `CHANGELOG.md`)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. All new env vars have safe defaults that preserve current behavior:
- `PLAUD_PROXY_SCOPE` defaults to `"all"` — existing Webshare-using deploys see no change.
- `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` defaults to `10` — well above legitimate usage.
- `inProgress: true` is an additive field on the sync response; clients that ignore it continue to work.

## Additional Notes

**Deliberately deferred (separate follow-ups):**

- **Flipping `PLAUD_PROXY_SCOPE` default to `api-only`.** This is the largest bandwidth win, but `resource.plaud.ai` direct-from-hosted-egress has not been probe-verified. Flipping blind would 403 every download in production if the CDN host shares Cloudflare's datacenter-ASN block. Plan: probe after merge, then a one-line follow-up PR flipping the default.
- **Cross-worker dedup on hosted.** Two requests landing on different Next.js workers in the same millisecond can each start a sync. The rate limit caps the steady-state damage; the millisecond-overlap case is bounded but real. Would have required a Postgres advisory lock holding a connection for the entire sync (or a row-claim with a new column) — too costly for the marginal win.
- **Redis-backed rate limiting / queueing.** Deferred to its own design discussion when a real queue use case lands. The Postgres bucket is fine for current volume.

## For Reviewers

- `src/lib/sync/sync-recordings.ts`: the new `syncRecordingsForUser` is a thin dedup wrapper around the renamed `runSyncRecordingsForUser`. Worth confirming the `finally` always clears the map entry (success, throw, rejected awaiter).
- `src/hooks/use-auto-sync.ts`: the cross-tab stamp is best-effort; intentional design choice given the server rate limit + in-process dedup catch anything that slips through. Self-expires after 90s.
- `src/lib/plaud/proxy.ts`: the scope check runs after the existing Plaud-host whitelist, so SSRF posture is unchanged — we never proxy a non-Plaud URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Webshare proxy load during Plaud sync by collapsing duplicate syncs and allowing direct egress for audio downloads when configured. Cuts burst traffic from multi-tab/rage-clicks and lowers proxy bandwidth.

- **New Features**
  - Per-user rate limit on `POST /api/plaud/sync` via `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` (default 10); returns 429 with rate-limit headers before any Plaud/Webshare call.
  - In-process dedup in `syncRecordingsForUser`; concurrent same-worker calls share one run and coalesced callers get `inProgress: true`.
  - Client-side guardrails: cross-tab `localStorage` in-flight stamp (90s TTL), 5s floor on manual taps, and quiet no-op handling for `inProgress: true`.
  - `PLAUD_PROXY_SCOPE` (`all` default | `api-only`) to bypass proxying `resource.plaud.ai` signed-URL audio downloads; API calls stay proxied.

- **Bug Fixes**
  - Cross-tab stamp: add per-call token and only clear the stamp when owned, preventing a tab from wiping a sibling’s active lock; backward compatible with pre-token stamps.

<sup>Written for commit b3bb7004376ba716b3ba6aaaf9481b3b18d47ce8. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

