### PR TITLE
docs: add Discord community link and /discord redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/typescript-5.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Next.js](https://img.shields.io/badge/next.js-16-000000?logo=next.js&logoColor=white)](https://nextjs.org/)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://openplaud.com/discord)
 
-[Quick Start](#-quick-start) • [Features](#-features) • [Configuration](#-configuration-guide) • [Contributing](#-contributing) • [License](#-license)
+[Quick Start](#-quick-start) • [Features](#-features) • [Configuration](#-configuration-guide) • [Contributing](#-contributing) • [Discord](https://openplaud.com/discord) • [License](#-license)
 
 </div>
 
@@ -603,7 +604,8 @@ Made with ❤️ for Plaud Note users who want full control over their transcrip
 
 - 📖 [Documentation](docs/) - Detailed guides and API references
 - 🐛 [Issues](https://github.com/openplaud/openplaud/issues) - Bug reports and feature requests
-- 💬 [Discussions](https://github.com/openplaud/openplaud/discussions) - Community discussions
+- 💬 [Discussions](https://github.com/openplaud/openplaud/discussions) - Long-form community discussions
+- 💬 [Discord](https://openplaud.com/discord) - Real-time community chat
 - 📝 [Changelog](CHANGELOG.md) - Version history and release notes
 
 ## ⭐ Support the Project

--- a/src/app/discord/route.ts
+++ b/src/app/discord/route.ts
@@ -1,0 +1,12 @@
+import { permanentRedirect } from "next/navigation";
+
+// Public shortcut for the OpenPlaud community Discord. Lives in the repo
+// (not Cloudflare) so the invite URL is version-controlled and visible in
+// `git log` / grep, matching the `install.sh` precedent for user-facing
+// URLs on openplaud.com. If the invite ever needs to rotate, change the
+// string here and ship a commit.
+const DISCORD_INVITE_URL = "https://discord.gg/F4saKNQrYQ";
+
+export function GET() {
+    permanentRedirect(DISCORD_INVITE_URL);
+}


### PR DESCRIPTION
## Description

Adds a permanent `openplaud.com/discord` shortcut that redirects to the community Discord invite, and links the Discord from the README.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

None.

## Changes Made

- New route handler `src/app/discord/route.ts` that issues a 308 `permanentRedirect` to `https://discord.gg/F4saKNQrYQ`. The invite URL is hardcoded in the route file so rotations are a one-line code change with a `git log` trail — same convention as `src/app/install.sh/route.ts`.
- `README.md`: added a Discord badge and a top-row nav link, plus a `Discord` bullet under `📚 Resources` alongside the existing GitHub Discussions line (Discord = real-time, Discussions = long-form).
- All README links point at `https://openplaud.com/discord` (not the raw `discord.gg` URL) so the indirection is the single source of truth.

### Why code, not Cloudflare

- Matches the `install.sh` precedent: user-facing `openplaud.com/*` URLs live in the repo, version-controlled and reviewable.
- Self-host gets the shortcut for free with no extra config.
- A Cloudflare Bulk Redirect would also work but hides the URL from contributors.

## Testing

- Not run (not requested). The change is a static-string `permanentRedirect` plus README copy; no behavior to assert beyond what the framework guarantees.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

## Database Changes

None.

## Breaking Changes

None. Purely additive: a new route and README links.

## Additional Notes

- No env vars added. The invite URL is a public, permanent invite, treated the same as the hardcoded GitHub URLs elsewhere in the README.
- No `CHANGELOG.md` entry — per `AGENTS.md`, marketing/community surface changes with no behavioral, schema, or env impact are not changelog material.

## For Reviewers

- Confirm you're happy with `permanentRedirect` (308) vs a temporary 307 — 308 is intentional so browsers and search engines cache it; rotation requires shipping a commit, which is the desired tradeoff.
- Confirm both README link placements (top nav row and Resources bullet) are where you want them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permanent `openplaud.com/discord` redirect to the community Discord and links it in the README for easy discovery. Keeps the invite URL version-controlled and consistent across docs.

- **New Features**
  - New route `src/app/discord/route.ts` sends a 308 `permanentRedirect` (via `next/navigation`) to `https://discord.gg/F4saKNQrYQ`.
  - README: added a Discord badge, top nav link, and a Resources entry; all links point to `https://openplaud.com/discord`.

<sup>Written for commit b25e7061f1b7e02434fd66a53c5029aa74d2250f. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

