### PR TITLE
refactor(dashboard): split RecordingList into focused components

### DIFF
--- a/src/components/dashboard/pending-upload-row.tsx
+++ b/src/components/dashboard/pending-upload-row.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface PendingUpload {
+    id: string;
+    filename: string;
+    filesize: number;
+}
+
+function formatSize(bytes: number) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function PendingUploadRow({
+    upload,
+    rowPadding,
+}: {
+    upload: PendingUpload;
+    rowPadding: string;
+}) {
+    return (
+        <div className={cn("flex items-center gap-3", rowPadding)}>
+            <Loader2 className="size-4 animate-spin text-primary" />
+            <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-muted-foreground">
+                    {upload.filename}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                    Uploading… {formatSize(upload.filesize)}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/recording-list-toolbar.tsx
+++ b/src/components/dashboard/recording-list-toolbar.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { ArrowDownAZ, Rows3, Search, X } from "lucide-react";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+
+export type SortOrder = "newest" | "oldest" | "name";
+export type ListDensity = "comfortable" | "compact";
+
+export function RecordingListToolbar({
+    query,
+    onQueryChange,
+    onEnterSelectFirst,
+    searchRef,
+    filteredCount,
+    totalCount,
+    sortOrder,
+    onSortOrderChange,
+    density,
+    onDensityChange,
+}: {
+    query: string;
+    onQueryChange: (next: string) => void;
+    onEnterSelectFirst: () => void;
+    searchRef: React.RefObject<HTMLInputElement | null>;
+    filteredCount: number;
+    totalCount: number;
+    sortOrder: SortOrder;
+    onSortOrderChange: (next: SortOrder) => void;
+    density: ListDensity;
+    onDensityChange: (next: ListDensity) => void;
+}) {
+    return (
+        <div className="flex flex-col gap-2 border-b p-3">
+            <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                    ref={searchRef}
+                    value={query}
+                    onChange={(e) => onQueryChange(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            onEnterSelectFirst();
+                        }
+                    }}
+                    placeholder="Search recordings, transcripts..."
+                    className="h-9 pl-8 pr-8"
+                    aria-label="Search recordings"
+                />
+                {query && (
+                    <button
+                        type="button"
+                        onClick={() => onQueryChange("")}
+                        aria-label="Clear search"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:text-foreground"
+                    >
+                        <X className="size-4" />
+                    </button>
+                )}
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>
+                    {filteredCount}
+                    {query ? " matching" : ""} of {totalCount} recording
+                    {totalCount !== 1 ? "s" : ""}
+                </span>
+                <div className="flex items-center gap-1">
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                aria-label="Sort"
+                            >
+                                <ArrowDownAZ className="size-3.5" />
+                                <span>
+                                    {sortOrder === "newest"
+                                        ? "Newest"
+                                        : sortOrder === "oldest"
+                                          ? "Oldest"
+                                          : "Name"}
+                                </span>
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                            <DropdownMenuRadioGroup
+                                value={sortOrder}
+                                onValueChange={(v) =>
+                                    onSortOrderChange(v as SortOrder)
+                                }
+                            >
+                                <DropdownMenuRadioItem value="newest">
+                                    Newest first
+                                </DropdownMenuRadioItem>
+                                <DropdownMenuRadioItem value="oldest">
+                                    Oldest first
+                                </DropdownMenuRadioItem>
+                                <DropdownMenuRadioItem value="name">
+                                    Name
+                                </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                aria-label="Density"
+                            >
+                                <Rows3 className="size-3.5" />
+                                <span>
+                                    {density === "compact"
+                                        ? "Compact"
+                                        : "Comfortable"}
+                                </span>
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuLabel>Density</DropdownMenuLabel>
+                            <DropdownMenuRadioGroup
+                                value={density}
+                                onValueChange={(v) =>
+                                    onDensityChange(v as ListDensity)
+                                }
+                            >
+                                <DropdownMenuRadioItem value="comfortable">
+                                    Comfortable
+                                </DropdownMenuRadioItem>
+                                <DropdownMenuRadioItem value="compact">
+                                    Compact
+                                </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/recording-list.tsx
+++ b/src/components/dashboard/recording-list.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import {
-    ArrowDownAZ,
-    Loader2,
-    Mic,
-    MoreHorizontal,
-    Play,
-    Rows3,
-    Search,
-    Trash2,
-    X,
-} from "lucide-react";
+import { Mic } from "lucide-react";
 import type * as React from "react";
 import {
     useCallback,
@@ -20,34 +10,26 @@ import {
     useRef,
     useState,
 } from "react";
-import { useConfirm } from "@/components/confirm-dialog";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { dateGroupLabel, formatDateTime } from "@/lib/format-date";
-import { formatDurationMs } from "@/lib/format-duration";
-import { cn } from "@/lib/utils";
+    type PendingUpload,
+    PendingUploadRow,
+} from "@/components/dashboard/pending-upload-row";
+import {
+    type ListDensity,
+    RecordingListToolbar,
+    type SortOrder,
+} from "@/components/dashboard/recording-list-toolbar";
+import { RecordingRow } from "@/components/dashboard/recording-row";
+import { Card, CardContent } from "@/components/ui/card";
+import { dateGroupLabel } from "@/lib/format-date";
 import type { DateTimeFormat } from "@/types/common";
 import type { Recording } from "@/types/recording";
 
-export type SortOrder = "newest" | "oldest" | "name";
-export type ListDensity = "comfortable" | "compact";
-
-export interface PendingUpload {
-    id: string; // local nanoid-ish, "pending:..."
-    filename: string;
-    filesize: number;
-}
+export type { PendingUpload } from "@/components/dashboard/pending-upload-row";
+export type {
+    ListDensity,
+    SortOrder,
+} from "@/components/dashboard/recording-list-toolbar";
 
 interface TranscriptionData {
     text?: string;
@@ -80,12 +62,6 @@ function persistSetting(field: string, value: unknown) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ [field]: value }),
     }).catch(() => {});
-}
-
-const formatDuration = formatDurationMs;
-
-function formatSize(bytes: number) {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function transcriptSnippet(
@@ -122,7 +98,6 @@ export function RecordingList({
     const [density, setDensity] = useState<ListDensity>(initialDensity);
     const [query, setQuery] = useState("");
     const [visibleCount, setVisibleCount] = useState(initialChunkSize);
-    const confirm = useConfirm();
     const searchRef = useRef<HTMLInputElement>(null);
     const sentinelRef = useRef<HTMLDivElement>(null);
     const rowRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
@@ -136,6 +111,14 @@ export function RecordingList({
         setDensity(next);
         persistSetting("listDensity", next);
     }, []);
+
+    const registerRowRef = useCallback(
+        (id: string, el: HTMLButtonElement | null) => {
+            if (el) rowRefs.current.set(id, el);
+            else rowRefs.current.delete(id);
+        },
+        [],
+    );
 
     const filtered = useMemo(() => {
         const q = query.trim().toLowerCase();
@@ -265,152 +248,33 @@ export function RecordingList({
     return (
         <Card hasNoPadding>
             <CardContent className="p-0">
-                {/* Header: search + sort + density */}
-                <div className="flex flex-col gap-2 border-b p-3">
-                    <div className="relative">
-                        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                        <Input
-                            ref={searchRef}
-                            value={query}
-                            onChange={(e) => setQuery(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter" && filtered.length > 0) {
-                                    e.preventDefault();
-                                    onSelect(filtered[0]);
-                                }
-                            }}
-                            placeholder="Search recordings, transcripts..."
-                            className="h-9 pl-8 pr-8"
-                            aria-label="Search recordings"
-                        />
-                        {query && (
-                            <button
-                                type="button"
-                                onClick={() => setQuery("")}
-                                aria-label="Clear search"
-                                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:text-foreground"
-                            >
-                                <X className="size-4" />
-                            </button>
-                        )}
-                    </div>
-                    <div className="flex items-center justify-between text-xs text-muted-foreground">
-                        <span>
-                            {filtered.length}
-                            {query ? " matching" : ""} of {recordings.length}{" "}
-                            recording
-                            {recordings.length !== 1 ? "s" : ""}
-                        </span>
-                        <div className="flex items-center gap-1">
-                            <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        className="h-7 px-2 text-xs"
-                                        aria-label="Sort"
-                                    >
-                                        <ArrowDownAZ className="size-3.5" />
-                                        <span>
-                                            {sortOrder === "newest"
-                                                ? "Newest"
-                                                : sortOrder === "oldest"
-                                                  ? "Oldest"
-                                                  : "Name"}
-                                        </span>
-                                    </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                    <DropdownMenuLabel>
-                                        Sort by
-                                    </DropdownMenuLabel>
-                                    <DropdownMenuRadioGroup
-                                        value={sortOrder}
-                                        onValueChange={(v) =>
-                                            setSortOrderPersisted(
-                                                v as SortOrder,
-                                            )
-                                        }
-                                    >
-                                        <DropdownMenuRadioItem value="newest">
-                                            Newest first
-                                        </DropdownMenuRadioItem>
-                                        <DropdownMenuRadioItem value="oldest">
-                                            Oldest first
-                                        </DropdownMenuRadioItem>
-                                        <DropdownMenuRadioItem value="name">
-                                            Name
-                                        </DropdownMenuRadioItem>
-                                    </DropdownMenuRadioGroup>
-                                </DropdownMenuContent>
-                            </DropdownMenu>
-                            <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        className="h-7 px-2 text-xs"
-                                        aria-label="Density"
-                                    >
-                                        <Rows3 className="size-3.5" />
-                                        <span>
-                                            {density === "compact"
-                                                ? "Compact"
-                                                : "Comfortable"}
-                                        </span>
-                                    </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                    <DropdownMenuLabel>
-                                        Density
-                                    </DropdownMenuLabel>
-                                    <DropdownMenuRadioGroup
-                                        value={density}
-                                        onValueChange={(v) =>
-                                            setDensityPersisted(
-                                                v as ListDensity,
-                                            )
-                                        }
-                                    >
-                                        <DropdownMenuRadioItem value="comfortable">
-                                            Comfortable
-                                        </DropdownMenuRadioItem>
-                                        <DropdownMenuRadioItem value="compact">
-                                            Compact
-                                        </DropdownMenuRadioItem>
-                                    </DropdownMenuRadioGroup>
-                                </DropdownMenuContent>
-                            </DropdownMenu>
-                        </div>
-                    </div>
-                </div>
+                <RecordingListToolbar
+                    query={query}
+                    onQueryChange={setQuery}
+                    onEnterSelectFirst={() => {
+                        if (filtered.length > 0) onSelect(filtered[0]);
+                    }}
+                    searchRef={searchRef}
+                    filteredCount={filtered.length}
+                    totalCount={recordings.length}
+                    sortOrder={sortOrder}
+                    onSortOrderChange={setSortOrderPersisted}
+                    density={density}
+                    onDensityChange={setDensityPersisted}
+                />
 
-                {/* Pending uploads (optimistic placeholders, always on top) */}
                 {pendingUploads.length > 0 && (
                     <div className="divide-y bg-muted/30">
                         {pendingUploads.map((p) => (
-                            <div
+                            <PendingUploadRow
                                 key={p.id}
-                                className={cn(
-                                    "flex items-center gap-3",
-                                    rowPadding,
-                                )}
-                            >
-                                <Loader2 className="size-4 animate-spin text-primary" />
-                                <div className="min-w-0 flex-1">
-                                    <p className="truncate text-sm font-medium text-muted-foreground">
-                                        {p.filename}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                        Uploading… {formatSize(p.filesize)}
-                                    </p>
-                                </div>
-                            </div>
+                                upload={p}
+                                rowPadding={rowPadding}
+                            />
                         ))}
                     </div>
                 )}
 
-                {/* Grouped list */}
                 <div>
                     {grouped.map((group, gi) => (
                         <div
@@ -422,193 +286,29 @@ export function RecordingList({
                                 </div>
                             )}
                             <div className="divide-y">
-                                {group.items.map((recording) => {
-                                    const isSelected =
-                                        currentRecording?.id === recording.id;
-                                    const inFlight = inFlightActions.get(
-                                        recording.id,
-                                    );
-                                    const transcript = transcriptions.get(
-                                        recording.id,
-                                    );
-                                    const snippet = transcriptSnippet(
-                                        transcript?.text,
-                                    );
-                                    return (
-                                        <div
-                                            key={recording.id}
-                                            className={cn(
-                                                "group/row relative",
-                                                isSelected
-                                                    ? "bg-accent shadow-[inset_2px_0_0_0_var(--color-primary)]"
-                                                    : null,
-                                            )}
-                                        >
-                                            <button
-                                                ref={(el) => {
-                                                    if (el)
-                                                        rowRefs.current.set(
-                                                            recording.id,
-                                                            el,
-                                                        );
-                                                    else
-                                                        rowRefs.current.delete(
-                                                            recording.id,
-                                                        );
-                                                }}
-                                                type="button"
-                                                onClick={() =>
-                                                    onSelect(recording)
-                                                }
-                                                className={cn(
-                                                    "w-full text-left transition-colors hover:bg-accent/60",
-                                                    rowPadding,
-                                                )}
-                                            >
-                                                <div className="min-w-0 flex-1">
-                                                    <div className="flex items-center gap-2">
-                                                        <h3 className="truncate text-sm font-medium">
-                                                            {recording.filename}
-                                                        </h3>
-                                                        {inFlight && (
-                                                            <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[11px] text-primary">
-                                                                <Loader2
-                                                                    className="size-3 animate-spin"
-                                                                    aria-hidden="true"
-                                                                />
-                                                                {inFlight ===
-                                                                "transcribing"
-                                                                    ? "Transcribing"
-                                                                    : "Summarizing"}
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                    {snippet ? (
-                                                        <p
-                                                            className={cn(
-                                                                "truncate text-xs text-muted-foreground",
-                                                                isCompact
-                                                                    ? "mt-0.5"
-                                                                    : "mt-1",
-                                                            )}
-                                                        >
-                                                            {snippet}
-                                                        </p>
-                                                    ) : (
-                                                        <p
-                                                            className={cn(
-                                                                "text-xs text-muted-foreground",
-                                                                isCompact
-                                                                    ? "mt-0.5"
-                                                                    : "mt-1",
-                                                            )}
-                                                        >
-                                                            {formatDuration(
-                                                                recording.duration,
-                                                            )}
-                                                            {" \u00b7 "}
-                                                            {formatDateTime(
-                                                                recording.startTime,
-                                                                dateTimeFormat,
-                                                            )}
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            </button>
-                                            <div className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/row:opacity-100 focus-within:opacity-100 has-[[data-state=open]]:opacity-100">
-                                                <DropdownMenu>
-                                                    <DropdownMenuTrigger
-                                                        asChild
-                                                    >
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="icon-sm"
-                                                            aria-label="Row actions"
-                                                            onClick={(e) =>
-                                                                e.stopPropagation()
-                                                            }
-                                                        >
-                                                            <MoreHorizontal className="size-4" />
-                                                        </Button>
-                                                    </DropdownMenuTrigger>
-                                                    <DropdownMenuContent align="end">
-                                                        <DropdownMenuItem
-                                                            onSelect={() =>
-                                                                onSelect(
-                                                                    recording,
-                                                                )
-                                                            }
-                                                        >
-                                                            <Play />
-                                                            Open
-                                                        </DropdownMenuItem>
-                                                        <DropdownMenuSeparator />
-                                                        <DropdownMenuItem
-                                                            variant="destructive"
-                                                            onSelect={(e) => {
-                                                                // Keep menu mounted so confirm dialog can take focus.
-                                                                e.preventDefault();
-                                                                void confirm({
-                                                                    title: "Delete this recording?",
-                                                                    description:
-                                                                        (
-                                                                            <>
-                                                                                <span className="font-medium text-foreground">
-                                                                                    {
-                                                                                        recording.filename
-                                                                                    }
-                                                                                </span>
-                                                                                <br />
-                                                                                The
-                                                                                audio
-                                                                                file
-                                                                                and
-                                                                                any
-                                                                                transcript
-                                                                                or
-                                                                                summary
-                                                                                will
-                                                                                be
-                                                                                removed.
-                                                                                If
-                                                                                the
-                                                                                file
-                                                                                is
-                                                                                still
-                                                                                on
-                                                                                your
-                                                                                Plaud
-                                                                                device,
-                                                                                the
-                                                                                next
-                                                                                sync
-                                                                                will
-                                                                                re-download
-                                                                                it.
-                                                                            </>
-                                                                        ),
-                                                                    confirmLabel:
-                                                                        "Delete",
-                                                                    pendingLabel:
-                                                                        "Deleting…",
-                                                                    destructive: true,
-                                                                    onConfirm:
-                                                                        () =>
-                                                                            onDelete(
-                                                                                recording,
-                                                                            ),
-                                                                });
-                                                            }}
-                                                        >
-                                                            <Trash2 />
-                                                            Delete
-                                                        </DropdownMenuItem>
-                                                    </DropdownMenuContent>
-                                                </DropdownMenu>
-                                            </div>
-                                        </div>
-                                    );
-                                })}
+                                {group.items.map((recording) => (
+                                    <RecordingRow
+                                        key={recording.id}
+                                        recording={recording}
+                                        isSelected={
+                                            currentRecording?.id ===
+                                            recording.id
+                                        }
+                                        inFlight={inFlightActions.get(
+                                            recording.id,
+                                        )}
+                                        snippet={transcriptSnippet(
+                                            transcriptions.get(recording.id)
+                                                ?.text,
+                                        )}
+                                        isCompact={isCompact}
+                                        rowPadding={rowPadding}
+                                        dateTimeFormat={dateTimeFormat}
+                                        onSelect={onSelect}
+                                        onDelete={onDelete}
+                                        registerRef={registerRowRef}
+                                    />
+                                ))}
                             </div>
                         </div>
                     ))}
@@ -624,7 +324,6 @@ export function RecordingList({
                         </div>
                     )}
 
-                    {/* Infinite-scroll sentinel */}
                     <div ref={sentinelRef} className="h-4" aria-hidden="true" />
                 </div>
             </CardContent>

--- a/src/components/dashboard/recording-row.tsx
+++ b/src/components/dashboard/recording-row.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Loader2, MoreHorizontal, Play, Trash2 } from "lucide-react";
+import { useConfirm } from "@/components/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { formatDateTime } from "@/lib/format-date";
+import { formatDurationMs } from "@/lib/format-duration";
+import { cn } from "@/lib/utils";
+import type { DateTimeFormat } from "@/types/common";
+import type { Recording } from "@/types/recording";
+
+export function RecordingRow({
+    recording,
+    isSelected,
+    inFlight,
+    snippet,
+    isCompact,
+    rowPadding,
+    dateTimeFormat,
+    onSelect,
+    onDelete,
+    registerRef,
+}: {
+    recording: Recording;
+    isSelected: boolean;
+    inFlight: "transcribing" | "summarizing" | undefined;
+    snippet: string | null;
+    isCompact: boolean;
+    rowPadding: string;
+    dateTimeFormat: DateTimeFormat;
+    onSelect: (recording: Recording) => void;
+    onDelete: (recording: Recording) => Promise<void>;
+    registerRef: (id: string, el: HTMLButtonElement | null) => void;
+}) {
+    const confirm = useConfirm();
+    return (
+        <div
+            className={cn(
+                "group/row relative",
+                isSelected
+                    ? "bg-accent shadow-[inset_2px_0_0_0_var(--color-primary)]"
+                    : null,
+            )}
+        >
+            <button
+                ref={(el) => {
+                    registerRef(recording.id, el);
+                }}
+                type="button"
+                onClick={() => onSelect(recording)}
+                className={cn(
+                    "w-full text-left transition-colors hover:bg-accent/60",
+                    rowPadding,
+                )}
+            >
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                        <h3 className="truncate text-sm font-medium">
+                            {recording.filename}
+                        </h3>
+                        {inFlight && (
+                            <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[11px] text-primary">
+                                <Loader2
+                                    className="size-3 animate-spin"
+                                    aria-hidden="true"
+                                />
+                                {inFlight === "transcribing"
+                                    ? "Transcribing"
+                                    : "Summarizing"}
+                            </span>
+                        )}
+                    </div>
+                    {snippet ? (
+                        <p
+                            className={cn(
+                                "truncate text-xs text-muted-foreground",
+                                isCompact ? "mt-0.5" : "mt-1",
+                            )}
+                        >
+                            {snippet}
+                        </p>
+                    ) : (
+                        <p
+                            className={cn(
+                                "text-xs text-muted-foreground",
+                                isCompact ? "mt-0.5" : "mt-1",
+                            )}
+                        >
+                            {formatDurationMs(recording.duration)}
+                            {" \u00b7 "}
+                            {formatDateTime(
+                                recording.startTime,
+                                dateTimeFormat,
+                            )}
+                        </p>
+                    )}
+                </div>
+            </button>
+            <div className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/row:opacity-100 focus-within:opacity-100 has-[[data-state=open]]:opacity-100">
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label="Row actions"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <MoreHorizontal className="size-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem onSelect={() => onSelect(recording)}>
+                            <Play />
+                            Open
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={(e) => {
+                                // Keep menu mounted so confirm dialog can take focus.
+                                e.preventDefault();
+                                void confirm({
+                                    title: "Delete this recording?",
+                                    description: (
+                                        <>
+                                            <span className="font-medium text-foreground">
+                                                {recording.filename}
+                                            </span>
+                                            <br />
+                                            The audio file and any transcript or
+                                            summary will be removed. If the file
+                                            is still on your Plaud device, the
+                                            next sync will re-download it.
+                                        </>
+                                    ),
+                                    confirmLabel: "Delete",
+                                    pendingLabel: "Deleting…",
+                                    destructive: true,
+                                    onConfirm: () => onDelete(recording),
+                                });
+                            }}
+                        >
+                            <Trash2 />
+                            Delete
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Description

Splits the 633-line `RecordingList` dashboard component (`no-giant-component` warning, surfaced by React Review on #165) into three focused siblings. Orchestration stays in the parent; presentational chunks move out.

## Type of Change

- [x] Code refactoring

## Related Issues

Follow-up to #165 (review-bot warning, deferred from that PR's "zero behavior change" scope).

## Changes Made

- **New** `recording-list-toolbar.tsx` (153 lines) — search input, count text, sort dropdown, density dropdown. Receives query/sort/density state and setters from the parent.
- **New** `recording-row.tsx` (158 lines) — per-recording row JSX with in-flight pill, snippet/meta line, and the row-actions dropdown including the delete-confirm wiring.
- **New** `pending-upload-row.tsx` (36 lines) — the optimistic placeholder row, plus the local `formatSize` helper.
- **Slimmed** `recording-list.tsx` 633 → 332 lines. Keeps state, filtering, sorting, grouping, infinite-scroll IntersectionObserver, and the `useImperativeHandle` keyboard nav (`focusSearch` / `next` / `prev`).

## Behavior preservation

- Public surface of `RecordingList` is unchanged: same props, same exported types (`SortOrder`, `ListDensity`, `PendingUpload`, `RecordingListHandle`).
- `SortOrder` / `ListDensity` now live in `recording-list-toolbar.tsx` and `PendingUpload` in `pending-upload-row.tsx`; both are re-exported from `recording-list.tsx` so `workstation.tsx` and `use-upload-queue.ts` keep working without import changes.
- Row refs move from an inline `ref={(el) => …}` to a parent-supplied `registerRef(id, el)` callback. The null-cleanup branch is preserved so `next()`/`prev()` don't scroll to stale DOM nodes.
- The destructive `DropdownMenuItem`'s `onSelect={(e) => e.preventDefault()}` is preserved — that's the "keep menu mounted so confirm dialog can take focus" fix.
- `transcriptSnippet` stays in the parent (it's the helper kept in sync with `command-palette-parts.tsx`; centralizing it is a separate decision).

## Testing

- `pnpm format-and-lint:fix` — clean (2 pre-existing infos in `src/tests/admin/elevated-cookie.test.ts`, unrelated)
- `pnpm type-check` — passes
- `pnpm test` — 362 passed, 5 skipped (integration, opt-in)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. `RecordingList`'s public API is preserved; the only internal change visible to direct callers is that `PendingUpload`, `SortOrder`, and `ListDensity` are re-exported from `recording-list.tsx` rather than defined there.

## For Reviewers

- Manual smoke test recommended: search-while-typing, sort/density dropdowns, row hover → kebab menu → delete confirm, keyboard nav (↑/↓ between rows after the imperative-handle `next`/`prev`), infinite scroll past the initial chunk.
- Confirm `registerRef` callback approach is acceptable — the only alternative was hoisting the `rowRefs` Map ref into the row component via context, which felt heavier for a single use.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic dashboard `RecordingList` into three focused components to reduce complexity while keeping behavior and the public API unchanged.

- **Refactors**
  - Added `recording-list-toolbar.tsx` for search, counts, sort, and density.
  - Added `recording-row.tsx` for per-recording UI, in-flight pill, and actions menu with delete confirm.
  - Added `pending-upload-row.tsx` for optimistic upload placeholders.
  - `recording-list.tsx` now only orchestrates state, filtering, sorting, grouping, infinite scroll, and keyboard nav.
  - Switched row refs to `registerRef(id, el)` to keep `next/prev` scrolling reliable.
  - Moved `SortOrder`, `ListDensity`, and `PendingUpload` to their files and re-exported from `recording-list.tsx` (no import changes for callers).

<sup>Written for commit 6ebe76998e443a4cb285fef48d20a3463c0931ca. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

