### PR TITLE
refactor(plaud): drop wreq-js, route optional proxy through undici ProxyAgent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,11 @@
-# OpenPlaud image version (used by docker-compose.yml)
-# Recommended: pin to a specific version for reproducible deploys.
-#   latest  → newest stable release (default)
-#   0.1.0   → pinned release
-#   dev     → rolling build from `main` (unstable, opt-in)
+# OpenPlaud image version. Pin to a release (e.g. `0.5.3`) for reproducible deploys.
 OPENPLAUD_VERSION=latest
 
 # Database
 DATABASE_URL=postgresql://user:password@localhost:5432/openplaud
 
-# Postgres password used by the bundled `db` service in docker-compose.yml.
-# Default is `postgres` for backward compat with existing deploys. The
-# one-line installer generates a random value here. If you set this on an
-# already-running stack, you must also recreate the `db` volume — the
-# password is baked into the data dir at first init.
+# Postgres password for the bundled `db` service. Default `postgres`. Changing
+# this on an existing stack requires recreating the `db` volume.
 # POSTGRES_PASSWORD=
 
 # Better Auth
@@ -22,87 +15,45 @@ BETTER_AUTH_SECRET=your-secret-key-here-generate-with-openssl-rand-hex-32
 # API_TOKEN_HASH_SECRET=
 APP_URL=http://localhost:3000
 
-# Disable email/password registration. When `true`, the sign-up endpoint
-# is disabled server-side, /register shows a "registration disabled"
-# panel, and the /login page hides its register link. Useful for
-# closed self-host instances. Defaults to `false` (registration open).
+# Disable email/password registration. Default `false`.
 # DISABLE_REGISTRATION=false
 
-# Disable the self-host "update available" check. When unset/`false`,
-# the footer fetches the latest release tag from api.github.com (cached
-# 5 minutes) and shows a small "update available" link when a newer
-# version exists. Set to `true` if your instance blocks outbound HTTPS
-# or you don't want any phone-home behavior. Has no effect when
-# IS_HOSTED=true (the hosted instance hides the badge anyway).
+# Disable the footer "update available" check against api.github.com.
 # DISABLE_UPDATE_CHECK=false
 
-# ----------------------------------------------------------------------
-# Admin dashboard (HOSTED-ONLY -- self-hosters: leave all of these blank)
-# ----------------------------------------------------------------------
-# The /admin dashboard is only reachable when IS_HOSTED=true. Self-host
-# instances do not have an admin layer and do not need these vars; the
-# admin gate trips on IS_HOSTED before any of these are read.
-#
-# ADMIN_EMAILS: comma-separated allowlist of operator emails. Source of
-# truth for admin identity (kept out of DB so a DB compromise alone does
-# not grant admin). Empty/unset => admin dashboard is off.
+# Admin dashboard (hosted-only). Inert unless IS_HOSTED=true.
 # ADMIN_EMAILS=ops@openplaud.com,founder@openplaud.com
-#
-# ADMIN_IP_ALLOWLIST: optional comma-separated CIDR list. When set,
-# /admin/* and /api/admin/* return 404 for clients outside the list.
-# Empty/unset disables the check. Useful when running behind a static
-# bastion or office IP.
 # ADMIN_IP_ALLOWLIST=10.0.0.0/24,2001:db8::/32
-#
-# ADMIN_REAUTH_TTL_MINUTES: how long an admin elevated session lasts
-# after password reprompt. Default 30. Range 1..1440.
 # ADMIN_REAUTH_TTL_MINUTES=30
-#
-# ADMIN_MUTATION_TTL_MINUTES: tighter window required for any admin
-# mutation (suspend, force-disconnect, etc.). Default 10. Range 1..60.
 # ADMIN_MUTATION_TTL_MINUTES=10
 
-# Webhooks default to permissive self-host targets unless IS_HOSTED=true.
-# Set true to require HTTPS public targets with DNS pinning; set false to allow
-# local Docker service URLs such as http://n8n:5678/webhook.
+# Require public HTTPS webhook targets with DNS pinning. Defaults to IS_HOSTED.
+# Set false to allow Docker-network URLs like http://n8n:5678/webhook.
 # WEBHOOKS_REQUIRE_PUBLIC_TARGETS=false
 
-# v1 API IP rate limits ignore forwarding headers by default because clients can
-# spoof them unless a trusted reverse proxy strips or overwrites those headers.
-# Hosted mode requires true; set it only behind a trusted proxy/load balancer.
+# Trust X-Forwarded-For for /api/v1/* rate limiting. Only enable behind a
+# trusted reverse proxy that strips client-supplied forwarding headers.
 # RATE_LIMIT_TRUST_PROXY_HEADERS=false
 
 # Encryption (for API keys, tokens, S3 credentials)
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 
-# Plaud outbound proxy (HOSTED-ONLY in practice -- most self-hosters do
-# not need this). Plaud's API sits behind Cloudflare with aggressive
-# bot/datacenter-ASN filtering. From flagged VPS IPs (Contabo, OVH, ...)
-# every Plaud endpoint returns a 403 + Cloudflare HTML challenge at the
-# edge regardless of token, region, or headers. Setting WEBSHARE_API_KEY
-# routes Plaud-bound calls (api*.plaud.ai, resource.plaud.ai) through
-# a residential proxy from your Webshare account, with automatic
-# rotation on rejection. Unset (default) keeps every call on the direct
-# egress path -- the right default for residential / homelab IPs that
-# Cloudflare doesn't flag. No effect on non-Plaud outbound traffic
-# (S3, AI providers, SMTP, GitHub release check).
+# Optional outbound proxy for Plaud API calls. Useful when the host's egress
+# IP can't reach Plaud directly (geo-restriction, ISP blocking, datacenter
+# IP filtering). Set this to a Webshare API key and Plaud-bound requests
+# (api*.plaud.ai, resource.plaud.ai) are routed through a random valid proxy
+# from your Webshare account, with automatic rotation on 403/407. Unset
+# (default) sends all calls direct. No effect on non-Plaud outbound traffic.
 # WEBSHARE_API_KEY=
 
-# Scope of the Webshare proxy. "all" (default) routes every Plaud
-# outbound (api*.plaud.ai + resource.plaud.ai signed-URL audio CDN)
-# through the proxy. "api-only" skips proxying resource.plaud.ai
-# downloads -- audio bytes are the dominant proxy cost, so flipping
-# this can save most of your Webshare quota. ONLY enable this after
-# verifying with scripts/plaud-egress-probe.sh that resource.plaud.ai
-# serves direct from your egress IPs (a 403 in production would break
-# every download). Inert when WEBSHARE_API_KEY is unset.
+# Proxy scope. `all` (default) proxies api*.plaud.ai and resource.plaud.ai
+# audio downloads. `api-only` skips audio downloads to save proxy bandwidth.
+# Inert when WEBSHARE_API_KEY is unset.
 # PLAUD_PROXY_SCOPE=all
 
-# Per-user rate limit on POST /api/plaud/sync, requests per minute.
-# Backstops the in-app client throttling (manual-tap floor + cross-tab
-# dedup). Even a script hammering the endpoint is capped here before
-# any Plaud or Webshare call is issued. Default 10. Range 1..600.
+# Per-user rate limit on POST /api/plaud/sync (requests per minute).
+# Default 10. Range 1..600.
 # PLAUD_SYNC_RATE_LIMIT_PER_MINUTE=10
 
 # Storage Configuration
@@ -118,23 +69,8 @@ LOCAL_STORAGE_PATH=./storage
 # S3_ACCESS_KEY_ID=
 # S3_SECRET_ACCESS_KEY=
 
-# Rybbit analytics (hosted-only - leave blank for self-host)
-# Both must be set together. The tracking script is proxied through
-# /api/_int/* to bypass ad-blockers, so RYBBIT_HOST must be reachable
-# from the OpenPlaud server (server-to-server) - it does not need to be
-# public. Self-hosters: ignore both vars; the analytics component returns
-# null and no proxy routes are registered.
-#
-# Edge-proxy requirement: Rybbit derives client IP / geo from the
-# X-Forwarded-For (or X-Real-IP) header on the incoming request. Your
-# edge proxy in front of OpenPlaud (Caddy / nginx / Cloudflare) must
-# set X-Forwarded-For - all of those do by default. A bare `next start`
-# exposed directly to the internet will not, and Rybbit will see every
-# visitor as the OpenPlaud server's IP. Verify on first deploy by
-# checking that visitors show varied IPs / countries in the Rybbit dash.
-#
-# Enable "SPA Navigation" per-site in your Rybbit dashboard so client-side
-# Next.js route changes are tracked as pageviews.
+# Rybbit analytics (hosted-only). Both must be set together. Requires an edge
+# proxy that sets X-Forwarded-For so Rybbit sees real client IPs.
 # RYBBIT_SITE_ID=
 # RYBBIT_HOST=https://rybbit.example.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 - `PLAUD_SYNC_RATE_LIMIT_PER_MINUTE` env var (default 10) capping per-user sync requests. Backstops the new client-side throttling at the route boundary so a script hammering `POST /api/plaud/sync` is rejected before any Plaud or Webshare call is issued.
 
 ### Changed
-- Sync flow now coalesces concurrent calls for the same user inside one Next.js worker into a single Plaud round-trip; secondary callers receive the same result with an `inProgress: true` marker and the client renders it as a quiet no-op (no extra `router.refresh()`, no duplicate toast). Combined with a new client-side cross-tab `localStorage` in-flight stamp (90s TTL) and a 5s floor on manual sync taps, this collapses N-tab fan-out and rage-clicks before they reach the API. Reduces Webshare proxy load on hosted by suppressing redundant runs that were previously paginating Plaud and re-downloading recordings through the proxy.
+- `WEBSHARE_API_KEY` proxy path now uses native `fetch` through `undici.ProxyAgent` instead of the previous `wreq-js` dependency. Drops a Rust napi addon from the standalone Docker image and removes the Turbopack workaround in `next.config.ts`. No behavioral change for proxy users; direct-egress path unchanged.
+- Sync flow now coalesces concurrent calls for the same user inside one Next.js worker into a single Plaud round-trip; secondary callers receive the same result with an `inProgress: true` marker and the client renders it as a quiet no-op (no extra `router.refresh()`, no duplicate toast). Combined with a new client-side cross-tab `localStorage` in-flight stamp (90s TTL) and a 5s floor on manual sync taps, this collapses N-tab fan-out and rage-clicks before they reach the API.
+
+### Removed
+- `wreq-js` dependency.
 
 ## [0.5.3] - 2026-05-15
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,51 +1,13 @@
 import { createMDX } from "fumadocs-mdx/next";
 import type { NextConfig } from "next";
 
-// The Rybbit analytics proxy used to live here as a `rewrites()` entry.
-// `next.config.ts` is evaluated at `next build`, and the published Docker
-// image is built generically without `IS_HOSTED`/`RYBBIT_*` set, so the
-// rewrite list was baked as `[]` and `/api/_int/*` 404'd at runtime even
-// when those vars were configured on the host. The proxy now lives as
-// runtime route handlers under `src/app/api/int/*` which read `env` at
-// request time, in lockstep with `<RybbitAnalytics>`'s render gate.
-//
-// Folder name note: route folder is `int`, NOT `_int`. App Router treats
-// `_`-prefixed folders as private and excludes them from the route
-// manifest, which silently 404'd every `/api/_int/*` path via the
-// prerendered not-found page — a separate regression from the
-// build-time-rewrites one above.
 const nextConfig: NextConfig = {
     output: "standalone",
-    // `wreq-js` is a Rust napi addon used by `src/lib/plaud/fetch.ts` to
-    // emit a Chrome-shaped TLS handshake when calling Plaud through the
-    // Webshare proxy (see `src/lib/plaud/fetch.ts`). The package ships
-    // prebuilt `.node` binaries that Turbopack can't bundle into ESM
-    // chunks (`non-ecmascript placeable asset`). Externalise so Next
-    // leaves the require in place and node-file-trace pulls the binary
-    // into the standalone output at runtime.
-    serverExternalPackages: ["wreq-js"],
-    // The `/install.sh` and `/[version]/install.sh` routes read
-    // `scripts/install.sh` from disk at request time. The standalone
-    // output only includes files reachable through the build graph, so
-    // declare the script as an extra traced input or it won't ship in
-    // the Docker image. See `src/lib/install-script.ts`.
-    //
-    // `wreq-js` is listed in `serverExternalPackages` above so Turbopack
-    // leaves a runtime `externalImport("wreq-js")` in the output. Under
-    // Next 16 + Turbopack, the file tracer does NOT follow that dynamic
-    // import, so `node_modules/wreq-js` is missing from
-    // `.next/standalone/node_modules` and the server boots into
-    //   `Cannot find package 'wreq-js' from '.next/server/chunks/[turbopack]_runtime.js'`
-    // the moment any Plaud helper loads (only when `WEBSHARE_API_KEY` is
-    // set — direct egress doesn't pull this module in). Pull the whole
-    // package, including its prebuilt `.node` binaries, into the trace
-    // explicitly. The `"/**/*"` route key applies the include to every
-    // route, since the Plaud fetch is reachable from sync, OTP, workspace
-    // token, recording mutations, and the dev probe.
+    // `scripts/install.sh` is read from disk at request time by the
+    // /install.sh routes; declare it so the standalone tracer ships it.
     outputFileTracingIncludes: {
         "/install.sh": ["./scripts/install.sh"],
         "/[version]/install.sh": ["./scripts/install.sh"],
-        "/**/*": ["./node_modules/wreq-js/**/*"],
     },
     images: {
         loader: "custom",
@@ -54,14 +16,6 @@ const nextConfig: NextConfig = {
     },
 };
 
-// Fumadocs MDX integration. `createMDX()` reads `source.config.ts`, emits
-// compiled content into `src/.source/` (see `outDir` below), and registers
-// the `.mdx` webpack loader.
-// The wrapper is a no-op for non-MDX routes — self-host and hosted builds are
-// identical with or without docs content present.
-// `outDir` is set under `src/` so the existing `@/*` -> `./src/*` tsconfig
-// path alias resolves `@/.source` without adding a second alias. Keep this
-// in lockstep with the `.gitignore` entry and the import in `src/lib/source.ts`.
 const withMDX = createMDX({ outDir: "src/.source" });
 
 export default withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
         "tailwind-merge": "^3.4.0",
         "undici": "^7.16.0",
         "vitest": "^4.0.12",
-        "wreq-js": "^2.3.0",
         "zod": "^4.1.12"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,9 +128,6 @@ importers:
       vitest:
         specifier: ^4.0.12
         version: 4.0.12(@types/debug@4.1.13)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)
-      wreq-js:
-        specifier: ^2.3.0
-        version: 2.3.0
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -4829,11 +4826,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  wreq-js@2.3.0:
-    resolution: {integrity: sha512-jROBpTUhVH40qG+cAvBhdduKPGDSx55jK1dIDmVuu29sux9i8KY0u0wb5tHkMzXKDy9hrfHP+bpvaSq25rGwEA==}
-    cpu: [x64, arm64]
-    os: [darwin, linux, win32]
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
@@ -10230,8 +10222,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
-
-  wreq-js@2.3.0: {}
 
   ws@8.17.1: {}
 

--- a/src/app/api/dev/plaud/info/route.ts
+++ b/src/app/api/dev/plaud/info/route.ts
@@ -56,8 +56,6 @@ export const GET = apiHandler(async (request: Request) => {
         trashedRecordingCount =
             trash.data_file_total ?? trash.data_file_list?.length ?? 0;
     } catch (err) {
-        // Dev introspection — surface the underlying message in the body
-        // (this endpoint is gated behind NODE_ENV !== "production" above).
         errorMessage = err instanceof Error ? err.message : String(err);
     }
 
@@ -68,9 +66,6 @@ export const GET = apiHandler(async (request: Request) => {
         reachable,
         latencyMs,
         error: errorMessage,
-        // Whether outbound Plaud calls go through the Webshare residential
-        // proxy. Surfaced here so we can quickly tell, on a flagged-egress
-        // VPS, whether the proxy path is wired up.
         usingPlaudProxy: isPlaudProxyConfigured(),
         connection: {
             id: connection.id,
@@ -78,11 +73,6 @@ export const GET = apiHandler(async (request: Request) => {
             server: serverKeyFromApiBase(connection.apiBase),
             plaudEmail: connection.plaudEmail,
             workspaceId: client.workspaceId ?? connection.workspaceId,
-            // "cache"      = used the stored workspaceId as-is
-            // "resolved"   = client discovered or replaced it (cache empty
-            //                or stale-cache rescue picked a different id)
-            // "unresolved" = nothing stored and nothing resolved (the UT
-            //                fallback path)
             workspaceIdSource:
                 client.workspaceId &&
                 client.workspaceId !== connection.workspaceId

--- a/src/app/api/plaud/sync/route.ts
+++ b/src/app/api/plaud/sync/route.ts
@@ -7,9 +7,6 @@ import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
 export const POST = apiHandler(async (request: Request) => {
     const session = await requireApiSession(request);
 
-    // Backstop against spam-click + multi-tab fan-out. Defaults to 10/min
-    // per user; configurable via PLAUD_SYNC_RATE_LIMIT_PER_MINUTE. Returns
-    // before any Plaud/Webshare call is issued.
     const limited = await enforcePlaudSyncRateLimit(session.user.id);
     if (limited) return limited;
 
@@ -20,9 +17,6 @@ export const POST = apiHandler(async (request: Request) => {
         newRecordings: result.newRecordings,
         updatedRecordings: result.updatedRecordings,
         errors: result.errors,
-        // `true` when this call coalesced into an already-running sync
-        // in the same process. Clients should treat as a no-op success
-        // (no router.refresh(), no "synced N" toast).
         inProgress: result.inProgress,
     });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -16,40 +16,24 @@ const optionalStrictBoolean = z
     });
 
 export const envSchema = z.object({
-    // Deployment mode. `true` means this instance is the OpenPlaud-operated
-    // hosted product (marketing landing visible at `/`). Default `false`:
-    // self-host instances skip the marketing surface and bounce logged-out
-    // visitors at `/` straight to `/login`.
+    /** True for the OpenPlaud-operated hosted instance; default false (self-host). */
     IS_HOSTED: z
         .string()
         .optional()
         .transform((val) => val === "true"),
 
-    // Disable email/password sign-up. When `true`, the better-auth
-    // sign-up endpoint is disabled server-side (security boundary), the
-    // /register page renders a disabled-state panel, and the /login page
-    // hides its register link. Operator-controlled, defaults to `false`
-    // (registration open). Self-host only -- the OpenPlaud-operated hosted
-    // instance leaves this unset.
+    /** Disable email/password sign-up. */
     DISABLE_REGISTRATION: z
         .string()
         .optional()
         .transform((val) => val === "true"),
 
-    // Disable the self-host update-available check (GitHub releases API).
-    // When `true`, the footer never reaches out to api.github.com to look
-    // for a newer release tag. Useful for instances with strict egress
-    // controls or operators who don't want any phone-home behavior.
-    // Defaults to `false` (check enabled). Inert when IS_HOSTED=true --
-    // the hosted instance hides the badge unconditionally because the
-    // operator (us) controls deploys.
+    /** Disable the self-host update-available check. */
     DISABLE_UPDATE_CHECK: z
         .string()
         .optional()
         .transform((val) => val === "true"),
 
-    // Server-required values are optional at schema level so that `next build`
-    // (phase-production-build) doesn't depend on server-only secrets.
     DATABASE_URL: z.string().optional(),
 
     BETTER_AUTH_SECRET: z.string().optional(),
@@ -62,17 +46,12 @@ export const envSchema = z.object({
         }),
     APP_URL: z.string().url("APP_URL must be a valid URL").optional(),
 
-    // Webhook target hardening. Unset means default to IS_HOSTED; explicit
-    // false keeps self-host integrations like Docker service hostnames working.
+    /** Require public HTTPS webhook targets. Defaults to IS_HOSTED. */
     WEBHOOKS_REQUIRE_PUBLIC_TARGETS: optionalStrictBoolean,
 
-    // Only enable when a trusted reverse proxy strips or overwrites incoming
-    // client-supplied forwarding headers before requests reach Next.js.
+    /** Trust X-Forwarded-For for IP rate limiting; only enable behind a trusted proxy. */
     RATE_LIMIT_TRUST_PROXY_HEADERS: optionalStrictBoolean,
 
-    // Encryption
-    // Optional at env-schema level so that builds don't fail if it's missing;
-    // encryption code is responsible for enforcing a strong key at runtime.
     ENCRYPTION_KEY: z.string().optional(),
 
     DEFAULT_STORAGE_TYPE: z.enum(["local", "s3"]).optional().default("local"),
@@ -83,31 +62,24 @@ export const envSchema = z.object({
     S3_ACCESS_KEY_ID: z.string().optional(),
     S3_SECRET_ACCESS_KEY: z.string().optional(),
 
-    // Webshare residential-proxy API key. When set, Plaud-bound outbound
-    // requests route through the operator's Webshare proxy list with
-    // automatic rotation on 403/407. Unset (default) keeps every call
-    // on the direct egress path.
+    /**
+     * Optional Webshare API key. When set, Plaud-bound outbound requests are
+     * routed through a proxy from the configured Webshare account. Unset
+     * (default) keeps every call on the direct egress path.
+     */
     WEBSHARE_API_KEY: z
         .string()
         .optional()
         .transform((val) => (val === "" ? undefined : val)),
 
-    // Scope of the Webshare proxy. "all" (default) routes every Plaud
-    // outbound (API + signed-URL audio CDN) through the proxy. "api-only"
-    // skips proxying resource.plaud.ai signed-URL downloads, sending
-    // those direct from the server's egress IP. Audio bytes dominate
-    // proxy bandwidth, so flipping this to api-only on hosted can save
-    // most of the Webshare quota -- BUT only do so after verifying with
-    // scripts/plaud-egress-probe.sh that resource.plaud.ai actually
-    // serves direct from your egress IPs. Inert when WEBSHARE_API_KEY
-    // is unset (no proxy is used at all).
+    /**
+     * Which Plaud hosts route through the proxy. `all` (default) includes
+     * `resource.plaud.ai` audio downloads; `api-only` skips them.
+     * Inert when WEBSHARE_API_KEY is unset.
+     */
     PLAUD_PROXY_SCOPE: z.enum(["all", "api-only"]).optional().default("all"),
 
-    // Per-user rate limit on POST /api/plaud/sync, in requests per minute.
-    // Defaults to 10. Backstops the client-side manual-sync floor and
-    // cross-tab dedup: even if a script hammers the endpoint, the bucket
-    // throttles it before any Plaud or Webshare call is issued. Set lower
-    // for tighter quotas, higher for power users. Range 1..600.
+    /** Per-user rate limit on POST /api/plaud/sync. Default 10, range 1..600. */
     PLAUD_SYNC_RATE_LIMIT_PER_MINUTE: z
         .string()
         .regex(
@@ -129,10 +101,7 @@ export const envSchema = z.object({
         .transform((val) => val === "true"),
     SMTP_USER: z.string().optional(),
     SMTP_PASSWORD: z.string().optional(),
-    // Rybbit analytics (hosted mode only). Both must be set together for
-    // the tracking script and proxy rewrites to activate. Self-host leaves
-    // them unset; the analytics component returns null and no rewrites are
-    // registered, so no requests go to Rybbit at all.
+    /** Rybbit analytics (hosted only). Inert unless both site id and host are set. */
     RYBBIT_SITE_ID: z.string().optional(),
     RYBBIT_HOST: z.string().url("RYBBIT_HOST must be a valid URL").optional(),
 
@@ -152,13 +121,11 @@ export const envSchema = z.object({
             },
         ),
 
-    // Admin dashboard (hosted-only). All three are inert when IS_HOSTED is
-    // unset/false -- the admin gate trips before any of these are read.
-    //
-    // ADMIN_EMAILS: comma-separated allowlist of operator email addresses.
-    // Lower-cased and trimmed at parse time. Empty => no admins (default).
-    // Source of truth for admin identity; intentionally out of the DB so a
-    // DB compromise alone does not grant admin.
+    /**
+     * Hosted-only admin dashboard config. Inert when IS_HOSTED is unset.
+     * `ADMIN_EMAILS`: comma-separated allowlist of operator emails (source of
+     * truth for admin identity, kept out of the DB).
+     */
     ADMIN_EMAILS: z
         .string()
         .optional()
@@ -169,9 +136,7 @@ export const envSchema = z.object({
             }),
         ),
 
-    // ADMIN_IP_ALLOWLIST: optional comma-separated CIDR list. When set, admin
-    // routes 404 for requests whose client IP isn't in the list. Empty/unset
-    // disables the check (relying on the auth + reauth chain instead).
+    /** Optional CIDR allowlist for /admin/*. Empty/unset disables the check. */
     ADMIN_IP_ALLOWLIST: z
         .string()
         .optional()
@@ -182,13 +147,7 @@ export const envSchema = z.object({
             }),
         ),
 
-    // ADMIN_REAUTH_TTL_MINUTES: how long an admin's elevated cookie is valid
-    // after password reprompt before the dashboard forces another reauth.
-    // Default 30. Mutations require the cookie to be issued within the last
-    // ADMIN_MUTATION_TTL_MINUTES (default 10) -- a tighter window than reads.
-    // TTLs validated as strict positive integers. The leading regex
-    // rejects malformed values (`parseInt("30abc")` would silently coerce
-    // to 30); the .pipe(z.number()...) clamps to a sane range.
+    /** Admin reauth cookie TTL (minutes). Default 30, max 1440. */
     ADMIN_REAUTH_TTL_MINUTES: z
         .string()
         .regex(/^\d+$/, "ADMIN_REAUTH_TTL_MINUTES must be a positive integer")
@@ -201,6 +160,7 @@ export const envSchema = z.object({
                 .positive()
                 .max(24 * 60),
         ),
+    /** Tighter TTL required for admin mutations (minutes). Default 10, max 60. */
     ADMIN_MUTATION_TTL_MINUTES: z
         .string()
         .regex(/^\d+$/, "ADMIN_MUTATION_TTL_MINUTES must be a positive integer")
@@ -258,14 +218,10 @@ function validateEnv(): Env {
             ADMIN_MUTATION_TTL_MINUTES: process.env.ADMIN_MUTATION_TTL_MINUTES,
         });
 
-        // In runtime (dev/prod servers), we require a strong encryption key.
-        // During `next build` (phase-production-build) we skip this so that
-        // server-only config doesn't break the frontend build.
         const isProductionBuildPhase =
             process.env.NEXT_PHASE === "phase-production-build";
 
         if (!isProductionBuildPhase) {
-            // Core server-side envs must be present when the server actually runs.
             if (!parsed.DATABASE_URL) {
                 throw new Error(
                     "DATABASE_URL must be set in non-build runtime (dev/prod server)",
@@ -298,7 +254,6 @@ function validateEnv(): Env {
                 );
             }
 
-            // Encryption key: required and strong at runtime, ignored during build.
             const key = parsed.ENCRYPTION_KEY;
             if (!key) {
                 throw new Error(

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -7,6 +7,25 @@ import {
 } from "./proxy";
 
 const MAX_PROXY_ROTATIONS = 1;
+const PLAUD_WEB_ORIGIN = "https://web.plaud.ai";
+
+const agentCache = new Map<string, ProxyAgent>();
+
+function getOrCreateAgent(proxy: SelectedProxy): ProxyAgent {
+    let agent = agentCache.get(proxy.id);
+    if (!agent) {
+        agent = new ProxyAgent({ uri: proxy.url });
+        agentCache.set(proxy.id, agent);
+    }
+    return agent;
+}
+
+function evictAgent(proxyId: string): void {
+    const agent = agentCache.get(proxyId);
+    if (!agent) return;
+    agentCache.delete(proxyId);
+    agent.close().catch(() => undefined);
+}
 
 /**
  * `fetch`-shaped wrapper. When `WEBSHARE_API_KEY` is configured and the URL
@@ -27,11 +46,11 @@ export async function plaudFetch(
         return fetch(url, init);
     }
 
-    const headers = mergeBrowserHeaders(url, init?.headers);
+    const headers = mergeBrowserHeaders(init?.headers);
 
     let attempt = 0;
     while (true) {
-        const dispatcher = new ProxyAgent({ uri: currentProxy.url });
+        const dispatcher = getOrCreateAgent(currentProxy);
         let response: Response;
         try {
             response = await fetch(url, {
@@ -48,6 +67,7 @@ export async function plaudFetch(
                     currentProxy.label,
                     err instanceof Error ? err.message : String(err),
                 );
+                evictAgent(currentProxy.id);
                 invalidatePlaudProxy(currentProxy);
                 const next = await getPlaudProxyUrl();
                 if (!next) return fetch(url, init);
@@ -68,6 +88,7 @@ export async function plaudFetch(
                 currentProxy.label,
                 response.statusText,
             );
+            evictAgent(currentProxy.id);
             invalidatePlaudProxy(currentProxy);
 
             const next = await getPlaudProxyUrl();
@@ -86,18 +107,8 @@ export async function plaudFetch(
  * Layer browser-shaped headers under the caller's headers in insertion order.
  * Caller-provided headers always win.
  */
-function mergeBrowserHeaders(
-    url: string,
-    callerHeaders: HeadersInit | undefined,
-): Headers {
+function mergeBrowserHeaders(callerHeaders: HeadersInit | undefined): Headers {
     const out = new Headers();
-    let origin = "https://web.plaud.ai";
-    try {
-        const u = new URL(url);
-        if (u.hostname === "resource.plaud.ai") origin = "https://web.plaud.ai";
-    } catch {
-        // fall through with default
-    }
 
     out.append(
         "sec-ch-ua",
@@ -110,11 +121,11 @@ function mergeBrowserHeaders(
         "user-agent",
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
     );
-    out.append("origin", origin);
+    out.append("origin", PLAUD_WEB_ORIGIN);
     out.append("sec-fetch-site", "same-site");
     out.append("sec-fetch-mode", "cors");
     out.append("sec-fetch-dest", "empty");
-    out.append("referer", `${origin}/`);
+    out.append("referer", `${PLAUD_WEB_ORIGIN}/`);
     out.append("accept-encoding", "gzip, deflate, br, zstd");
     out.append("accept-language", "en-US,en;q=0.9");
     out.append("priority", "u=1, i");
@@ -145,5 +156,10 @@ function logProxyEvent(
     );
 }
 
-/** Test-only no-op. */
-export function _resetPlaudFetchForTest(): void {}
+/** Test-only: close and clear cached proxy agents. */
+export function _resetPlaudFetchForTest(): void {
+    for (const agent of agentCache.values()) {
+        agent.close().catch(() => undefined);
+    }
+    agentCache.clear();
+}

--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -1,7 +1,4 @@
-import {
-    fetch as impersonateFetch,
-    type BodyInit as WreqBodyInit,
-} from "wreq-js";
+import { ProxyAgent } from "undici";
 import {
     getPlaudProxyUrl,
     invalidatePlaudProxy,
@@ -10,10 +7,13 @@ import {
 } from "./proxy";
 
 const MAX_PROXY_ROTATIONS = 1;
-const IMPERSONATE_BROWSER = "chrome_142" as const;
-const IMPERSONATE_OS = "windows" as const;
 
-/** `fetch`-shaped wrapper that routes Plaud-bound requests through the configured proxy. */
+/**
+ * `fetch`-shaped wrapper. When `WEBSHARE_API_KEY` is configured and the URL
+ * targets a Plaud host, routes the request through an HTTP proxy from the
+ * configured pool with one rotation on 403/407. Otherwise behaves as a
+ * pass-through to the global `fetch`.
+ */
 export async function plaudFetch(
     url: string,
     init?: RequestInit,
@@ -22,24 +22,24 @@ export async function plaudFetch(
         return fetch(url, init);
     }
 
-    let attempt = 0;
     let currentProxy: SelectedProxy | null = await getPlaudProxyUrl();
     if (!currentProxy) {
         return fetch(url, init);
     }
 
+    const headers = mergeBrowserHeaders(url, init?.headers);
+
+    let attempt = 0;
     while (true) {
+        const dispatcher = new ProxyAgent({ uri: currentProxy.url });
         let response: Response;
         try {
-            response = (await impersonateFetch(url, {
-                method: init?.method,
-                headers: init?.headers as Record<string, string> | undefined,
-                body: init?.body as WreqBodyInit | null | undefined,
-                signal: init?.signal ?? undefined,
-                proxy: currentProxy.url,
-                browser: IMPERSONATE_BROWSER,
-                os: IMPERSONATE_OS,
-            })) as unknown as Response;
+            response = await fetch(url, {
+                ...init,
+                headers,
+                // @ts-expect-error -- undici extension to RequestInit
+                dispatcher,
+            });
         } catch (err) {
             if (attempt < MAX_PROXY_ROTATIONS) {
                 logProxyEvent(
@@ -50,9 +50,7 @@ export async function plaudFetch(
                 );
                 invalidatePlaudProxy(currentProxy);
                 const next = await getPlaudProxyUrl();
-                if (!next) {
-                    return fetch(url, init);
-                }
+                if (!next) return fetch(url, init);
                 currentProxy = next;
                 attempt += 1;
                 continue;
@@ -72,7 +70,6 @@ export async function plaudFetch(
             );
             invalidatePlaudProxy(currentProxy);
 
-            // Resolve next proxy before draining body; returning a drained Response would break JSON parse downstream.
             const next = await getPlaudProxyUrl();
             if (!next) return response;
             await response.body?.cancel().catch(() => undefined);
@@ -83,6 +80,52 @@ export async function plaudFetch(
 
         return response;
     }
+}
+
+/**
+ * Layer browser-shaped headers under the caller's headers in insertion order.
+ * Caller-provided headers always win.
+ */
+function mergeBrowserHeaders(
+    url: string,
+    callerHeaders: HeadersInit | undefined,
+): Headers {
+    const out = new Headers();
+    let origin = "https://web.plaud.ai";
+    try {
+        const u = new URL(url);
+        if (u.hostname === "resource.plaud.ai") origin = "https://web.plaud.ai";
+    } catch {
+        // fall through with default
+    }
+
+    out.append(
+        "sec-ch-ua",
+        '"Google Chrome";v="142", "Chromium";v="142", "Not?A_Brand";v="24"',
+    );
+    out.append("sec-ch-ua-mobile", "?0");
+    out.append("sec-ch-ua-platform", '"Windows"');
+    out.append("accept", "application/json, text/plain, */*");
+    out.append(
+        "user-agent",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+    );
+    out.append("origin", origin);
+    out.append("sec-fetch-site", "same-site");
+    out.append("sec-fetch-mode", "cors");
+    out.append("sec-fetch-dest", "empty");
+    out.append("referer", `${origin}/`);
+    out.append("accept-encoding", "gzip, deflate, br, zstd");
+    out.append("accept-language", "en-US,en;q=0.9");
+    out.append("priority", "u=1, i");
+
+    if (callerHeaders) {
+        const incoming = new Headers(callerHeaders);
+        incoming.forEach((value, key) => {
+            out.set(key, value);
+        });
+    }
+    return out;
 }
 
 function logProxyEvent(

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -66,9 +66,9 @@ export function shouldProxyPlaud(url: string): boolean {
     }
 }
 
+/** A single proxy selection. `url` contains credentials and must not be logged. */
 export interface SelectedProxy {
     id: string;
-    /** Contains credentials; do not log. */
     url: string;
     label: string;
 }

--- a/src/tests/plaud-proxy.integration.test.ts
+++ b/src/tests/plaud-proxy.integration.test.ts
@@ -24,7 +24,7 @@ if (!hasCreds) {
 const describeIntegration = hasCreds ? describe : describe.skip;
 
 const PLAUD_URL =
-    "https://api-euc1.plaud.ai/team-app/workspaces/list?need_personal_workspace=true";
+    "https://api.plaud.ai/team-app/workspaces/list?need_personal_workspace=true";
 
 async function callPlaud(): Promise<Response> {
     return plaudFetch(PLAUD_URL, {

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -24,6 +24,9 @@ vi.mock("undici", () => ({
         constructor(opts: unknown) {
             mockProxyAgent.ctor(opts);
         }
+        close(): Promise<void> {
+            return Promise.resolve();
+        }
     },
 }));
 

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -15,12 +15,16 @@ const mockEnv = vi.hoisted(() => ({
 
 vi.mock("@/lib/env", () => ({ env: mockEnv }));
 
-const mockWreq = vi.hoisted(() => ({
-    fetch: vi.fn() as Mock,
+const mockProxyAgent = vi.hoisted(() => ({
+    ctor: vi.fn() as Mock,
 }));
 
-vi.mock("wreq-js", () => ({
-    fetch: mockWreq.fetch,
+vi.mock("undici", () => ({
+    ProxyAgent: class {
+        constructor(opts: unknown) {
+            mockProxyAgent.ctor(opts);
+        }
+    },
 }));
 
 import { _resetPlaudFetchForTest, plaudFetch } from "@/lib/plaud/fetch";
@@ -77,7 +81,7 @@ const otherProxy = {
 beforeEach(() => {
     mockFetch = vi.fn();
     global.fetch = mockFetch as typeof global.fetch;
-    mockWreq.fetch.mockReset();
+    mockProxyAgent.ctor.mockReset();
     mockEnv.WEBSHARE_API_KEY = undefined;
     mockEnv.PLAUD_PROXY_SCOPE = "all";
     _resetPlaudProxyCacheForTest();
@@ -114,69 +118,71 @@ describe("shouldProxyPlaud", () => {
     });
 });
 
-describe("plaudFetch without Webshare configured", () => {
-    it("calls global fetch directly and never invokes wreq-js", async () => {
+describe("plaudFetch without a proxy configured", () => {
+    it("calls global fetch directly with no dispatcher", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockWreq.fetch).not.toHaveBeenCalled();
+        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
         expect(isPlaudProxyConfigured()).toBe(false);
     });
 
     it("does not proxy non-Plaud URLs", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://example.com/x");
-        expect(mockWreq.fetch).not.toHaveBeenCalled();
+        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
     });
 });
 
-describe("plaudFetch with Webshare configured", () => {
+describe("plaudFetch with a proxy configured", () => {
     beforeEach(() => {
         mockEnv.WEBSHARE_API_KEY = "test-key";
     });
 
-    it("fetches the Webshare list via global fetch and routes the Plaud call through the proxy", async () => {
-        mockFetch.mockResolvedValueOnce(webshareList([sampleProxy]));
-        mockWreq.fetch.mockResolvedValueOnce(okResponse());
+    it("fetches the Webshare list and attaches a ProxyAgent dispatcher to the Plaud call", async () => {
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy]))
+            .mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
 
-        // The Webshare list endpoint itself is not in the proxy scope.
-        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
         const [listUrl] = mockFetch.mock.calls[0];
         expect(String(listUrl)).toContain("proxy.webshare.io");
 
-        expect(mockWreq.fetch).toHaveBeenCalledTimes(1);
-        const [plaudUrl, opts] = mockWreq.fetch.mock.calls[0];
+        const [plaudUrl, opts] = mockFetch.mock.calls[1];
         expect(String(plaudUrl)).toBe(PLAUD_API_URL);
-        expect(opts.proxy).toBe(
-            `http://${sampleProxy.username}:${sampleProxy.password}@${sampleProxy.proxy_address}:${sampleProxy.port}`,
-        );
-        expect(typeof opts.browser).toBe("string");
-        expect(opts.browser).toMatch(/^chrome_/);
-        expect(opts.os).toBeDefined();
+        expect((opts as { dispatcher?: unknown }).dispatcher).toBeDefined();
+
+        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(1);
+        expect(mockProxyAgent.ctor).toHaveBeenCalledWith({
+            uri: `http://${sampleProxy.username}:${sampleProxy.password}@${sampleProxy.proxy_address}:${sampleProxy.port}`,
+        });
+
+        const sentHeaders = (opts as { headers: Headers }).headers;
+        expect(sentHeaders.get("user-agent")).toMatch(/Chrome/);
+        expect(sentHeaders.get("sec-ch-ua")).toContain("Chromium");
     });
 
     it("rotates exactly once on 403 and returns the second response", async () => {
-        mockFetch.mockResolvedValueOnce(
-            webshareList([sampleProxy, otherProxy]),
-        );
-        mockWreq.fetch
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
             .mockResolvedValueOnce(forbiddenResponse())
             .mockResolvedValueOnce(forbiddenResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(403);
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockWreq.fetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(2);
     });
 
     it("returns a readable body when rotation is exhausted (no second proxy)", async () => {
-        mockFetch.mockResolvedValueOnce(webshareList([sampleProxy]));
-        mockWreq.fetch.mockResolvedValueOnce(forbiddenResponse());
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy]))
+            .mockResolvedValueOnce(forbiddenResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(403);
@@ -185,32 +191,30 @@ describe("plaudFetch with Webshare configured", () => {
     });
 
     it("returns the success response after a rotation succeeds", async () => {
-        mockFetch.mockResolvedValueOnce(
-            webshareList([sampleProxy, otherProxy]),
-        );
-        mockWreq.fetch
+        mockFetch
+            .mockResolvedValueOnce(webshareList([sampleProxy, otherProxy]))
             .mockResolvedValueOnce(forbiddenResponse())
             .mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockWreq.fetch).toHaveBeenCalledTimes(2);
+        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(2);
     });
 
-    it("falls through to direct fetch when Webshare list is empty", async () => {
+    it("falls through to direct fetch when the proxy list is empty", async () => {
         mockFetch
             .mockResolvedValueOnce(webshareList([]))
             .mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockWreq.fetch).not.toHaveBeenCalled();
+        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
     });
 
     it("does not proxy non-Plaud URLs even when configured", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://s3.amazonaws.com/some-bucket/file");
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockWreq.fetch).not.toHaveBeenCalled();
+        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Description

The optional Plaud outbound proxy (enabled by `WEBSHARE_API_KEY`) previously routed through `wreq-js` to emit a Chrome-shaped TLS handshake. End-to-end testing against a real Plaud account confirms that handshake-level impersonation is not required: native `fetch` through `undici.ProxyAgent` with browser-shaped HTTP headers gets the same `status: 0` JSON responses from Plaud's API, both for one-shot calls and for sustained sequential calls across rotating proxies.

Removing `wreq-js` drops a Rust napi addon from the standalone Docker image and lets us delete the Turbopack `outputFileTracingIncludes` workaround that was added in v0.5.3 to keep `.next/standalone` shippable.

While here, the `WEBSHARE_API_KEY` and `PLAUD_PROXY_SCOPE` documentation in `.env.example` and `src/lib/env.ts` is reframed as an optional outbound proxy for environments where the host's egress IP can't reach Plaud directly (geo-restriction, ISP blocking, datacenter IP filtering) rather than as anti-bot tooling. Narrative/strategy comments across `env.ts`, `.env.example`, `next.config.ts`, and the Plaud route handlers are trimmed per AGENTS.md (JSDoc on exported APIs only, design rationale in commit messages).

## Type of Change

- [x] Code refactoring
- [x] Documentation update
- [x] Dependency update

## Related Issues

None.

## Changes Made

- `src/lib/plaud/fetch.ts`: replace `wreq-js`'s impersonating `fetch` with native `fetch` + `undici.ProxyAgent`. Same two-attempt 403/407 rotation, same `shouldProxyPlaud` gating. Layers Chrome 142 / Windows headers in real browser insertion order; caller-provided headers (e.g. `authorization`, `content-type`) always win.
- `package.json`: remove `wreq-js`.
- `next.config.ts`: drop `serverExternalPackages: ["wreq-js"]` and the `outputFileTracingIncludes` entry that pulled the napi binary into the standalone output. Strip the Rybbit history block.
- `src/lib/env.ts`, `.env.example`: collapse multi-paragraph narrative comments into one-line JSDoc / config notes. Reframe `WEBSHARE_API_KEY` neutrally.
- `src/app/api/plaud/sync/route.ts`, `src/app/api/dev/plaud/info/route.ts`, `src/lib/plaud/proxy.ts`: strip strategy comments.
- `src/tests/plaud-proxy.test.ts`: replace the `wreq-js` mock with an `undici.ProxyAgent` mock; assert dispatcher attachment and browser-shaped headers.
- `src/tests/plaud-proxy.integration.test.ts`: retarget at `api.plaud.ai` (matches a `us-west-2` bearer token) so the assertion isn't masking a `-302` region hint.
- `CHANGELOG.md`: `Changed` entry for the proxy swap, `Removed` entry for `wreq-js`.

## Testing

### Test Environment
- OS: macOS
- Node: pnpm 10.18, Node 22 (per local toolchain)

### Test Steps
1. `pnpm format-and-lint:fix` — clean (2 pre-existing `useTemplate` infos in an untouched file).
2. `pnpm type-check` — clean.
3. `pnpm test` — 362 passed, 5 skipped (integration suites requiring real credentials), 0 failures.
4. `PLAUD_BEARER_TOKEN=... WEBSHARE_API_KEY=... pnpm vitest run src/tests/plaud-proxy.integration.test.ts` against a real Plaud account through the Webshare pool — both tests green: single call returns `status: 0` with workspace data, three sequential calls across rotating proxies all return 200.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. `WEBSHARE_API_KEY` users keep the same behavior — same rotation policy, same scope semantics, same env var name. Direct-egress path (no proxy configured) is unchanged and was already not loading the removed dependency.

## For Reviewers

- Confirm the merged-header policy in `mergeBrowserHeaders` (caller wins on every key) matches what callers in `src/lib/plaud/client.ts` expect.
- Sanity-check the `.env.example` and `src/lib/env.ts` reframing reads as neutral self-host operator documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the optional Plaud proxy path with native fetch using `undici.ProxyAgent`, caching agents per proxy id and closing them on rotation to prevent socket leaks. This removes `wreq-js`, simplifies `next.config.ts`, and keeps proxy/direct behavior unchanged.

- **Refactors**
  - Proxy path now uses native fetch + `undici.ProxyAgent`; agents cached per proxy id and closed when a proxy is invalidated. Preserves a single rotation on 403/407; `shouldProxyPlaud` gating unchanged.
  - Applied Chrome 142/Windows headers under caller headers (caller wins); removed a dead origin branch. Trimmed comments and reframed `WEBSHARE_API_KEY` as an optional outbound proxy; clarified `PLAUD_PROXY_SCOPE`. Tests now mock `ProxyAgent` and assert dispatcher + headers; integration test targets `api.plaud.ai`.

- **Dependencies**
  - Removed `wreq-js` and pruned from `pnpm-lock.yaml`.
  - Deleted `serverExternalPackages` and the `outputFileTracingIncludes` workaround for `wreq-js` in `next.config.ts`.

<sup>Written for commit 2293daa81432b8c8c2c94bf22762434bbbe1a136. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

