### PR TITLE
docs: add non-affiliation disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ This means:
 ## ⚖️ Disclaimer
 
 - **Not affiliated.** OpenPlaud is an independent open-source project. It is not affiliated with, endorsed by, or sponsored by Plaud Inc. or any of its subsidiaries. "Plaud" and related marks are the property of their respective owners and are used here only for descriptive interoperability purposes (nominative fair use).
-- **Third-party devices and services.** OpenPlaud is designed to interoperate with hardware and services from third parties users choose to connect — including recording devices (such as Plaud) and storage and AI providers. Users are solely responsible for complying with the applicable terms of service, acceptable-use policies, and laws governing any third-party device or service they connect to this software.
+- **Third-party devices and services.** OpenPlaud is designed to interoperate with hardware and services from third parties that users choose to connect — including recording devices (such as Plaud) and storage and AI providers. Users are solely responsible for complying with the applicable terms of service, acceptable-use policies, and laws governing any third-party device or service they connect to this software.
 
 ## 🙏 Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -594,6 +594,11 @@ This means:
 - ⚠️ Must open-source any modifications if you run it as a service
 - ⚠️ Must include original license and copyright
 
+## ⚖️ Disclaimer
+
+- **Not affiliated.** OpenPlaud is an independent open-source project. It is not affiliated with, endorsed by, or sponsored by Plaud Inc. or any of its subsidiaries. "Plaud" and related marks are the property of their respective owners and are used here only for descriptive interoperability purposes (nominative fair use).
+- **Third-party devices and services.** OpenPlaud is designed to interoperate with hardware and services from third parties users choose to connect — including recording devices (such as Plaud) and storage and AI providers. Users are solely responsible for complying with the applicable terms of service, acceptable-use policies, and laws governing any third-party device or service they connect to this software.
+
 ## 🙏 Acknowledgments
 
 Originally created by **Perier**. Now developed and maintained by the OpenPlaud community.


### PR DESCRIPTION
## Description

Adds a Disclaimer section to `README.md` covering non-affiliation with Plaud Inc. and user responsibility for third-party device/service terms of use.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #
Relates to #

## Changes Made

- New `## ⚖️ Disclaimer` section placed between License and Acknowledgments.
- Bullet 1: clarifies OpenPlaud is independent — not affiliated with, endorsed by, or sponsored by Plaud Inc.; "Plaud" marks used under nominative fair use.
- Bullet 2: users are responsible for complying with the terms of any third-party devices, storage providers, and AI providers they connect.

## Testing

### Test Steps
- Docs-only change. No commands run.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Database Changes

N/A

## Breaking Changes

None.

## Additional Notes

Scope intentionally limited to the disclaimer block. No roadmap/marketing claims included in this section (kept neutral and legal-adjacent).

## For Reviewers

- Wording of the nominative-fair-use clause.
- Placement (after License, before Acknowledgments).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Disclaimer to the README noting OpenPlaud’s non‑affiliation with Plaud Inc. (nominative fair use) and user responsibility for third‑party terms; clarifies the third‑party clause wording. Placed after License and before Acknowledgments.

<sup>Written for commit e681d75dfe174b44e2c3b04c54bf025ea2f05f7c. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

