### PR TITLE
feat(admin): add install.sh hit counter for self-host reach

### DIFF
--- a/src/app/(admin)/admin/(gated)/_components/install-hits-tile.tsx
+++ b/src/app/(admin)/admin/(gated)/_components/install-hits-tile.tsx
@@ -27,6 +27,14 @@ export async function InstallHitsTile({ days = 30 }: { days?: number }) {
             </div>
             {stats.topVersions.length > 0 ? (
                 <table className="w-full mt-3 text-xs">
+                    <thead>
+                        <tr className="text-left text-muted-foreground">
+                            <th className="py-1 font-medium">Version</th>
+                            <th className="py-1 font-medium text-right">
+                                Hits
+                            </th>
+                        </tr>
+                    </thead>
                     <tbody>
                         {stats.topVersions.map((row) => (
                             <tr key={row.version} className="border-t">

--- a/src/app/(admin)/admin/(gated)/_components/install-hits-tile.tsx
+++ b/src/app/(admin)/admin/(gated)/_components/install-hits-tile.tsx
@@ -1,0 +1,46 @@
+import { getInstallHitStats } from "@/lib/admin/install-hits";
+import { formatNumber } from "./metrics";
+
+/**
+ * Aggregate counter for fetches of `/install.sh` and `/{version}/install.sh`.
+ *
+ * Read this as a directional trend, not a deployment count. One operator
+ * re-running the installer five times is five hits; CI pipelines count
+ * every run. See `lib/admin/install-hits.ts` for the privacy model
+ * (no IP, no UA, no identifier of any kind).
+ */
+export async function InstallHitsTile({ days = 30 }: { days?: number }) {
+    const stats = await getInstallHitStats(days);
+
+    return (
+        <div className="border rounded-xl p-4 bg-card">
+            <div className="text-xs text-muted-foreground">
+                Install script hits ({days}d)
+            </div>
+            <div className="text-2xl font-semibold mt-1">
+                {formatNumber(stats.total)}
+            </div>
+            <div className="text-xs text-muted-foreground mt-1">
+                {formatNumber(stats.distinctVersions)} distinct versions ·
+                origin fetches only (undercounted behind CDN cache), incl.
+                reruns, CI, bots and link previews. Not an instance count.
+            </div>
+            {stats.topVersions.length > 0 ? (
+                <table className="w-full mt-3 text-xs">
+                    <tbody>
+                        {stats.topVersions.map((row) => (
+                            <tr key={row.version} className="border-t">
+                                <td className="py-1 font-mono text-muted-foreground">
+                                    {row.version}
+                                </td>
+                                <td className="py-1 text-right tabular-nums">
+                                    {formatNumber(row.count)}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            ) : null}
+        </div>
+    );
+}

--- a/src/app/(admin)/admin/(gated)/page.tsx
+++ b/src/app/(admin)/admin/(gated)/page.tsx
@@ -1,4 +1,5 @@
 import { fleetOverview } from "@/lib/admin/queries";
+import { InstallHitsTile } from "./_components/install-hits-tile";
 import {
     formatBytes,
     formatHours,
@@ -249,6 +250,15 @@ export default async function AdminOverviewPage() {
                             };
                         })()}
                     />
+                </div>
+            </section>
+
+            <section>
+                <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground mb-2">
+                    Self-host reach
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <InstallHitsTile days={30} />
                 </div>
             </section>
         </div>

--- a/src/app/[version]/install.sh/route.ts
+++ b/src/app/[version]/install.sh/route.ts
@@ -14,11 +14,11 @@ export async function GET(
 ) {
     const { version } = await params;
     if (!isValidVersionTag(version)) {
-        // Still record the attempt so we can see if junk paths are getting
-        // hammered, bucketed as "invalid" by recordInstallHit. Awaited
-        // because serverless runtimes kill pending promises after response
-        // flush -- losing increments.
-        await recordInstallHit(version);
+        // Record the attempt so we can see if junk paths are getting
+        // hammered. Force the "invalid" bucket explicitly -- the raw
+        // segment might match a special bucket name (e.g. "latest")
+        // and falsely inflate that bucket even though we 404'd here.
+        await recordInstallHit("invalid");
         return NextResponse.json(
             { error: "Invalid version tag. Expected vX.Y.Z." },
             { status: 404 },

--- a/src/app/[version]/install.sh/route.ts
+++ b/src/app/[version]/install.sh/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { recordInstallHit } from "@/lib/admin/install-hits";
 import {
     INSTALL_SCRIPT_HEADERS,
     isValidVersionTag,
@@ -13,11 +14,17 @@ export async function GET(
 ) {
     const { version } = await params;
     if (!isValidVersionTag(version)) {
+        // Still record the attempt so we can see if junk paths are getting
+        // hammered, bucketed as "invalid" by recordInstallHit. Awaited
+        // because serverless runtimes kill pending promises after response
+        // flush -- losing increments.
+        await recordInstallHit(version);
         return NextResponse.json(
             { error: "Invalid version tag. Expected vX.Y.Z." },
             { status: 404 },
         );
     }
     const script = await renderInstallScript(version);
+    await recordInstallHit(version);
     return new Response(script, { headers: INSTALL_SCRIPT_HEADERS });
 }

--- a/src/app/install.sh/route.ts
+++ b/src/app/install.sh/route.ts
@@ -1,3 +1,4 @@
+import { recordInstallHit } from "@/lib/admin/install-hits";
 import {
     fetchLatestReleaseTag,
     INSTALL_SCRIPT_HEADERS,
@@ -11,5 +12,9 @@ export const runtime = "nodejs";
 export async function GET() {
     const tag = (await fetchLatestReleaseTag()) ?? APP_VERSION_TAG;
     const script = await renderInstallScript(tag);
+    // Aggregate counter; no-op on self-host, swallows errors internally.
+    // Awaited (not fire-and-forget) because serverless runtimes kill
+    // pending promises after response flush -- losing increments.
+    await recordInstallHit("latest");
     return new Response(script, { headers: INSTALL_SCRIPT_HEADERS });
 }

--- a/src/db/migrations/0023_ordinary_roxanne_simpson.sql
+++ b/src/db/migrations/0023_ordinary_roxanne_simpson.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "install_script_hits" (
+	"day" date NOT NULL,
+	"version" text NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "install_script_hits_day_version_pk" PRIMARY KEY("day","version")
+);

--- a/src/db/migrations/meta/0023_snapshot.json
+++ b/src/db/migrations/meta/0023_snapshot.json
@@ -1,0 +1,2211 @@
+{
+  "id": "f1cc7cbd-84e9-4124-a66a-c22f65b30061",
+  "prevId": "e46da9ca-a228-4ac5-ac02-9d595a31ff42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_action_log": {
+      "name": "admin_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_action_log_created_idx": {
+          "name": "admin_action_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_action_log_target_user_idx": {
+          "name": "admin_action_log_target_user_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_action_log_admin_user_id_users_id_fk": {
+          "name": "admin_action_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_action_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_created_idx": {
+          "name": "admin_audit_log_admin_created_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "api_key_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"read\"]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limit_buckets": {
+      "name": "api_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_buckets_reset_at_idx": {
+          "name": "api_rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.install_script_hits": {
+      "name": "install_script_hits",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_script_hits_day_version_pk": {
+          "name": "install_script_hits_day_version_pk",
+          "columns": [
+            "day",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "waveform_peaks": {
+          "name": "waveform_peaks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_user_id_plaud_file_id_unique": {
+          "name": "recordings_user_id_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_config": {
+      "name": "storage_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_config": {
+          "name": "s3_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_config_user_id_users_id_fk": {
+          "name": "storage_config_user_id_users_id_fk",
+          "tableFrom": "storage_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_config_user_id_unique": {
+          "name": "storage_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "player_scrubber": {
+          "name": "player_scrubber",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waveform'"
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "list_density": {
+          "name": "list_density",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comfortable'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_id_idx": {
+          "name": "webhook_deliveries_endpoint_id_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recording_id_idx": {
+          "name": "webhook_deliveries_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_user_id_users_id_fk": {
+          "name": "webhook_deliveries_user_id_users_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_recording_id_recordings_id_fk": {
+          "name": "webhook_deliveries_recording_id_recordings_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_status": {
+          "name": "last_delivery_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_user_id_idx": {
+          "name": "webhook_endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_user_id_users_id_fk": {
+          "name": "webhook_endpoints_user_id_users_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_source": {
+      "name": "api_key_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "device-flow"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1778498592155,
       "tag": "0022_icy_norman_osborn",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1779721528953,
+      "tag": "0023_ordinary_roxanne_simpson",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,10 +1,12 @@
 import {
     boolean,
+    date,
     index,
     integer,
     jsonb,
     pgEnum,
     pgTable,
+    primaryKey,
     real,
     text,
     timestamp,
@@ -571,5 +573,31 @@ export const apiRateLimitBuckets = pgTable(
         resetAtIdx: index("api_rate_limit_buckets_reset_at_idx").on(
             table.resetAt,
         ),
+    }),
+);
+
+/**
+ * Aggregate hit counter for the install.sh routes. Counts every fetch of
+ * `/install.sh` and `/{version}/install.sh` on the hosted instance.
+ *
+ * Privacy: no IP, no User-Agent, no identifier of any kind. Just (day,
+ * version) -> count. This is first-party traffic on our own webserver,
+ * not user-device storage. Self-host instances do NOT write to this
+ * table -- writes are gated on env.IS_HOSTED.
+ *
+ * Not an instance count. One operator re-running `install.sh` five times
+ * is five hits. CI pipelines count every run. Read as a directional
+ * trend, not absolute deployments.
+ */
+export const installScriptHits = pgTable(
+    "install_script_hits",
+    {
+        day: date("day").notNull(),
+        /** "latest" for the unversioned route, "vX.Y.Z" for versioned, "invalid" for anything that fails the version regex. */
+        version: text("version").notNull(),
+        count: integer("count").notNull().default(0),
+    },
+    (table) => ({
+        pk: primaryKey({ columns: [table.day, table.version] }),
     }),
 );

--- a/src/lib/admin/install-hits.ts
+++ b/src/lib/admin/install-hits.ts
@@ -27,8 +27,9 @@ function today(): string {
  * (only the hosted instance is a meaningful aggregator), and any DB error
  * is swallowed -- the install script must serve even if the DB is down.
  *
- * Callers do not need to await this in a way that blocks the response;
- * it's safe to fire-and-forget.
+ * Callers MUST `await` this. Serverless runtimes can kill pending promises
+ * after response flush, silently dropping increments. The upsert is
+ * sub-5ms; the helper is a no-op on self-host anyway.
  */
 export async function recordInstallHit(rawVersion: string): Promise<void> {
     if (!env.IS_HOSTED) return;
@@ -67,7 +68,10 @@ export async function getInstallHitStats(
     if (!env.IS_HOSTED) {
         return { total: 0, distinctVersions: 0, topVersions: [] };
     }
-    const since = new Date(Date.now() - days * 86_400_000)
+    // `days` is inclusive of today: a 30-day window covers today plus the
+    // 29 preceding UTC days = 30 distinct date buckets. Subtracting
+    // `days * DAY_MS` and slicing would include 31 buckets (off-by-one).
+    const since = new Date(Date.now() - (days - 1) * 86_400_000)
         .toISOString()
         .slice(0, 10);
 

--- a/src/lib/admin/install-hits.ts
+++ b/src/lib/admin/install-hits.ts
@@ -1,0 +1,92 @@
+import { and, desc, gte, sql, sum } from "drizzle-orm";
+import { db } from "@/db";
+import { installScriptHits } from "@/db/schema";
+import { env } from "@/lib/env";
+import { isValidVersionTag } from "@/lib/install-script";
+
+/**
+ * Bucket a raw version segment into the value we store. We allow:
+ *   - "latest" for the unversioned `/install.sh` route
+ *   - "vX.Y.Z" tags that pass the existing version regex
+ *   - "invalid" for everything else, so a flood of garbage paths can't
+ *     blow up table cardinality
+ */
+function normalizeVersion(raw: string): string {
+    if (raw === "latest") return "latest";
+    if (isValidVersionTag(raw)) return raw;
+    return "invalid";
+}
+
+/** UTC date string in `YYYY-MM-DD` form. drizzle `date` columns accept this. */
+function today(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Record a single hit on the install-script route. No-op on self-host
+ * (only the hosted instance is a meaningful aggregator), and any DB error
+ * is swallowed -- the install script must serve even if the DB is down.
+ *
+ * Callers do not need to await this in a way that blocks the response;
+ * it's safe to fire-and-forget.
+ */
+export async function recordInstallHit(rawVersion: string): Promise<void> {
+    if (!env.IS_HOSTED) return;
+    try {
+        const version = normalizeVersion(rawVersion);
+        await db
+            .insert(installScriptHits)
+            .values({ day: today(), version, count: 1 })
+            .onConflictDoUpdate({
+                target: [installScriptHits.day, installScriptHits.version],
+                set: { count: sql`${installScriptHits.count} + 1` },
+            });
+    } catch {
+        // Intentionally silent. The install script's job is to serve;
+        // a missed counter increment is not worth a 500.
+    }
+}
+
+export type InstallHitStats = {
+    /** Total hits across all versions in the requested window. */
+    total: number;
+    /** Number of distinct version buckets with at least one hit in the window. */
+    distinctVersions: number;
+    /** Top versions by hit count, descending, capped by caller. */
+    topVersions: Array<{ version: string; count: number }>;
+};
+
+/**
+ * Aggregate stats for the admin dashboard tile. Returns zeros on self-host
+ * (the table will be empty there anyway).
+ */
+export async function getInstallHitStats(
+    days: number,
+    topN = 5,
+): Promise<InstallHitStats> {
+    if (!env.IS_HOSTED) {
+        return { total: 0, distinctVersions: 0, topVersions: [] };
+    }
+    const since = new Date(Date.now() - days * 86_400_000)
+        .toISOString()
+        .slice(0, 10);
+
+    const rows = await db
+        .select({
+            version: installScriptHits.version,
+            count: sum(installScriptHits.count).mapWith(Number),
+        })
+        .from(installScriptHits)
+        .where(and(gte(installScriptHits.day, since)))
+        .groupBy(installScriptHits.version)
+        .orderBy(desc(sum(installScriptHits.count)));
+
+    const total = rows.reduce((acc, r) => acc + (r.count ?? 0), 0);
+    const distinctVersions = rows.length;
+    const topVersions = rows.slice(0, topN).map((r) => ({
+        version: r.version,
+        count: r.count ?? 0,
+    }));
+
+    return { total, distinctVersions, topVersions };
+}

--- a/src/tests/install-hits.test.ts
+++ b/src/tests/install-hits.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the install-script hit counter (`src/lib/admin/install-hits.ts`).
+ *
+ * Pins:
+ *   - Self-host (`IS_HOSTED=false`) is a hard no-op: the counter never
+ *     touches the DB and the stats query returns zeros without reading.
+ *   - On hosted, valid version tags pass through and bogus ones get
+ *     bucketed as "invalid" so route abuse can't blow up table cardinality.
+ *   - Counter swallows DB errors (the install script must serve even
+ *     when the DB is unhealthy).
+ */
+
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    IS_HOSTED: false,
+}));
+
+vi.mock("@/lib/env", () => ({ env: mockEnv }));
+
+const mockDb = vi.hoisted(() => {
+    const onConflictDoUpdate = vi.fn(async () => undefined);
+    const values = vi.fn(() => ({ onConflictDoUpdate }));
+    const insert = vi.fn(() => ({ values }));
+    const orderBy = vi.fn(
+        async () => [] as Array<{ version: string; count: number }>,
+    );
+    const groupBy = vi.fn(() => ({ orderBy }));
+    const where = vi.fn(() => ({ groupBy }));
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    return { insert, select, values, onConflictDoUpdate, orderBy };
+});
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: mockDb.insert,
+        select: mockDb.select,
+    },
+}));
+
+import { getInstallHitStats, recordInstallHit } from "@/lib/admin/install-hits";
+
+beforeEach(() => {
+    mockEnv.IS_HOSTED = false;
+    (mockDb.insert as Mock).mockClear();
+    (mockDb.select as Mock).mockClear();
+    (mockDb.values as Mock).mockClear();
+    (mockDb.onConflictDoUpdate as Mock).mockClear();
+    (mockDb.orderBy as Mock).mockClear();
+    (mockDb.orderBy as Mock).mockImplementation(async () => []);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("recordInstallHit", () => {
+    it("is a no-op on self-host (IS_HOSTED=false)", async () => {
+        mockEnv.IS_HOSTED = false;
+        await recordInstallHit("latest");
+        await recordInstallHit("v0.5.3");
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("upserts on hosted for the 'latest' bucket", async () => {
+        mockEnv.IS_HOSTED = true;
+        await recordInstallHit("latest");
+        expect(mockDb.insert).toHaveBeenCalledTimes(1);
+        const inserted = (mockDb.values as Mock).mock.calls[0]?.[0];
+        expect(inserted).toMatchObject({ version: "latest", count: 1 });
+        expect(inserted.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("preserves valid vX.Y.Z tags verbatim", async () => {
+        mockEnv.IS_HOSTED = true;
+        await recordInstallHit("v0.5.3");
+        const inserted = (mockDb.values as Mock).mock.calls[0]?.[0];
+        expect(inserted.version).toBe("v0.5.3");
+    });
+
+    it("buckets malformed version segments as 'invalid'", async () => {
+        mockEnv.IS_HOSTED = true;
+        await recordInstallHit("../../etc/passwd");
+        await recordInstallHit("0.5.3"); // missing leading v
+        await recordInstallHit("v0.5.3-rc.1"); // not strict X.Y.Z
+        const versions = (mockDb.values as Mock).mock.calls.map(
+            (c) => (c[0] as { version: string }).version,
+        );
+        expect(versions).toEqual(["invalid", "invalid", "invalid"]);
+    });
+
+    it("swallows DB errors so the install script keeps serving", async () => {
+        mockEnv.IS_HOSTED = true;
+        (mockDb.onConflictDoUpdate as Mock).mockRejectedValueOnce(
+            new Error("db down"),
+        );
+        await expect(recordInstallHit("latest")).resolves.toBeUndefined();
+    });
+});
+
+describe("getInstallHitStats", () => {
+    it("returns zeros on self-host without reading the DB", async () => {
+        mockEnv.IS_HOSTED = false;
+        const stats = await getInstallHitStats(30);
+        expect(stats).toEqual({
+            total: 0,
+            distinctVersions: 0,
+            topVersions: [],
+        });
+        expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it("aggregates totals, distinct version count, and top-N on hosted", async () => {
+        mockEnv.IS_HOSTED = true;
+        (mockDb.orderBy as Mock).mockImplementationOnce(async () => [
+            { version: "latest", count: 120 },
+            { version: "v0.5.3", count: 40 },
+            { version: "v0.5.2", count: 12 },
+            { version: "invalid", count: 3 },
+        ]);
+        const stats = await getInstallHitStats(30, 2);
+        expect(stats.total).toBe(175);
+        expect(stats.distinctVersions).toBe(4);
+        expect(stats.topVersions).toEqual([
+            { version: "latest", count: 120 },
+            { version: "v0.5.3", count: 40 },
+        ]);
+    });
+});


### PR DESCRIPTION
## Description

Adds an aggregate-only hit counter for the `/install.sh` and `/{version}/install.sh` routes so we can see directional self-host reach without phoning home from operator machines.

No IP, no User-Agent, no instance identifier of any kind. Just `(day, version) -> count`, written only when `IS_HOSTED=true`. Self-host instances do not touch the table. Counts are origin fetches, so CDN cache (existing `s-maxage=300`) will undercount — that tradeoff is called out directly in the tile copy.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

n/a

## Changes Made

- `src/db/schema.ts`: new `install_script_hits` table keyed on `(day, version)` with a `count` integer; migration `0023_ordinary_roxanne_simpson.sql` generated via `pnpm db:generate`.
- `src/lib/admin/install-hits.ts`: `recordInstallHit(version)` upserts the (day, version) row; no-op when `IS_HOSTED=false`; DB errors swallowed so the install script keeps serving when the DB is unhealthy. Bogus version segments bucket as `"invalid"` so route abuse can't blow up cardinality.
- `src/app/install.sh/route.ts` and `src/app/[version]/install.sh/route.ts`: `await` the counter (not fire-and-forget — serverless runtimes can kill pending promises after response flush, dropping increments).
- `src/app/(admin)/admin/(gated)/_components/install-hits-tile.tsx` + dashboard page: new "Self-host reach" section showing 30-day total, distinct-version count, and top-5 versions table. Copy: "origin fetches only (undercounted behind CDN cache), incl. reruns, CI, bots and link previews. Not an instance count."
- `src/tests/install-hits.test.ts`: covers `IS_HOSTED` gating (read + write), version normalization (`latest` / `vX.Y.Z` / `invalid`), top-N aggregation, and that DB errors don't propagate.

## Testing

### Test Environment
- OS: macOS
- Node version: project default (pnpm)

### Test Steps
- `pnpm test src/tests/install-hits.test.ts` — 7/7 pass
- `pnpm test` — 369 pass, 5 skipped (integration suites without secrets), 0 failures
- `pnpm type-check` — clean
- `pnpm format-and-lint:fix` — clean
- `pnpm db:generate` — produced a single additive migration, no drift

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — intentionally none; this is hosted-only ops plumbing per AGENTS.md ("Hosted-only behavioral changes are not changelog material"), no self-hoster-visible surface changes.
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [x] I have generated a new migration (`pnpm db:generate`) — `src/db/migrations/0023_ordinary_roxanne_simpson.sql`
- [x] I have tested the migration locally
- [x] Additive only — new table, no destructive change. Rollback is `DROP TABLE install_script_hits;`.

## Breaking Changes

None. Schema change is additive; self-host code paths are unchanged because the counter is gated on `IS_HOSTED`.

## Additional Notes

Why this design over a self-host telemetry ping (considered and rejected):

- We're EU-hosted, so a default-on phone-home from self-host instances is hard to defend under GDPR + ePrivacy 5(3) — an opt-out env var is not valid consent, and "legitimate interest" loses the balancing test against users who specifically self-host to avoid phoning home.
- This design has zero new user-device storage, zero new outbound calls from self-host, and zero new privacy-policy surface. It measures origin traffic on our own webserver, which is normal first-party analytics.
- Tradeoff: we lose "active long-running instance count" as a signal. That's fine — directional trend on installs + GitHub clone/release stats answer the actual questions.

Known limitations baked into the tile copy:

- CDN `s-maxage=300` on `install.sh` means coalesced origin requests; we accept undercount in exchange for keeping the cache.
- Bots, link previews (Slack, GitHub social cards), and CI all count. Directional metric only.
- Day boundary is UTC.

## For Reviewers

- `src/lib/admin/install-hits.ts` — confirm the `IS_HOSTED` gate placement and that the `try/catch` envelope is wide enough to truly never throw to the caller.
- `src/app/[version]/install.sh/route.ts` — confirm you're OK counting 404 attempts (bucketed as `invalid`); rationale is "see if abuse is happening" but easy to drop if you'd rather not.
- Tile copy on the dashboard — read as a future maintainer reading the number cold. Is the "not an instance count" caveat clear enough?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a privacy‑preserving hit counter for the install script to gauge self‑host reach without device telemetry. The admin dashboard shows a 30‑day view; we store only `(day, version)` on hosted.

- **New Features**
  - Aggregate-only counter for `/install.sh` and `/{version}/install.sh`, keyed by (day, version); runs only when `IS_HOSTED=true`; stores no IP/UA; invalid paths bucketed as "invalid".
  - Admin tile “Self-host reach” with 30‑day total, distinct versions, and top‑5; routes await the upsert and swallow DB errors; counts are origin fetches and undercount behind the CDN.

- **Bug Fixes**
  - Force the "invalid" bucket for 404s on versioned routes so `/latest/install.sh` doesn’t inflate "latest".
  - Correct 30‑day window start (subtract `days‑1`) to avoid 31 buckets.
  - Add table headers for better screen reader support.

<sup>Written for commit 797fdedee17fa2171837d80cabdc612a438e11cc. Summary will update on new commits. <a href="https://cubic.dev/pr/openplaud/openplaud/pull/180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

