### PR TITLE
docs(readme): add rebrand note, drop redundant H1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![Riffado](.github/assets/banner.png)
 
-# Riffado
-
 **Open-source AI transcription companion for voice recorders.**
 
 *Bring your own AI provider, own your transcripts, self-host or hosted.*
@@ -16,6 +14,8 @@
 </div>
 
 ---
+
+> **Renamed May 2026.** Riffado was previously **OpenPlaud**. Same project, same code, same team, same license &mdash; new name so the project isn't tied to one device vendor in its name. [Read the rebrand note &rarr;](https://riffado.com/rebrand)
 
 Riffado is an open-source companion app for AI voice recorders. It syncs your recordings from the manufacturer's cloud, transcribes them with any OpenAI-compatible API (or in the browser, for free), and stores everything on infrastructure you control. **Currently supports the Plaud Note family — Note, Note Pro, and NotePin. More device support on the way.** AGPL-3.0.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-> **Renamed May 2026.** Riffado was previously **OpenPlaud**. Same project, same code, same team, same license &mdash; new name so the project isn't tied to one device vendor in its name. [Read the rebrand note &rarr;](https://riffado.com/rebrand)
+> **OpenPlaud is now Riffado.** Same project, same code, same team, same license &mdash; renamed in May 2026 so the project isn't tied to one device vendor in its name. [Read the rebrand note &rarr;](https://riffado.com/rebrand)
 
 Riffado is an open-source companion app for AI voice recorders. It syncs your recordings from the manufacturer's cloud, transcribes them with any OpenAI-compatible API (or in the browser, for free), and stores everything on infrastructure you control. **Currently supports the Plaud Note family — Note, Note Pro, and NotePin. More device support on the way.** AGPL-3.0.
 


### PR DESCRIPTION
## Description

Small README polish to land alongside the rebrand: add a callout for anyone Googling "openplaud" who hits the repo, and drop the redundant `# Riffado` H1 since the banner image directly above already carries the project name.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Added a one-line callout right under the centered intro block: "Renamed May 2026. Riffado was previously OpenPlaud. Same project, same code, same team, same license — new name so the project isn't tied to one device vendor in its name." with a link to `https://riffado.com/rebrand`.
- Removed the `# Riffado` H1. The banner image (`./.github/assets/banner.png`) already carries the project name; the tagline now reads cleanly as the first text line on its own. GitHub's repo sidebar still surfaces the repo name independently, so this changes nothing for SEO or GitHub UI.

## Screenshots (if applicable)

N/A — minor markdown change.

## Testing

### Test Environment

- OS: macOS (dev)
- Node version: n/a (docs only)
- Browser (if UI changes): n/a

### Test Steps

1. Confirmed visually that the README top renders cleanly with the banner → tagline → byline → badges → nav links sequence and no redundant H1.
2. Confirmed the new callout link target `https://riffado.com/rebrand` matches the public explainer page shipped in PR #185.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [ ] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

No schema changes.

## Breaking Changes

None.

## Additional Notes

The README still contains the phrase "Bring your own AI provider" in the tagline. We scrubbed that exact framing from the landing surfaces in PR #185 in favor of vendor-named language, but the README's audience is technical (self-hosters, contributors) where the phrase is unambiguous. Left as-is intentionally; can revisit if you want the README to mirror the landing copy precisely.

## For Reviewers

- Confirm the callout's link target (`https://riffado.com/rebrand`) is the URL you want long-lived. The page itself ships with PR #185.
- Confirm you're OK with no H1 in the README. GitHub repo title is unaffected.
