### PR TITLE
fix(seo): scope sitemap and robots to hosted mode

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,43 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/lib/env";
+
+// `force-dynamic` so `env.IS_HOSTED` / `env.APP_URL` are read at request
+// time, not bake time.
+export const dynamic = "force-dynamic";
+
+// Private surfaces excluded from the hosted crawl. These either require
+// auth, redirect to login, or are non-content endpoints; keeping them out
+// of the index avoids crawl budget waste and accidental exposure.
+const HOSTED_DISALLOW = [
+    "/api/",
+    "/dashboard",
+    "/settings",
+    "/onboarding",
+    "/recordings/",
+    "/admin",
+    "/login",
+    "/register",
+    "/forgot-password",
+    "/reset-password",
+    "/suspended",
+    "/dev/",
+];
+
+export default function robots(): MetadataRoute.Robots {
+    // Self-host instances are private by default -- block all crawling and
+    // advertise no sitemap. The hosted product (IS_HOSTED=true) is the only
+    // surface meant to be indexed.
+    if (!env.IS_HOSTED) {
+        return {
+            rules: [{ userAgent: "*", disallow: "/" }],
+        };
+    }
+
+    const baseUrl = env.APP_URL ?? "https://riffado.com";
+
+    return {
+        rules: [{ userAgent: "*", allow: "/", disallow: HOSTED_DISALLOW }],
+        sitemap: `${baseUrl}/sitemap.xml`,
+        host: baseUrl,
+    };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,15 +2,50 @@ import type { MetadataRoute } from "next";
 import { env } from "@/lib/env";
 import { source } from "@/lib/source";
 
-// `force-dynamic` so `env.APP_URL` is read at request time, not bake time.
+// `force-dynamic` so `env.IS_HOSTED` / `env.APP_URL` are read at request
+// time, not bake time.
 export const dynamic = "force-dynamic";
 
+// Public, indexable static routes served only by the hosted product.
+// Docs pages are appended separately from the Fumadocs source. Private
+// surfaces (app, auth, admin, api) are intentionally absent and are also
+// disallowed in `robots.ts`.
+const STATIC_ROUTES: {
+    path: string;
+    priority: number;
+    changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+}[] = [
+    { path: "/", priority: 1.0, changeFrequency: "daily" },
+    { path: "/changelog", priority: 0.8, changeFrequency: "daily" },
+    { path: "/install", priority: 0.7, changeFrequency: "weekly" },
+    { path: "/rebrand", priority: 0.5, changeFrequency: "yearly" },
+    { path: "/privacy", priority: 0.3, changeFrequency: "yearly" },
+    { path: "/terms", priority: 0.3, changeFrequency: "yearly" },
+];
+
 export default function sitemap(): MetadataRoute.Sitemap {
+    // Self-host instances are not crawled (see `robots.ts` -- `Disallow: /`),
+    // so they expose no sitemap entries. The sitemap is a hosted-only surface.
+    if (!env.IS_HOSTED) {
+        return [];
+    }
+
     const baseUrl = env.APP_URL ?? "https://riffado.com";
-    return source.getPages().map((page) => ({
-        url: `${baseUrl}${page.url}`,
-        lastModified: page.data.lastModified,
-        changeFrequency: "weekly",
-        priority: 0.7,
+
+    const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => ({
+        url: `${baseUrl}${route.path}`,
+        changeFrequency: route.changeFrequency,
+        priority: route.priority,
     }));
+
+    const docsEntries: MetadataRoute.Sitemap = source
+        .getPages()
+        .map((page) => ({
+            url: `${baseUrl}${page.url}`,
+            lastModified: page.data.lastModified,
+            changeFrequency: "weekly",
+            priority: 0.7,
+        }));
+
+    return [...staticEntries, ...docsEntries];
 }


### PR DESCRIPTION
## Description

The sitemap previously emitted only docs pages, leaving the marketing, legal, and content routes uncrawlable. This scopes both the sitemap and a new robots policy to deployment mode: the hosted product gets a complete sitemap and a crawlable robots policy, while self-host instances are made fully uncrawlable.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

<!-- No tracking issue. -->

## Changes Made

- `src/app/sitemap.ts`: return an empty sitemap when `!env.IS_HOSTED`; when hosted, emit the public static routes (`/`, `/changelog`, `/install`, `/rebrand`, `/privacy`, `/terms`) alongside the existing Fumadocs docs pages, via a typed static-route list with per-route priority/changeFrequency.
- `src/app/robots.ts` (new, `force-dynamic`): self-host returns `Disallow: /` with no sitemap line; hosted allows `/` with private prefixes excluded (`/api/`, `/dashboard`, `/settings`, `/onboarding`, `/recordings/`, `/admin`, auth routes, `/suspended`, `/dev/`) and advertises `${baseUrl}/sitemap.xml` plus `host`.
- Both read `env` at request time and reuse the established `env.APP_URL ?? "https://riffado.com"` base-URL fallback.

## Testing

### Test Steps
1. `pnpm format-and-lint:fix` — clean (2 pre-existing infos in an untouched test file).
2. `pnpm type-check` — passes.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. Default (self-host) behavior is the conservative path: no sitemap entries and no crawling. Marketing/legal/changelog routes are gated behind `IS_HOSTED` and already redirect or 404 on self-host, so listing them only in the hosted sitemap matches existing route behavior.

## For Reviewers

- Confirm the self-host invariant: empty sitemap + `Disallow: /`, no sitemap advertised.
- Confirm the hosted private-path disallow list matches the route groups you want kept out of the index.
