### PR TITLE
docs(legal): accurate privacy policy and terms of service

### DIFF
--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -1,25 +1,34 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+    CONTACT_EMAILS,
+    EFFECTIVE_DATE_DISPLAY,
+    LEGAL_ADDRESS_LINE,
+    LEGAL_ENTITY,
+    MIN_AGE,
+    SUBPROCESSORS,
+    SUPERVISORY_AUTHORITY,
+} from "@/lib/legal/constants";
 
 /*
- * TODO(legal): Replace this placeholder with the real privacy policy
- * before hosted GA. This is a structural stub so the footer's Privacy
- * link is not a dead link -- the content here is NOT a legal document
- * and must not be treated as one. Coordinate with counsel on:
- *   - Data controller / processor framing
- *   - Sub-processors (AI providers, S3 host, email, analytics)
- *   - International transfer mechanism (SCCs)
- *   - User rights (access, deletion, export -- export is already
- *     implemented via the full-backup endpoint)
- *   - Retention defaults and overrides
- *   - Cookie / tracking disclosure (Rybbit only, no third-party ads)
- *   - Contact for data requests (privacy@riffado.com -- needs
- *     mailbox if we want to use it)
+ * Privacy policy for the HOSTED service only. The `(legal)` layout 404s
+ * when `!IS_HOSTED`, so this never serves on a self-hosted instance.
+ *
+ * Structure follows the GDPR Article 13 information obligations: who the
+ * controller is, what we process and why, the legal bases, recipients
+ * (sub-processors), transfers, retention, data-subject rights, and the
+ * right to lodge a complaint with the supervisory authority.
+ *
+ * Every factual claim here is traceable to code: AES-256-GCM token
+ * encryption (`src/lib/encryption.ts`), full-archive export, account
+ * deletion, self-hosted Rybbit analytics, user-configured AI providers.
+ * Do not add claims the code does not back. Variable facts (entity,
+ * address, sub-processors, contacts) come from `@/lib/legal/constants`.
  */
 
 export const metadata: Metadata = {
     title: "Privacy Policy — Riffado",
-    description: "How Riffado handles your data on the hosted service.",
+    description: "How the hosted Riffado service handles your personal data.",
 };
 
 export default function PrivacyPage() {
@@ -27,72 +36,235 @@ export default function PrivacyPage() {
         <>
             <h1>Privacy Policy</h1>
             <p>
-                <em>Last updated: TBD. This page is a placeholder.</em>
+                <em>Effective {EFFECTIVE_DATE_DISPLAY}.</em>
             </p>
             <p>
-                Riffado is open-source software you can run yourself (under
-                AGPL-3.0) or use through the hosted service at riffado.com. This
-                page describes how the hosted service handles your data. If you
+                This policy explains how we handle personal data on the hosted
+                Riffado service at riffado.com. Riffado is also open-source
+                software you can run yourself under the AGPL-3.0 license. If you
                 self-host, your data never touches our infrastructure and this
-                policy does not apply to you. See the{" "}
+                policy does not apply to you — see the{" "}
                 <Link href="https://github.com/riffado/riffado#readme">
                     project README
                 </Link>{" "}
                 for self-host guidance.
             </p>
 
-            <h2>What we collect</h2>
+            <h2>Who we are</h2>
             <p>
-                Account information you provide (email, name), the Plaud account
-                credentials you connect (encrypted at rest with AES-256-GCM),
-                and the recordings, transcripts, and summaries the service
-                generates on your behalf.
+                The hosted service is operated by {LEGAL_ENTITY.fullName} (
+                {LEGAL_ENTITY.name}), {LEGAL_ENTITY.form}, with its registered
+                office at {LEGAL_ADDRESS_LINE}, entered in the National Court
+                Register (KRS) under number {LEGAL_ENTITY.krs} by the{" "}
+                {LEGAL_ENTITY.registrationCourt}; NIP {LEGAL_ENTITY.nip}, REGON{" "}
+                {LEGAL_ENTITY.regon}; share capital {LEGAL_ENTITY.shareCapital}.
+                We are the data controller for the personal data described
+                below. For privacy questions or to exercise your rights, contact{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.privacy}`}>
+                    {CONTACT_EMAILS.privacy}
+                </Link>
+                .
             </p>
+
+            <h2>What we collect</h2>
+            <ul>
+                <li>
+                    <strong>Account data</strong> — the email address and name
+                    you provide when you register, and authentication data
+                    needed to sign you in.
+                </li>
+                <li>
+                    <strong>Connected recorder credentials</strong> — the Plaud
+                    account token you connect, stored encrypted at rest with
+                    AES-256-GCM and decrypted only when we make a request to
+                    Plaud on your behalf.
+                </li>
+                <li>
+                    <strong>Your content</strong> — the recordings, transcripts,
+                    and summaries the service syncs or generates for you.
+                </li>
+                <li>
+                    <strong>Usage analytics</strong> — privacy-friendly,
+                    aggregate usage data collected through analytics software we
+                    host ourselves. It uses no advertising cookies and is not
+                    shared with any third party.
+                </li>
+            </ul>
+
+            <h2>Why we process it, and on what legal basis</h2>
+            <ul>
+                <li>
+                    To provide the service — sync, transcription, storage, and
+                    export — on the legal basis of performing our contract with
+                    you (Art. 6(1)(b) GDPR).
+                </li>
+                <li>
+                    To send transactional email (password resets, recording
+                    notifications you enable), also as performance of the
+                    contract.
+                </li>
+                <li>
+                    To keep the service secure and working, and to understand
+                    aggregate usage, on the basis of our legitimate interests
+                    (Art. 6(1)(f) GDPR).
+                </li>
+                <li>
+                    When you choose a cloud AI provider, to forward the relevant
+                    audio or text to it at your direction so it can transcribe
+                    or summarize your content.
+                </li>
+            </ul>
 
             <h2>What we do not do</h2>
             <ul>
                 <li>We do not train AI models on your recordings.</li>
-                <li>We do not sell your data.</li>
+                <li>We do not sell your personal data.</li>
                 <li>
-                    We do not share recordings with anyone other than the AI
-                    provider you configure to transcribe and summarize them.
+                    We do not use advertising trackers or share data with ad
+                    networks.
                 </li>
             </ul>
 
-            <h2>AI providers</h2>
+            <h2>Who processes data for us</h2>
             <p>
-                When you configure an AI provider (OpenAI, Anthropic, Groq,
-                OpenRouter, a local Ollama instance, etc.) the hosted service
-                forwards the relevant audio or text to that provider on your
-                behalf. Their privacy terms apply to that processing. We do not
-                retain a separate copy of what we send to them beyond what is
-                already stored in your account.
+                We use the following sub-processors to run the hosted service.
+                Each handles personal data only on our instructions under a data
+                processing agreement:
+            </p>
+            <div className="overflow-x-auto mb-4">
+                <table className="w-full text-sm border-collapse">
+                    <thead>
+                        <tr className="border-b border-border text-left">
+                            <th className="py-2 pr-4 font-semibold text-foreground">
+                                Sub-processor
+                            </th>
+                            <th className="py-2 pr-4 font-semibold text-foreground">
+                                Purpose
+                            </th>
+                            <th className="py-2 pr-4 font-semibold text-foreground">
+                                Location
+                            </th>
+                            <th className="py-2 font-semibold text-foreground">
+                                Safeguard
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="text-muted-foreground">
+                        {SUBPROCESSORS.map((p) => (
+                            <tr
+                                key={p.name}
+                                className="border-b border-border/40 align-top"
+                            >
+                                <td className="py-2 pr-4 text-foreground">
+                                    {p.name}
+                                </td>
+                                <td className="py-2 pr-4">{p.purpose}</td>
+                                <td className="py-2 pr-4">{p.location}</td>
+                                <td className="py-2">{p.safeguard}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            <p>
+                Our analytics software runs on our own infrastructure, so it is
+                not a third-party recipient of your data.
             </p>
 
-            <h2>Export and deletion</h2>
+            <h2>AI providers you configure</h2>
             <p>
-                You can export every recording, transcript, and summary from
-                your account at any time via the full-backup endpoint. You can
-                delete your account, which removes all associated data from
-                active storage.
+                When you configure a cloud AI provider (such as OpenAI,
+                Anthropic, or Groq) the service forwards the relevant audio or
+                text to that provider at your direction. You contract with that
+                provider directly and their privacy terms govern that processing
+                — they are not our sub-processors. We do not retain a separate
+                copy beyond what is already stored in your account. If you
+                transcribe in your browser or with a local model, no audio
+                leaves your control through a third party at all.
+            </p>
+
+            <h2>International transfers</h2>
+            <p>
+                Most processing happens within the European Economic Area. Where
+                a sub-processor is established outside the EEA (see the table
+                above), transfers are covered by the EU Standard Contractual
+                Clauses and the provider&apos;s data processing agreement.
+            </p>
+
+            <h2>Retention</h2>
+            <p>
+                We keep your content and account data for as long as your
+                account is active. When you delete your account, we remove the
+                associated data from active storage; residual copies in routine
+                backups age out on the backup rotation. We keep the minimum
+                records we are legally required to retain.
+            </p>
+
+            <h2>Your rights</h2>
+            <p>
+                Under the GDPR you have the right to access, rectify, erase,
+                restrict, and object to the processing of your personal data,
+                and the right to data portability. You can act on most of these
+                yourself: export every recording, transcript, and summary at any
+                time via the full-archive export, and delete your account to
+                erase your data. For anything else, contact{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.privacy}`}>
+                    {CONTACT_EMAILS.privacy}
+                </Link>{" "}
+                and we will respond within the time the GDPR allows.
+            </p>
+            <p>
+                You also have the right to lodge a complaint with a supervisory
+                authority. Our lead authority is {SUPERVISORY_AUTHORITY.name},{" "}
+                {SUPERVISORY_AUTHORITY.address} (
+                <Link href={SUPERVISORY_AUTHORITY.url}>
+                    {SUPERVISORY_AUTHORITY.url.replace("https://", "")}
+                </Link>
+                ).
+            </p>
+
+            <h2>Security</h2>
+            <p>
+                Connected recorder tokens and other sensitive credentials are
+                encrypted at rest with AES-256-GCM. Report suspected
+                vulnerabilities to{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.security}`}>
+                    {CONTACT_EMAILS.security}
+                </Link>
+                .
+            </p>
+
+            <h2>Children</h2>
+            <p>
+                The hosted service is not directed to children. You must be at
+                least {MIN_AGE} years old to use it; if you are under 18, you
+                need a parent or guardian&apos;s consent.
             </p>
 
             <h2>Compliance posture</h2>
             <p>
                 Riffado is not HIPAA or SOC 2 certified. For regulated work,
                 self-host the project and plug in an AI provider that signs a
-                BAA you have reviewed, or run a local model.
+                data processing agreement you have reviewed, or run a local
+                model.
+            </p>
+
+            <h2>Changes</h2>
+            <p>
+                When we update this policy, we will post the new version here
+                and update the effective date above. We encourage you to review
+                it periodically.
             </p>
 
             <h2>Contact</h2>
             <p>
-                Questions about this policy:{" "}
-                <Link href="mailto:support@riffado.com">
-                    support@riffado.com
+                Privacy and data requests:{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.privacy}`}>
+                    {CONTACT_EMAILS.privacy}
                 </Link>
-                . Security disclosures:{" "}
-                <Link href="mailto:security@riffado.com">
-                    security@riffado.com
+                . General support:{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.support}`}>
+                    {CONTACT_EMAILS.support}
                 </Link>
                 .
             </p>

--- a/src/app/(legal)/terms/page.tsx
+++ b/src/app/(legal)/terms/page.tsx
@@ -1,21 +1,30 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+    CONTACT_EMAILS,
+    EFFECTIVE_DATE_DISPLAY,
+    GOVERNING_LAW,
+    LEGAL_ADDRESS_LINE,
+    LEGAL_ENTITY,
+    MIN_AGE,
+} from "@/lib/legal/constants";
 
 /*
- * TODO(legal): Replace this placeholder with the real terms of service
- * before hosted GA. This is a structural stub so the footer's Terms
- * link is not a dead link -- the content here is NOT a legal document
- * and must not be treated as one. Coordinate with counsel on:
- *   - Acceptable use (no automated abuse, no illegal content,
- *     recording-consent requirements vary by jurisdiction)
- *   - Account termination / suspension grounds
- *   - Subscription, billing, refund terms (once billing lands)
- *   - Disclaimer of warranties / limitation of liability
- *   - Governing law and dispute resolution
- *   - DMCA / takedown contact
- *   - Relationship to the AGPL-3.0 license that governs the software
- *     itself (the software is AGPL; the hosted service is a service
- *     under these terms -- these are independent contracts)
+ * Terms of Service for the HOSTED service only. The `(legal)` layout
+ * 404s when `!IS_HOSTED`, so this never serves on a self-hosted instance.
+ *
+ * The operator is a Polish company, so this doubles as the "regulamin"
+ * required of an electronic-service provider under the Polish Act on
+ * Providing Services by Electronic Means: it identifies the provider,
+ * the scope of services, technical conditions, the prohibition on
+ * unlawful content, contract conclusion/termination, and a complaints
+ * procedure. It also carries standard SaaS terms (acceptable use,
+ * disclaimers, liability, governing law).
+ *
+ * Factual claims track the code: AGPL-3.0 source, full-archive export,
+ * Plaud-upstream dependence, user-configured AI providers, no paid tier
+ * live yet (Pro is a waitlist). Variable facts come from
+ * `@/lib/legal/constants`.
  */
 
 export const metadata: Metadata = {
@@ -29,13 +38,37 @@ export default function TermsPage() {
         <>
             <h1>Terms of Service</h1>
             <p>
-                <em>Last updated: TBD. This page is a placeholder.</em>
+                <em>Effective {EFFECTIVE_DATE_DISPLAY}.</em>
             </p>
             <p>
                 These terms govern your use of the hosted Riffado service at
-                riffado.com. If you self-host the project, your relationship is
-                with the AGPL-3.0 license that governs the source code, not with
-                these terms.
+                riffado.com. By creating an account or using the service, you
+                agree to them. If you self-host the project instead, your
+                relationship is with the AGPL-3.0 license that governs the
+                source code, not with these terms.
+            </p>
+
+            <h2>Who provides the service</h2>
+            <p>
+                The hosted service is provided by {LEGAL_ENTITY.fullName} (
+                {LEGAL_ENTITY.name}), {LEGAL_ENTITY.form}, registered office at{" "}
+                {LEGAL_ADDRESS_LINE}, KRS {LEGAL_ENTITY.krs}, NIP{" "}
+                {LEGAL_ENTITY.nip}, REGON {LEGAL_ENTITY.regon}, share capital{" "}
+                {LEGAL_ENTITY.shareCapital}. You can reach us at{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.support}`}>
+                    {CONTACT_EMAILS.support}
+                </Link>
+                .
+            </p>
+
+            <h2>What the service does</h2>
+            <p>
+                Riffado syncs recordings from a connected voice recorder,
+                transcribes and summarizes them using the AI provider you choose
+                (or in your browser), stores them, and lets you export
+                everything. To use it you need a compatible browser, internet
+                access, an account, and — for sync — a connected recorder
+                account.
             </p>
 
             <h2>The software vs. the service</h2>
@@ -48,45 +81,128 @@ export default function TermsPage() {
                 >
                     github.com/riffado/riffado
                 </Link>
-                . You are free to run, modify, and redistribute it under the
-                terms of that license. These Terms of Service apply only to the
-                hosted instance we operate.
+                . You are free to run, modify, and redistribute it under that
+                license. These terms apply only to the hosted instance we
+                operate; they are a separate agreement from the AGPL-3.0
+                license.
+            </p>
+
+            <h2>Eligibility and accounts</h2>
+            <p>
+                You must be at least {MIN_AGE} years old to use the service; if
+                you are under 18, you need a parent or guardian&apos;s consent.
+                You are responsible for the activity under your account and for
+                keeping your credentials secure.
             </p>
 
             <h2>Acceptable use</h2>
             <p>
                 You may not use the service to process content you do not have
-                the right to record or process. Recording-consent laws vary by
-                jurisdiction; you are responsible for complying with the laws
-                that apply to you and to the people in your recordings.
+                the right to record or process, to break the law, or to disrupt
+                or abuse the service or its infrastructure. Recording-consent
+                laws vary by jurisdiction; you are responsible for complying
+                with the laws that apply to you and to the people in your
+                recordings.
             </p>
 
-            <h2>Your data</h2>
+            <h2>Your content</h2>
             <p>
                 You own the recordings, transcripts, and summaries you bring to
-                or generate through the service. You can export everything at
-                any time via the full-backup endpoint.
+                or generate through the service. We claim no ownership of them.
+                We process them only to provide the service to you, as described
+                in our <Link href="/privacy">Privacy Policy</Link>. You can
+                export everything at any time via the full-archive export.
             </p>
 
-            <h2>No warranty</h2>
+            <h2>AI providers</h2>
             <p>
-                The service is provided as-is. Sync depends on Plaud&apos;s
-                upstream API; AI features depend on the provider you configure.
-                We do our best to keep the service running and will communicate
-                outages, but we make no uptime guarantees on the hosted service
-                at this stage.
+                Cloud transcription and summarization run through the AI
+                provider you configure. You contract with that provider directly
+                and their terms apply to that processing. We are not responsible
+                for a third-party provider&apos;s output, availability, or
+                pricing.
+            </p>
+
+            <h2>Fees</h2>
+            <p>
+                The hosted service is currently free. There is no paid tier yet;
+                the &quot;Pro&quot; plan is a waitlist. If we introduce paid
+                plans, we will publish the pricing and terms before you are
+                charged, and any consumer withdrawal rights under EU law will
+                apply at that point.
+            </p>
+
+            <h2>Availability</h2>
+            <p>
+                The service is provided as-is and as-available. Sync depends on
+                Plaud&apos;s upstream API and AI features depend on the provider
+                you configure; both are outside our control. We do our best to
+                keep the service running and to communicate outages, but we make
+                no uptime guarantee at this stage.
+            </p>
+
+            <h2>Disclaimer and liability</h2>
+            <p>
+                To the fullest extent permitted by law, we disclaim implied
+                warranties and are not liable for indirect or consequential
+                loss, or for loss of data you could have preserved through the
+                export feature. Nothing in these terms limits liability that
+                cannot be limited by law, and none of this affects the mandatory
+                rights you have as a consumer.
+            </p>
+
+            <h2>Reporting illegal or infringing content</h2>
+            <p>
+                If you believe content on the service is illegal or infringes
+                your rights, email{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.support}`}>
+                    {CONTACT_EMAILS.support}
+                </Link>{" "}
+                with enough detail to identify the content and the basis for
+                your report. We will review and act on valid reports.
+            </p>
+
+            <h2>Suspension and termination</h2>
+            <p>
+                You can stop using the service and delete your account at any
+                time. We may suspend or terminate access if you breach these
+                terms or put the service or other users at risk. Where a
+                suspension applies, you will see a notice explaining it. You can
+                export your data before deleting your account.
+            </p>
+
+            <h2>Complaints</h2>
+            <p>
+                If something goes wrong, email{" "}
+                <Link href={`mailto:${CONTACT_EMAILS.support}`}>
+                    {CONTACT_EMAILS.support}
+                </Link>{" "}
+                describing the issue and your account email. We will confirm
+                receipt and respond within the time required by applicable law,
+                normally within 14 days.
+            </p>
+
+            <h2>Governing law</h2>
+            <p>
+                These terms are governed by {GOVERNING_LAW.lawPhrase}. If you
+                are a consumer, this does not deprive you of the protection of
+                the mandatory provisions of the law of your country of
+                residence, and you may bring proceedings in the courts there.
             </p>
 
             <h2>Changes</h2>
             <p>
-                We may update these terms. Material changes will be announced
-                before they take effect.
+                We may update these terms. We will notify registered users of
+                material changes by email before they take effect, and update
+                the effective date above. If you keep using the service after a
+                change takes effect, you accept the updated terms; if you do not
+                agree, you can stop using the service and delete your account.
             </p>
 
             <h2>Contact</h2>
             <p>
-                <Link href="mailto:support@riffado.com">
-                    support@riffado.com
+                <Link href={`mailto:${CONTACT_EMAILS.support}`}>
+                    {CONTACT_EMAILS.support}
                 </Link>
             </p>
         </>

--- a/src/lib/legal/constants.ts
+++ b/src/lib/legal/constants.ts
@@ -1,0 +1,120 @@
+/**
+ * Single source of truth for the operator's legal identity and the facts
+ * the hosted `(legal)` pages render. Centralized so the entity name,
+ * address, governing law, contacts, and sub-processor list live in one
+ * reviewable place instead of being duplicated across the privacy and
+ * terms documents.
+ *
+ * Public registry data only. No personal data (board-member names, PESEL,
+ * etc.) belongs here -- the operator is the company, not an individual.
+ *
+ * These pages describe the HOSTED service only. The `(legal)` layout
+ * 404s on self-host (`!IS_HOSTED`), so nothing here applies to a
+ * self-hosted instance.
+ */
+
+/** Operator and GDPR data controller for the hosted service. */
+export const LEGAL_ENTITY = {
+    /** Short trading form used in running prose. */
+    name: "PERIER sp. z o.o.",
+    /** Full registered name. */
+    fullName: "PERIER spółka z ograniczoną odpowiedzialnością",
+    form: "a limited liability company incorporated under the laws of Poland (spółka z ograniczoną odpowiedzialnością)",
+    krs: "0001203585",
+    nip: "8513340283",
+    regon: "543161719",
+    registrationCourt:
+        "District Court Szczecin-Centrum in Szczecin, 13th Commercial Division of the National Court Register (Sąd Rejonowy Szczecin-Centrum w Szczecinie, XIII Wydział Gospodarczy Krajowego Rejestru Sądowego)",
+    shareCapital: "PLN 5,000",
+    address: {
+        street: "ul. 1 Maja 39",
+        postalCode: "71-627",
+        city: "Szczecin",
+        country: "Poland",
+    },
+} as const;
+
+/** Governing law for the hosted service contract. */
+export const GOVERNING_LAW = {
+    country: "Poland",
+    /** Phrase to drop into prose, e.g. "governed by the laws of Poland". */
+    lawPhrase: "the laws of Poland",
+} as const;
+
+/**
+ * Minimum age to use the hosted service. 16 matches the digital-consent
+ * age set for Poland under Article 8 GDPR. Under-18s need a parent or
+ * guardian's consent to enter the service contract.
+ */
+export const MIN_AGE = 16;
+
+/** ISO date the current documents take effect. */
+export const EFFECTIVE_DATE = "2026-05-29";
+
+/** Human-readable effective date, pinned to UTC to avoid off-by-one. */
+export const EFFECTIVE_DATE_DISPLAY = new Date(
+    EFFECTIVE_DATE,
+).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+});
+
+/** Contact mailboxes referenced by the legal pages. */
+export const CONTACT_EMAILS = {
+    support: "support@riffado.com",
+    security: "security@riffado.com",
+    /** Dedicated mailbox for GDPR data-subject requests. */
+    privacy: "privacy@riffado.com",
+} as const;
+
+/** Polish data-protection supervisory authority (GDPR right to complain). */
+export const SUPERVISORY_AUTHORITY = {
+    name: "the President of the Personal Data Protection Office (Prezes Urzędu Ochrony Danych Osobowych, UODO)",
+    address: "ul. Stawki 2, 00-193 Warsaw, Poland",
+    url: "https://uodo.gov.pl",
+} as const;
+
+export type Subprocessor = {
+    name: string;
+    purpose: string;
+    location: string;
+    safeguard: string;
+};
+
+/**
+ * Third parties that process personal data on the operator's behalf for
+ * the hosted service. Self-hosted analytics (Rybbit) runs on the
+ * operator's own infrastructure and is intentionally NOT a third-party
+ * sub-processor. User-configured AI providers are not the operator's
+ * sub-processors either -- the user contracts with them directly.
+ *
+ * When error monitoring (PostHog EU) ships, add it here; being EU-hosted
+ * it introduces no new international-transfer concern.
+ */
+export const SUBPROCESSORS: Subprocessor[] = [
+    {
+        name: "netcup GmbH",
+        purpose: "Application hosting and database",
+        location: "Germany (EEA)",
+        safeguard: "Processed within the EEA",
+    },
+    {
+        name: "Cloudflare R2",
+        purpose: "Encrypted audio file storage",
+        location: "EU-region bucket; provider established in the USA",
+        safeguard:
+            "Data Processing Addendum and EU Standard Contractual Clauses",
+    },
+    {
+        name: "MXroute",
+        purpose: "Transactional email delivery",
+        location: "USA",
+        safeguard:
+            "Data Processing Addendum and EU Standard Contractual Clauses",
+    },
+];
+
+/** Formatted one-line postal address for the operator. */
+export const LEGAL_ADDRESS_LINE = `${LEGAL_ENTITY.address.street}, ${LEGAL_ENTITY.address.postalCode} ${LEGAL_ENTITY.address.city}, ${LEGAL_ENTITY.address.country}`;


### PR DESCRIPTION
## Description

Replaces the placeholder Privacy Policy and Terms of Service (both stamped "Last updated: TBD" / "this page is a placeholder") with complete, accurate documents for the hosted service. Pages remain hosted-only; the `(legal)` layout still 404s on self-host.

## Type of Change

- [x] Documentation update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Add `src/lib/legal/constants.ts` as the single source for operator identity (PERIER sp. z o.o., KRS/NIP/REGON, registered office), governing law, minimum age, effective date, contact emails, the UODO supervisory-authority block, and the sub-processor list (netcup, Cloudflare R2, MXroute).
- Rewrite the Privacy Policy to satisfy GDPR Article 13: controller identity, data categories, purposes + legal bases, sub-processor table, self-hosted-analytics carve-out, AI-provider passthrough, international transfers (SCCs), retention, data-subject rights mapped to the existing export + account-deletion mechanics, and the right to complain to UODO. "Changes" clause is now self-executing (post + effective date).
- Rewrite the Terms of Service to double as a Polish UŚUDE regulamin (provider identification, service scope, technical conditions, contract/termination, complaints procedure) plus standard SaaS terms (acceptable use, content ownership, AI-provider disclaimer, availability, liability with a consumer-rights carve-out, Polish governing law preserving consumer home-court protections).
- "Changes" clause in Terms commits to emailing registered users of material changes before they take effect.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): n/a

### Test Steps
1. `pnpm format-and-lint:fix` — clean on the touched files.
2. `pnpm type-check` — passes.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None. Hosted-only legal surface; self-host still 404s these routes. No schema, env, or routing changes.

## Additional Notes

- The Terms "notify registered users by email" commitment is a manual promise today: `sendEmail` is per-recipient transactional only, with no bulk path. When terms materially change, this needs a one-off notify-all-users job or manual send.
- The `privacy@riffado.com` mailbox alias has been configured out of band.

## For Reviewers

- Whether the GDPR Art. 13 + UŚUDE regulamin coverage is complete for a Polish sp. z o.o. operator. Enforceability of the liability-limitation and regulamin clauses still warrants a Polish radca prawny's review before treating this as legally final.
- Sub-processor list accuracy (netcup, Cloudflare R2, MXroute) and the SCC transfer framing.
