### PR TITLE
fix(webhooks): move instrumentation to src/ so it runs in standalone

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,6 +6,6 @@ export async function register() {
     if (process.env.NEXT_RUNTIME !== "nodejs") return;
 
     const { startWebhookWorker } =
-        require("./src/lib/webhooks/worker") as WebhookWorkerModule;
+        require("./lib/webhooks/worker") as WebhookWorkerModule;
     startWebhookWorker();
 }

--- a/src/tests/regressions/181-instrumentation-src-location.test.ts
+++ b/src/tests/regressions/181-instrumentation-src-location.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression test for #181: the webhook delivery worker never started in
+ * the `output: "standalone"` Docker build. Deliveries piled up in
+ * `webhook_deliveries` as `pending` with 0 attempts because nothing ever
+ * called `startWebhookWorker()`.
+ *
+ * Root cause: with a `src/` directory layout, Next.js derives the
+ * instrumentation-hook scan root from the app directory's parent (`src/`,
+ * not the repo root) and scans it non-recursively. A root-level
+ * `instrumentation.ts` sits one level above that scan root, so Next never
+ * detects it, never builds an instrumentation entry, and the standalone
+ * output ships without it. `register()` was therefore never invoked.
+ *
+ * Fix: move the file to `src/instrumentation.ts` so it sits at the
+ * convention level Next actually scans.
+ *
+ * The failure mode is silent -- `next build` still succeeds, the app still
+ * boots, and only the background worker goes missing. This test pins the
+ * file location so a move back to the repo root is caught here instead of
+ * in production.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+describe("instrumentation hook lives where Next scans it", () => {
+    it("exists at src/instrumentation.ts", () => {
+        expect(
+            existsSync(join(ROOT, "src", "instrumentation.ts")),
+            "src/instrumentation.ts is missing. Without it Next builds no " +
+                "instrumentation entry and the webhook worker never starts " +
+                "in the standalone build (see #181).",
+        ).toBe(true);
+    });
+
+    it("is not at the repo root, where a src/ layout makes Next ignore it", () => {
+        expect(
+            existsSync(join(ROOT, "instrumentation.ts")),
+            "instrumentation.ts at the repo root is silently dropped from " +
+                "the build when a src/ directory is used. Move it to " +
+                "src/instrumentation.ts (see #181).",
+        ).toBe(false);
+    });
+
+    it("starts the webhook worker", () => {
+        const source = readFileSync(
+            join(ROOT, "src", "instrumentation.ts"),
+            "utf8",
+        );
+        expect(source).toContain("startWebhookWorker");
+        expect(source).toContain("webhooks/worker");
+    });
+});


### PR DESCRIPTION
## Description

The webhook delivery worker never starts in the `output: "standalone"` Docker build, so `transcription.completed` / `transcription.failed` deliveries pile up in `webhook_deliveries` as `pending` with 0 attempts (reported in #181).

Root cause: `startWebhookWorker()` is only called from `register()` in the repo-root `instrumentation.ts`. With a `src/` directory layout, Next 16 derives the instrumentation-hook scan root from the app directory's parent (`src/`) and scans it non-recursively, so a repo-root `instrumentation.ts` is never detected as a convention-level hook and is never traced into the standalone output. `register()` is therefore never invoked.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #181

## Changes Made

- Move `instrumentation.ts` -> `src/instrumentation.ts` (the level Next scans) and drop the now-redundant `src/` from the worker import. The `require(...)` stays behind the `NEXT_RUNTIME !== "nodejs"` guard so the worker's node-only deps never enter the edge bundle that `src/proxy.ts` produces.
- Add `src/tests/regressions/181-instrumentation-src-location.test.ts` pinning the file location. The failure mode is silent — `next build` succeeds and the worker just never runs — so this guards against a move back to the repo root.

## Testing

- `pnpm format-and-lint:fix`, `pnpm type-check`, `pnpm test` (372 passing, including the new regression test) all clean.
- `pnpm build` now emits `.next/server/instrumentation.js` (absent before the move) and bundles the worker into the node runtime. Confirmed there is no edge-instrumentation entry and no worker symbols in any edge chunk, so the node-only deps stay out of the edge bundle.

## For Reviewers

Multi-process note: every Next server process now runs its own `setInterval` worker (relevant under hosted multi-process). This is safe — `claimDueWebhookDeliveries` claims work via an atomic conditional `UPDATE ... RETURNING` with a lease, so concurrent ticks do not double-deliver.

Full runtime confirmation (worker ticking inside a live standalone container) needs a Docker build plus a configured webhook endpoint. The change is verified here up to the build-output level: the instrumentation entry is now present in the standalone bundle, where it was absent before.
