### PR TITLE
perf(db): parallelize independent reads on hot server paths

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -17,46 +17,56 @@ import { serializeRecording } from "@/types/recording";
 export default async function DashboardPage() {
     const session = await requireAuth();
 
-    const userRecordings = await db
-        .select({
-            id: recordings.id,
-            filename: recordings.filename,
-            duration: recordings.duration,
-            startTime: recordings.startTime,
-            filesize: recordings.filesize,
-            deviceSn: recordings.deviceSn,
-            waveformPeaks: recordings.waveformPeaks,
-        })
-        .from(recordings)
-        .where(
-            and(
-                eq(recordings.userId, session.user.id),
-                isNull(recordings.deletedAt),
-            ),
-        )
-        .orderBy(desc(recordings.startTime));
-
-    const userTranscriptions = await db
-        .select({
-            recordingId: transcriptions.recordingId,
-            text: transcriptions.text,
-            language: transcriptions.detectedLanguage,
-        })
-        .from(transcriptions)
-        .where(eq(transcriptions.userId, session.user.id));
-
-    // We only need to know IF a summary exists per recording for the list
-    // status chip — the full summary is still fetched on selection by the
-    // existing /api/recordings/[id]/summary route.
-    const userSummaryRows = await db
-        .select({ recordingId: aiEnhancements.recordingId })
-        .from(aiEnhancements)
-        .where(
-            and(
-                eq(aiEnhancements.userId, session.user.id),
-                isNotNull(aiEnhancements.summary),
-            ),
-        );
+    const [userRecordings, userTranscriptions, userSummaryRows, [settingsRow]] =
+        await Promise.all([
+            db
+                .select({
+                    id: recordings.id,
+                    filename: recordings.filename,
+                    duration: recordings.duration,
+                    startTime: recordings.startTime,
+                    filesize: recordings.filesize,
+                    deviceSn: recordings.deviceSn,
+                    waveformPeaks: recordings.waveformPeaks,
+                })
+                .from(recordings)
+                .where(
+                    and(
+                        eq(recordings.userId, session.user.id),
+                        isNull(recordings.deletedAt),
+                    ),
+                )
+                .orderBy(desc(recordings.startTime)),
+            db
+                .select({
+                    recordingId: transcriptions.recordingId,
+                    text: transcriptions.text,
+                    language: transcriptions.detectedLanguage,
+                })
+                .from(transcriptions)
+                .where(eq(transcriptions.userId, session.user.id)),
+            // We only need to know IF a summary exists per recording for the
+            // list status chip — the full summary is still fetched on
+            // selection by the existing /api/recordings/[id]/summary route.
+            db
+                .select({ recordingId: aiEnhancements.recordingId })
+                .from(aiEnhancements)
+                .where(
+                    and(
+                        eq(aiEnhancements.userId, session.user.id),
+                        isNotNull(aiEnhancements.summary),
+                    ),
+                ),
+            // Load user settings server-side so the Workstation, list, and
+            // player render with the user's preferences on first paint — no
+            // waterfall of /api/settings/user fetches from three different
+            // components.
+            db
+                .select()
+                .from(userSettings)
+                .where(eq(userSettings.userId, session.user.id))
+                .limit(1),
+        ]);
     const summaryIds = new Set(userSummaryRows.map((r) => r.recordingId));
     const transcriptIds = new Set(userTranscriptions.map((t) => t.recordingId));
 
@@ -83,15 +93,6 @@ export default async function DashboardPage() {
             { text: decryptText(t.text), language: t.language || undefined },
         ]),
     );
-
-    // Load user settings server-side so the Workstation, list, and player
-    // can render with the user's preferences on first paint — no waterfall
-    // of /api/settings/user fetches from three different components.
-    const [settingsRow] = await db
-        .select()
-        .from(userSettings)
-        .where(eq(userSettings.userId, session.user.id))
-        .limit(1);
 
     // One source of truth for InitialSettings + their defaults lives in
     // `src/lib/settings/initial-settings.ts`; adding a new preference

--- a/src/app/(app)/recordings/[id]/page.tsx
+++ b/src/app/(app)/recordings/[id]/page.tsx
@@ -34,13 +34,6 @@ export default async function RecordingDetailPage({
         notFound();
     }
 
-    // Fetch transcription if exists
-    const [transcription] = await db
-        .select()
-        .from(transcriptions)
-        .where(eq(transcriptions.recordingId, id))
-        .limit(1);
-
     // Load player preferences server-side so the embedded
     // RecordingPlayer respects the user's saved volume / speed /
     // auto-play / scrubber choices. Without this, the legacy
@@ -48,16 +41,23 @@ export default async function RecordingDetailPage({
     // 75 / 1x / false defaults regardless of what the user picked
     // in Settings → Playback (the dashboard route already plumbs
     // these through Workstation).
-    const [settingsRow] = await db
-        .select({
-            defaultPlaybackSpeed: userSettings.defaultPlaybackSpeed,
-            defaultVolume: userSettings.defaultVolume,
-            autoPlayNext: userSettings.autoPlayNext,
-            playerScrubber: userSettings.playerScrubber,
-        })
-        .from(userSettings)
-        .where(eq(userSettings.userId, session.user.id))
-        .limit(1);
+    const [[transcription], [settingsRow]] = await Promise.all([
+        db
+            .select()
+            .from(transcriptions)
+            .where(eq(transcriptions.recordingId, id))
+            .limit(1),
+        db
+            .select({
+                defaultPlaybackSpeed: userSettings.defaultPlaybackSpeed,
+                defaultVolume: userSettings.defaultVolume,
+                autoPlayNext: userSettings.autoPlayNext,
+                playerScrubber: userSettings.playerScrubber,
+            })
+            .from(userSettings)
+            .where(eq(userSettings.userId, session.user.id))
+            .limit(1),
+    ]);
     const scrubberStyle: "waveform" | "slider" =
         settingsRow?.playerScrubber === "slider" ? "slider" : "waveform";
 

--- a/src/app/api/settings/storage/route.ts
+++ b/src/app/api/settings/storage/route.ts
@@ -17,27 +17,28 @@ export const GET = apiHandler(async (request: Request) => {
         isNull(recordings.deletedAt),
     );
 
-    const [totals] = await db
-        .select({
-            usedBytes: sql<number>`coalesce(sum(${recordings.filesize}), 0)::bigint`,
-            recordingCount: sql<number>`count(*)::int`,
-            totalDurationMs: sql<number>`coalesce(sum(${recordings.duration}), 0)::bigint`,
-        })
-        .from(recordings)
-        .where(activeRecording);
-
-    const largestRows = await db
-        .select({
-            id: recordings.id,
-            filename: recordings.filename,
-            filesize: recordings.filesize,
-            duration: recordings.duration,
-            startTime: recordings.startTime,
-        })
-        .from(recordings)
-        .where(activeRecording)
-        .orderBy(desc(recordings.filesize))
-        .limit(5);
+    const [[totals], largestRows] = await Promise.all([
+        db
+            .select({
+                usedBytes: sql<number>`coalesce(sum(${recordings.filesize}), 0)::bigint`,
+                recordingCount: sql<number>`count(*)::int`,
+                totalDurationMs: sql<number>`coalesce(sum(${recordings.duration}), 0)::bigint`,
+            })
+            .from(recordings)
+            .where(activeRecording),
+        db
+            .select({
+                id: recordings.id,
+                filename: recordings.filename,
+                filesize: recordings.filesize,
+                duration: recordings.duration,
+                startTime: recordings.startTime,
+            })
+            .from(recordings)
+            .where(activeRecording)
+            .orderBy(desc(recordings.filesize))
+            .limit(5),
+    ]);
     const largest = largestRows.map((r) => ({
         ...r,
         filename: decryptText(r.filename),

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -418,18 +418,19 @@ export async function listUsers(opts: {
         ? sql`where u.email ilike ${`%${search}%`}`
         : sql``;
 
-    const result = await db.execute<{
-        id: string;
-        email: string;
-        created_at: Date;
-        suspended_at: Date | null;
-        last_sync: Date | null;
-        plaud_connected: boolean;
-        plaud_region: string | null;
-        recording_count: number;
-        storage_bytes: number;
-        server_tx_30d: number;
-    }>(sql`
+    const [result, totalRes] = await Promise.all([
+        db.execute<{
+            id: string;
+            email: string;
+            created_at: Date;
+            suspended_at: Date | null;
+            last_sync: Date | null;
+            plaud_connected: boolean;
+            plaud_region: string | null;
+            recording_count: number;
+            storage_bytes: number;
+            server_tx_30d: number;
+        }>(sql`
         select
             u.id,
             u.email,
@@ -462,13 +463,13 @@ export async function listUsers(opts: {
         order by ${sortClause}
         limit ${opts.limit}
         offset ${opts.offset}
-    `);
-
-    const totalRes = await db.execute<{ n: number }>(sql`
+    `),
+        db.execute<{ n: number }>(sql`
         select count(*)::int as n
         from users u
         ${whereClause}
-    `);
+    `),
+    ]);
 
     return {
         rows: result.map((r) => ({


### PR DESCRIPTION
## Description

Several server components and routes awaited independent DB reads sequentially, so each round-trip waterfalled into the next. This wraps the reads that share no data dependency in `Promise.all` so they race. Behavior is unchanged — same queries, same results, same downstream use. Flagged by the react.review audit in #135 (`server-sequential-independent-await`).

## Type of Change

- [x] Performance improvement

## Related Issues

Relates to #135

## Changes Made

- `dashboard/page.tsx`: recordings, transcriptions, summary-existence, and user settings — four independent reads keyed on the user id — batched into one round-trip.
- `recordings/[id]/page.tsx`: the transcription and player-settings reads run together. The `recording` lookup stays sequential so its `notFound()` guard still short-circuits the other two on the 404 path.
- `settings/storage` (GET): usage totals and the top-5-largest query run together; the disk-free `statfs` stays sequential.
- admin `listUsers`: the page query and its count run together.

## Testing

- `pnpm format-and-lint:fix`, `pnpm type-check`, `pnpm test` (369 passing), `pnpm build` all clean. The change is behavior-preserving, so the existing suite covers it.

## For Reviewers

Scope is deliberately limited to the `server-sequential-independent-await` findings where I confirmed the awaits are genuinely independent (no data dependency, no shared transaction, no ordering side effect). The other audit categories in #135 are out of scope for this PR.
