### PR TITLE
refactor(db): centralize raw-SQL into src/db/queries and harden rate-limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,8 @@ In priority order when in doubt:
 
 - Prefer **server components**; use `"use client"` only for interactivity.
 - Route handlers live under `src/app/api/` — one `route.ts` per endpoint.
-- Database access via Drizzle. Queries may live inline in route handlers for now (no enforced `queries/` layer yet).
+- Database access via Drizzle. Fluent Drizzle queries (`db.select().from(...).where(...)`) may live inline in route handlers and feature `lib/` files. **Raw-SQL queries — anything calling `db.execute(sql\`...\`)` or holding a full `SELECT`/`INSERT`/`UPDATE`/`DELETE` inside a `sql\`\`` template — MUST live in `src/db/queries/`** and be imported by feature code. Inline `sql\`\`` *expression fragments* embedded inside Drizzle's fluent builder (`set: { col: sql\`col + 1\` }`, `where(sql\`json @> ...\`)`, `orderBy(sql\`...\`)`) stay where they're used — they're operator helpers, not queries.
+- When you write or touch any `sql\`\`` template: every interpolated value must be a `${...}` placeholder (param-bound, never string-concatenated); every `Date` value must be `.toISOString()` and cast (`${iso}::timestamp` for `timestamp` columns, `::timestamptz` only when the column is `timestamptz`); user-supplied `ILIKE` patterns must escape `%` and `_` with `escape '\\'`; sort columns and identifiers come from a fixed allowlist, never from user input.
 - Environment variables are validated via Zod in `src/lib/env.ts`. Add new vars there and access via the validated `env` object. **Never `process.env.X` directly in feature code.**
 - Toasts via `sonner`; no `alert()` or custom toast systems.
 - Client components that fetch from our own API use existing `/api/...` routes — no duplicate client-side Plaud API calls.

--- a/src/app/(admin)/admin/(gated)/page.tsx
+++ b/src/app/(admin)/admin/(gated)/page.tsx
@@ -1,4 +1,4 @@
-import { fleetOverview } from "@/lib/admin/queries";
+import { fleetOverview } from "@/db/queries/admin";
 import { InstallHitsTile } from "./_components/install-hits-tile";
 import {
     formatBytes,

--- a/src/app/(admin)/admin/(gated)/pricing-snapshot/page.tsx
+++ b/src/app/(admin)/admin/(gated)/pricing-snapshot/page.tsx
@@ -1,4 +1,4 @@
-import { pricingSnapshot } from "@/lib/admin/queries";
+import { pricingSnapshot } from "@/db/queries/admin";
 import { formatBytes, formatNumber } from "../_components/metrics";
 import { ExportCsvButton } from "./export-csv-button";
 

--- a/src/app/(admin)/admin/(gated)/signups/page.tsx
+++ b/src/app/(admin)/admin/(gated)/signups/page.tsx
@@ -1,4 +1,4 @@
-import { signupsByDay } from "@/lib/admin/queries";
+import { signupsByDay } from "@/db/queries/admin";
 import { formatNumber } from "../_components/metrics";
 
 export const dynamic = "force-dynamic";

--- a/src/app/(admin)/admin/(gated)/storage/page.tsx
+++ b/src/app/(admin)/admin/(gated)/storage/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { storageHistogram, topStorageUsers } from "@/lib/admin/queries";
+import { storageHistogram, topStorageUsers } from "@/db/queries/admin";
 import { formatBytes, formatNumber } from "../_components/metrics";
 
 export const dynamic = "force-dynamic";

--- a/src/app/(admin)/admin/(gated)/sync/page.tsx
+++ b/src/app/(admin)/admin/(gated)/sync/page.tsx
@@ -1,4 +1,4 @@
-import { syncHealth } from "@/lib/admin/queries";
+import { syncHealth } from "@/db/queries/admin";
 import { formatNumber } from "../_components/metrics";
 
 export const dynamic = "force-dynamic";

--- a/src/app/(admin)/admin/(gated)/transcription/page.tsx
+++ b/src/app/(admin)/admin/(gated)/transcription/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import {
     topServerTranscriptionUsers,
     transcriptionByProvider,
-} from "@/lib/admin/queries";
+} from "@/db/queries/admin";
 import { formatNumber } from "../_components/metrics";
 
 export const dynamic = "force-dynamic";

--- a/src/app/(admin)/admin/(gated)/users/[id]/page.tsx
+++ b/src/app/(admin)/admin/(gated)/users/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { getUserDetail } from "@/lib/admin/queries";
+import { getUserDetail } from "@/db/queries/admin";
 import {
     formatBytes,
     formatDate,

--- a/src/app/(admin)/admin/(gated)/users/page.tsx
+++ b/src/app/(admin)/admin/(gated)/users/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listUsers } from "@/lib/admin/queries";
+import { listUsers } from "@/db/queries/admin";
 import {
     formatBytes,
     formatNumber,

--- a/src/app/api/admin/pricing-snapshot/export.csv/route.ts
+++ b/src/app/api/admin/pricing-snapshot/export.csv/route.ts
@@ -1,7 +1,6 @@
-import { sql } from "drizzle-orm";
 import { headers as nextHeaders } from "next/headers";
 import { NextResponse } from "next/server";
-import { db } from "@/db";
+import { selectPricingSnapshotForCsvExport } from "@/db/queries/admin-pricing-snapshot-csv";
 import { logCsvExport } from "@/lib/admin/actions";
 import { requireAdminMutation } from "@/lib/admin/guard";
 import { clientIpFromHeaders } from "@/lib/admin/ip-allowlist";
@@ -38,44 +37,7 @@ export const POST = apiHandler(async (request: Request) => {
         );
     }
 
-    // Single round-trip: per-user storage, recording count, server-tx 30d.
-    // We do not include the user_id (an opaque nanoid) -- email is the
-    // operational handle. If you ever need user_id back, it should be a
-    // separate, more strongly justified export.
-    const rows = await db.execute<{
-        email: string;
-        created_at: Date;
-        suspended_at: Date | null;
-        recording_count: number;
-        storage_bytes: number;
-        server_tx_30d: number;
-    }>(sql`
-        with rec as (
-            select user_id,
-                   count(*)::int as n,
-                   coalesce(sum(filesize), 0)::bigint as bytes
-            from recordings
-            where deleted_at is null
-            group by user_id
-        ),
-        tx as (
-            select user_id, count(*)::int as n
-            from transcriptions
-            where transcription_type = 'server'
-              and created_at >= now() - interval '30 days'
-            group by user_id
-        )
-        select u.email,
-               u.created_at,
-               u.suspended_at,
-               coalesce(rec.n, 0)::int as recording_count,
-               coalesce(rec.bytes, 0)::bigint as storage_bytes,
-               coalesce(tx.n, 0)::int as server_tx_30d
-        from users u
-        left join rec on rec.user_id = u.id
-        left join tx on tx.user_id = u.id
-        order by storage_bytes desc nulls last
-    `);
+    const rows = await selectPricingSnapshotForCsvExport();
 
     await logCsvExport(
         {

--- a/src/app/api/recordings/[id]/peaks/route.ts
+++ b/src/app/api/recordings/[id]/peaks/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings } from "@/db/schema";
@@ -79,7 +79,9 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
     }
 
     // Conditional write: predicates on UPDATE so a concurrent DELETE
-    // doesn't race; matches zero rows on tombstoned recordings.
+    // doesn't race; matches zero rows on tombstoned recordings. The
+    // `waveformPeaks is null` clause makes the write idempotent under
+    // racing POSTs -- first writer wins, the rest no-op.
     const result = await db
         .update(recordings)
         .set({ waveformPeaks: normalized, updatedAt: new Date() })
@@ -88,7 +90,7 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                 eq(recordings.id, id),
                 eq(recordings.userId, session.user.id),
                 isNull(recordings.deletedAt),
-                sql`${recordings.waveformPeaks} is null`,
+                isNull(recordings.waveformPeaks),
             ),
         );
 

--- a/src/db/queries/admin-pricing-snapshot-csv.ts
+++ b/src/db/queries/admin-pricing-snapshot-csv.ts
@@ -1,0 +1,67 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+
+/**
+ * Per-user cost-snapshot row exposed via the admin CSV export. Schema is
+ * intentionally narrow: email is the operational handle (never user_id, an
+ * opaque nanoid that leaks nothing useful but is one more identifier to
+ * regret), plus storage/recording/server-tx counts and lifecycle dates.
+ *
+ * NEVER add: filenames, transcript text, summaries, decrypted secrets,
+ * bearer tokens, API keys. The bulk-PII guard in `queries-pii.test.ts`
+ * watches the sibling admin.ts file; if you grow this query, add the same
+ * guard here.
+ */
+export type PricingSnapshotCsvRow = {
+    email: string;
+    created_at: Date;
+    suspended_at: Date | null;
+    recording_count: number;
+    storage_bytes: number;
+    server_tx_30d: number;
+};
+
+/**
+ * One round-trip: joins per-user storage rollups with 30-day server-tx
+ * counts. Used by the admin pricing CSV export. Returns rows sorted by
+ * `storage_bytes desc` so the operator sees the biggest cost drivers first.
+ *
+ * Caller is responsible for elevation (`requireAdminMutation`), audit
+ * logging (`logCsvExport`), and CSV-injection escaping when serialising.
+ */
+export async function selectPricingSnapshotForCsvExport(): Promise<
+    PricingSnapshotCsvRow[]
+> {
+    // `now() - interval '30 days'` runs server-side, so the window anchors
+    // to the DB clock and we don't need to bind a Date param. No user
+    // input flows into this query -- the only "input" is the implicit
+    // 30-day constant, which is intentionally not parameterised so it
+    // shows up in EXPLAIN plans verbatim and is harder to drift.
+    return db.execute<PricingSnapshotCsvRow>(sql`
+        with rec as (
+            select user_id,
+                   count(*)::int as n,
+                   coalesce(sum(filesize), 0)::bigint as bytes
+            from recordings
+            where deleted_at is null
+            group by user_id
+        ),
+        tx as (
+            select user_id, count(*)::int as n
+            from transcriptions
+            where transcription_type = 'server'
+              and created_at >= now() - interval '30 days'
+            group by user_id
+        )
+        select u.email,
+               u.created_at,
+               u.suspended_at,
+               coalesce(rec.n, 0)::int as recording_count,
+               coalesce(rec.bytes, 0)::bigint as storage_bytes,
+               coalesce(tx.n, 0)::int as server_tx_30d
+        from users u
+        left join rec on rec.user_id = u.id
+        left join tx on tx.user_id = u.id
+        order by storage_bytes desc nulls last
+    `);
+}

--- a/src/db/queries/admin.ts
+++ b/src/db/queries/admin.ts
@@ -13,7 +13,6 @@ import {
 } from "drizzle-orm";
 import { db } from "@/db";
 import {
-    adminActionLog,
     adminAuditLog,
     aiEnhancements,
     apiCredentials,
@@ -397,7 +396,13 @@ export async function listUsers(opts: {
         | "last_sync_desc";
 }): Promise<{ rows: UserListRow[]; total: number }> {
     const since30 = new Date(Date.now() - 30 * DAY_MS).toISOString();
-    const search = (opts.q ?? "").trim().toLowerCase();
+    // ILIKE-escape: `%` and `_` are wildcards. Without escaping, a search
+    // for `_admin` matches `xadmin`, `yadmin`, etc., and `%` matches
+    // everything. Backslash is the default escape character in PostgreSQL.
+    // Admin-only surface, but escape anyway -- a permissive search input
+    // shouldn't surprise the operator with phantom matches.
+    const rawSearch = (opts.q ?? "").trim().toLowerCase();
+    const search = rawSearch.replace(/[\\%_]/g, (c) => `\\${c}`);
 
     const sortClause = (() => {
         switch (opts.sort) {
@@ -415,7 +420,7 @@ export async function listUsers(opts: {
     })();
 
     const whereClause = search
-        ? sql`where u.email ilike ${`%${search}%`}`
+        ? sql`where u.email ilike ${`%${search}%`} escape '\\'`
         : sql``;
 
     const result = await db.execute<{
@@ -455,7 +460,7 @@ export async function listUsers(opts: {
             select user_id, count(*)::int as n
             from transcriptions
             where transcription_type = 'server'
-              and created_at >= ${since30}
+              and created_at >= ${since30}::timestamp
             group by user_id
         ) t on t.user_id = u.id
         ${whereClause}
@@ -701,7 +706,7 @@ export async function topServerTranscriptionUsers(limit = 50) {
         left join transcriptions t
           on t.user_id = u.id
          and t.transcription_type = 'server'
-         and t.created_at >= ${since30}
+         and t.created_at >= ${since30}::timestamp
         group by u.id, u.email
         order by n desc nulls last
         limit ${limit}
@@ -720,9 +725,9 @@ export async function syncHealth() {
         select bucket, count(*)::int as n from (
             select case
                 when last_sync is null then 'never'
-                when last_sync >= ${h1} then 'fresh'
-                when last_sync >= ${d1} then 'stale_24h'
-                when last_sync >= ${d7} then 'stale_7d'
+                when last_sync >= ${h1}::timestamp then 'fresh'
+                when last_sync >= ${d1}::timestamp then 'stale_24h'
+                when last_sync >= ${d7}::timestamp then 'stale_7d'
                 else 'stale_old'
             end as bucket
             from plaud_connections
@@ -754,7 +759,7 @@ export async function pricingSnapshot() {
             select count(*)::int as n
             from transcriptions
             where transcription_type = 'server'
-              and created_at >= ${since30}
+              and created_at >= ${since30}::timestamp
             group by user_id
             order by n asc
         `),
@@ -779,5 +784,3 @@ export async function pruneAdminAuditLog(olderThanDays = 90): Promise<number> {
     `);
     return Number(rows[0]?.n ?? 0);
 }
-
-export { adminActionLog, adminAuditLog };

--- a/src/db/queries/plaud-locks.ts
+++ b/src/db/queries/plaud-locks.ts
@@ -1,0 +1,31 @@
+import { sql } from "drizzle-orm";
+import type { db } from "@/db";
+
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Acquire a per-user advisory lock for the duration of the current
+ * transaction. Serialises concurrent Plaud connect / reconnect attempts so
+ * the upsert into `plaud_connections` doesn't race with itself and produce
+ * orphan rows or stomp a freshly-rotated bearer token.
+ *
+ * `hashtextextended(text, 0)` is Postgres's 64-bit text hash used by
+ * `pg_advisory_xact_lock(bigint)`. We don't need cryptographic
+ * collision-resistance here -- a hash collision would only mean two
+ * unrelated users serialise on the same lock for a few hundred
+ * milliseconds, which is harmless. We do need stability across processes,
+ * which is exactly what advisory locks give us (and what an in-memory
+ * Map does NOT, under hosted multi-process invariants).
+ *
+ * The `plaud_connect:` prefix scopes this lock namespace so a future
+ * lock on the same userId for a different purpose doesn't deadlock with
+ * this one.
+ */
+export async function acquirePlaudConnectLock(
+    tx: DbTransaction,
+    userId: string,
+): Promise<void> {
+    await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${`plaud_connect:${userId}`}, 0))`,
+    );
+}

--- a/src/db/queries/rate-limit.ts
+++ b/src/db/queries/rate-limit.ts
@@ -1,0 +1,71 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+import { apiRateLimitBuckets } from "@/db/schema";
+
+export interface UpsertRateLimitBucketInput {
+    /**
+     * Already-derived bucket key. The query layer never sees raw user
+     * identifiers or IPs -- callers HMAC them first via
+     * `rate-limit.ts::bucketKey` so a hosted DB exfil doesn't reveal which
+     * users/IPs were rate-limited.
+     */
+    key: string;
+    /** Reference time for window comparisons. */
+    now: Date;
+    /** When the *new* window would expire if this row is a fresh start. */
+    resetAt: Date;
+}
+
+export interface UpsertRateLimitBucketRow {
+    count: number;
+    resetAt: Date;
+}
+
+/**
+ * Atomic fixed-window counter increment. Inserts a fresh bucket on first
+ * hit; on conflict, rolls the window over when the existing bucket has
+ * expired and otherwise increments the counter.
+ *
+ * Returns the post-write `(count, resetAt)`. Allowed/remaining math is
+ * the caller's responsibility.
+ *
+ * postgres-js binds Date \u2192 timestamp reliably for Drizzle column-typed
+ * values (`.values({...})`, `set: { updatedAt: now }`), but raw sql`...`
+ * bypasses Drizzle's encoder and crashes with ERR_INVALID_ARG_TYPE
+ * ("Received an instance of Date") under Bun/Next 16 when a Date sits
+ * inside a `sql\`\`` template literal. Cast the ISO string explicitly so
+ * postgres-js receives a string parameter and Postgres handles the
+ * timestamp conversion.
+ */
+export async function upsertRateLimitBucket({
+    key,
+    now,
+    resetAt,
+}: UpsertRateLimitBucketInput): Promise<UpsertRateLimitBucketRow | undefined> {
+    const nowIso = now.toISOString();
+    const resetAtIso = resetAt.toISOString();
+
+    const [bucket] = await db
+        .insert(apiRateLimitBuckets)
+        .values({
+            key,
+            count: 1,
+            resetAt,
+            createdAt: now,
+            updatedAt: now,
+        })
+        .onConflictDoUpdate({
+            target: apiRateLimitBuckets.key,
+            set: {
+                count: sql<number>`case when ${apiRateLimitBuckets.resetAt} <= ${nowIso}::timestamp then 1 else ${apiRateLimitBuckets.count} + 1 end`,
+                resetAt: sql<Date>`case when ${apiRateLimitBuckets.resetAt} <= ${nowIso}::timestamp then ${resetAtIso}::timestamp else ${apiRateLimitBuckets.resetAt} end`,
+                updatedAt: now,
+            },
+        })
+        .returning({
+            count: apiRateLimitBuckets.count,
+            resetAt: apiRateLimitBuckets.resetAt,
+        });
+
+    return bucket;
+}

--- a/src/db/queries/webhook-deliveries.ts
+++ b/src/db/queries/webhook-deliveries.ts
@@ -1,0 +1,215 @@
+import { and, eq, inArray, lte, or, type SQL, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
+
+/**
+ * Fair-share parameters for the delivery worker. Per-user cap prevents one
+ * noisy account from starving everyone else's queue (hosted invariant);
+ * total cap bounds per-tick work so a single tick can't OOM under burst.
+ */
+const DELIVERY_LIMIT = 50;
+const PER_USER_DELIVERY_LIMIT = 10;
+/**
+ * How long a "processing" claim is held before another worker may reclaim
+ * it. Must comfortably exceed the worst-case HTTP timeout plus any TCP
+ * handshake and DNS overhead in `postWebhookRequest`. 15 minutes is well
+ * above the 10s request timeout and gives Sentry-visible headroom.
+ */
+const PROCESSING_LEASE_MS = 15 * 60_000;
+
+type QueryResultRows<T> = T[] | { rows: T[] };
+type CandidateDeliveryRow = { id: string };
+
+export type ClaimedDelivery = {
+    delivery: typeof webhookDeliveries.$inferSelect;
+    endpoint: typeof webhookEndpoints.$inferSelect;
+};
+
+function rowsFromQueryResult<T>(result: QueryResultRows<T>): T[] {
+    return Array.isArray(result) ? result : result.rows;
+}
+
+function dueDeliveryPredicate(now: Date): SQL {
+    return or(
+        and(
+            eq(webhookDeliveries.status, "pending"),
+            lte(webhookDeliveries.nextAttemptAt, now),
+        ),
+        and(
+            eq(webhookDeliveries.status, "processing"),
+            lte(webhookDeliveries.nextAttemptAt, now),
+        ),
+    ) as SQL;
+}
+
+/**
+ * Two-phase atomic claim:
+ *   1. Pick up to `DELIVERY_LIMIT` delivery IDs that are due and fair
+ *      (no more than `PER_USER_DELIVERY_LIMIT` per user).
+ *   2. Conditionally flip them to `processing` with a lease expiry,
+ *      requiring the row to still be due and the endpoint still enabled.
+ *
+ * Step 2 returns only the rows we actually won, so concurrent workers can
+ * race safely. Returned in the original fair-share ordering so worker
+ * iteration is predictable.
+ */
+export async function claimDueWebhookDeliveries(): Promise<ClaimedDelivery[]> {
+    const now = new Date();
+    // postgres-js binds Date → timestamp parameters reliably when the
+    // Date sits behind a Drizzle column predicate, but raw sql`...` with
+    // Date placeholders crashes under Bun/Next 16 with
+    // ERR_INVALID_ARG_TYPE ("Received an instance of Date"). Cast the
+    // ISO string explicitly to `timestamp` to match the column type
+    // (`webhookDeliveries.nextAttemptAt` is `timestamp`, not
+    // `timestamptz`); using `::timestamptz` would force a timezone
+    // conversion on every comparison and skew the due window in any
+    // non-UTC server timezone.
+    const nowParam = sql`${now.toISOString()}::timestamp`;
+
+    const candidateResult = await db.execute(sql`
+        select id
+        from (
+            select
+                ${webhookDeliveries.id} as id,
+                ${webhookDeliveries.nextAttemptAt} as next_attempt_at,
+                row_number() over (
+                    partition by ${webhookDeliveries.userId}
+                    order by ${webhookDeliveries.nextAttemptAt} asc, ${webhookDeliveries.id} asc
+                ) as user_rank
+            from ${webhookDeliveries}
+            inner join ${webhookEndpoints}
+                on ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
+            where (
+                (${webhookDeliveries.status} = 'pending' and ${webhookDeliveries.nextAttemptAt} <= ${nowParam})
+                or (${webhookDeliveries.status} = 'processing' and ${webhookDeliveries.nextAttemptAt} <= ${nowParam})
+            )
+            and ${webhookEndpoints.enabled} = true
+        ) ranked_deliveries
+        where user_rank <= ${PER_USER_DELIVERY_LIMIT}
+        order by next_attempt_at asc, id asc
+        limit ${DELIVERY_LIMIT}
+    `);
+
+    const candidateRows = rowsFromQueryResult(
+        candidateResult as unknown as QueryResultRows<CandidateDeliveryRow>,
+    );
+
+    if (candidateRows.length === 0) return [];
+
+    const ids = candidateRows.map((row) => row.id);
+    const claimExpiresAt = new Date(now.getTime() + PROCESSING_LEASE_MS);
+    const claimedRows = await db
+        .update(webhookDeliveries)
+        .set({
+            status: "processing",
+            nextAttemptAt: claimExpiresAt,
+            updatedAt: now,
+        })
+        .where(
+            and(
+                inArray(webhookDeliveries.id, ids),
+                dueDeliveryPredicate(now),
+                sql`exists (
+                    select 1
+                    from ${webhookEndpoints}
+                    where ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
+                    and ${webhookEndpoints.enabled} = true
+                )`,
+            ),
+        )
+        .returning({ id: webhookDeliveries.id });
+
+    const claimedIds = new Set(claimedRows.map((row) => row.id));
+    if (claimedIds.size === 0) return [];
+
+    const rows = await db
+        .select({
+            delivery: webhookDeliveries,
+            endpoint: webhookEndpoints,
+        })
+        .from(webhookDeliveries)
+        .innerJoin(
+            webhookEndpoints,
+            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
+        )
+        .where(
+            and(
+                inArray(webhookDeliveries.id, Array.from(claimedIds)),
+                eq(webhookEndpoints.enabled, true),
+            ),
+        );
+
+    const order = new Map(ids.map((id, index) => [id, index]));
+    return rows.sort((a, b) => {
+        return (
+            (order.get(a.delivery.id) ?? Number.MAX_SAFE_INTEGER) -
+            (order.get(b.delivery.id) ?? Number.MAX_SAFE_INTEGER)
+        );
+    });
+}
+
+/**
+ * Re-fetch a claimed (delivery, endpoint) pair, asserting all of:
+ *   - delivery is still in `processing` state (we still own the lease),
+ *   - endpoint is still enabled (user didn't disable mid-flight),
+ *   - delivery.userId / endpoint.userId still line up (defence in depth).
+ *
+ * Returns null when any of those drift, so the worker can release the
+ * claim instead of POSTing to a stale target.
+ */
+export async function reloadClaimedDeliveryForSend(
+    claimed: ClaimedDelivery,
+): Promise<ClaimedDelivery | null> {
+    const [row] = await db
+        .select({
+            delivery: webhookDeliveries,
+            endpoint: webhookEndpoints,
+        })
+        .from(webhookDeliveries)
+        .innerJoin(
+            webhookEndpoints,
+            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
+        )
+        .where(
+            and(
+                eq(webhookDeliveries.id, claimed.delivery.id),
+                eq(webhookDeliveries.userId, claimed.delivery.userId),
+                eq(webhookDeliveries.endpointId, claimed.endpoint.id),
+                eq(webhookDeliveries.status, "processing"),
+                eq(webhookEndpoints.id, claimed.endpoint.id),
+                eq(webhookEndpoints.userId, claimed.endpoint.userId),
+                eq(webhookEndpoints.enabled, true),
+            ),
+        )
+        .limit(1);
+
+    return row ?? null;
+}
+
+/**
+ * Release a `processing` claim back to `pending` with `nextAttemptAt =
+ * now`, so another worker can pick it up immediately. Used when the worker
+ * decides not to POST (e.g. endpoint disabled mid-flight).
+ *
+ * userId is asserted so a bug in the worker can't bleed a release across
+ * users -- the hosted multi-tenancy invariant applies even here.
+ */
+export async function releaseClaimedDelivery(
+    delivery: typeof webhookDeliveries.$inferSelect,
+): Promise<void> {
+    const now = new Date();
+    await db
+        .update(webhookDeliveries)
+        .set({
+            status: "pending",
+            nextAttemptAt: now,
+            updatedAt: now,
+        })
+        .where(
+            and(
+                eq(webhookDeliveries.id, delivery.id),
+                eq(webhookDeliveries.userId, delivery.userId),
+                eq(webhookDeliveries.status, "processing"),
+            ),
+        );
+}

--- a/src/lib/plaud/persist-connection.ts
+++ b/src/lib/plaud/persist-connection.ts
@@ -1,5 +1,6 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
+import { acquirePlaudConnectLock } from "@/db/queries/plaud-locks";
 import { plaudConnections, plaudDevices } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
 import type { PlaudDeviceListResponse } from "@/types/plaud";
@@ -51,10 +52,7 @@ export async function persistPlaudConnection({
     const encryptedAccessToken = encrypt(accessToken);
 
     await db.transaction(async (tx) => {
-        // Advisory lock serialises concurrent connect attempts per user.
-        await tx.execute(
-            sql`SELECT pg_advisory_xact_lock(hashtextextended(${`plaud_connect:${userId}`}, 0))`,
-        );
+        await acquirePlaudConnectLock(tx, userId);
 
         const [existingConnection] = await tx
             .select()

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,7 +1,5 @@
 import { createHmac } from "node:crypto";
-import { sql } from "drizzle-orm";
-import { db } from "@/db";
-import { apiRateLimitBuckets } from "@/db/schema";
+import { upsertRateLimitBucket } from "@/db/queries/rate-limit";
 import { env } from "@/lib/env";
 
 export type RateLimitResult = {
@@ -25,6 +23,14 @@ function rateLimitSecret(): string {
     return secret;
 }
 
+/**
+ * HMAC the raw bucket key (user id, IP, token id, etc.) before it touches
+ * the DB. The hosted DB is a multi-tenant blast surface: an exfil should
+ * not let an attacker enumerate which users/IPs were rate-limited or
+ * correlate buckets back to identities. HMAC keyed off
+ * `API_TOKEN_HASH_SECRET` (falling back to `BETTER_AUTH_SECRET`) makes
+ * this collision-resistant and unforgeable without the server secret.
+ */
 function bucketKey(rawKey: string): string {
     return createHmac("sha256", rateLimitSecret()).update(rawKey).digest("hex");
 }
@@ -58,27 +64,37 @@ export async function consumeRateLimitBucket(
     { limit, windowMs, now = new Date() }: RateLimitConfig,
 ): Promise<RateLimitResult> {
     const resetAt = new Date(now.getTime() + windowMs);
-    const [bucket] = await db
-        .insert(apiRateLimitBuckets)
-        .values({
+
+    // Fail-open: if the bucket store is unreachable (DB down, query error,
+    // driver crash) we MUST NOT take down every rate-limited route with
+    // it. The whole point of the rate-limiter is to be a safety net; a
+    // broken safety net should not collapse the building. Log loudly so
+    // Sentry surfaces the outage, then allow the request through with
+    // synthetic headers that look like a full bucket.
+    //
+    // Trade-off: under a sustained bucket-store outage an attacker could
+    // burst past nominal limits. That's the correct trade vs. taking the
+    // API down -- the upstream (Cloudflare, ALB) still rate-limits at
+    // the edge, and the v1 surface has per-token auth as a second gate.
+    let bucket: Awaited<ReturnType<typeof upsertRateLimitBucket>>;
+    try {
+        bucket = await upsertRateLimitBucket({
             key: bucketKey(rawKey),
-            count: 1,
+            now,
             resetAt,
-            createdAt: now,
-            updatedAt: now,
-        })
-        .onConflictDoUpdate({
-            target: apiRateLimitBuckets.key,
-            set: {
-                count: sql<number>`case when ${apiRateLimitBuckets.resetAt} <= ${now} then 1 else ${apiRateLimitBuckets.count} + 1 end`,
-                resetAt: sql<Date>`case when ${apiRateLimitBuckets.resetAt} <= ${now} then ${resetAt} else ${apiRateLimitBuckets.resetAt} end`,
-                updatedAt: now,
-            },
-        })
-        .returning({
-            count: apiRateLimitBuckets.count,
-            resetAt: apiRateLimitBuckets.resetAt,
         });
+    } catch (error) {
+        console.warn(
+            "[rate-limit] bucket store unavailable; failing open",
+            error instanceof Error ? error.message : error,
+        );
+        return {
+            allowed: true,
+            limit,
+            remaining: limit,
+            resetAt,
+        };
+    }
 
     const count = bucket?.count ?? limit + 1;
     const bucketResetAt = bucket?.resetAt ?? resetAt;

--- a/src/lib/webhooks/worker.ts
+++ b/src/lib/webhooks/worker.ts
@@ -2,8 +2,13 @@ import type { IncomingMessage, RequestOptions } from "node:http";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import type { LookupFunction } from "node:net";
-import { and, eq, inArray, lte, or, type SQL, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
+import {
+    claimDueWebhookDeliveries,
+    releaseClaimedDelivery,
+    reloadClaimedDeliveryForSend,
+} from "@/db/queries/webhook-deliveries";
 import { webhookDeliveries, webhookEndpoints } from "@/db/schema";
 import {
     createOutboundWebhookPayload,
@@ -28,10 +33,7 @@ import {
 } from "@/lib/webhooks/url";
 
 const TICK_MS = 30_000;
-const DELIVERY_LIMIT = 50;
-const PER_USER_DELIVERY_LIMIT = 10;
 const TIMEOUT_MS = 10_000;
-const PROCESSING_LEASE_MS = 15 * 60_000;
 const BACKOFF_MS = [30_000, 120_000, 600_000, 3_600_000, 21_600_000] as const;
 
 let started = false;
@@ -46,38 +48,10 @@ type WebhookDeliveryResult = {
     permanentFailure?: boolean;
 };
 
-type ClaimedDelivery = {
-    delivery: typeof webhookDeliveries.$inferSelect;
-    endpoint: typeof webhookEndpoints.$inferSelect;
-};
-
-type CandidateDeliveryRow = {
-    id: string;
-};
-
-type QueryResultRows<T> = T[] | { rows: T[] };
-
 export function getWebhookBackoffMs(attemptNumber: number): number {
     return BACKOFF_MS[
         Math.min(Math.max(attemptNumber, 1), BACKOFF_MS.length) - 1
     ];
-}
-
-function rowsFromQueryResult<T>(result: QueryResultRows<T>): T[] {
-    return Array.isArray(result) ? result : result.rows;
-}
-
-function dueDeliveryPredicate(now: Date): SQL {
-    return or(
-        and(
-            eq(webhookDeliveries.status, "pending"),
-            lte(webhookDeliveries.nextAttemptAt, now),
-        ),
-        and(
-            eq(webhookDeliveries.status, "processing"),
-            lte(webhookDeliveries.nextAttemptAt, now),
-        ),
-    ) as SQL;
 }
 
 async function readResponseBody(response: IncomingMessage): Promise<string> {
@@ -361,150 +335,6 @@ async function markDeliveryAttempt(
                 ),
             );
     });
-}
-
-async function claimDueWebhookDeliveries(): Promise<ClaimedDelivery[]> {
-    const now = new Date();
-    // postgres-js binds Date → timestamp parameters reliably when the
-    // Date sits behind a Drizzle column predicate, but raw sql`...` with
-    // Date placeholders crashes under Bun/Next 16 with
-    // ERR_INVALID_ARG_TYPE ("Received an instance of Date"). Cast the
-    // ISO string explicitly to `timestamp` to match the column type
-    // (`webhookDeliveries.nextAttemptAt` is `timestamp`, not
-    // `timestamptz`); using `::timestamptz` would force a timezone
-    // conversion on every comparison and skew the due window in any
-    // non-UTC server timezone.
-    const nowParam = sql`${now.toISOString()}::timestamp`;
-
-    const candidateResult = await db.execute(sql`
-        select id
-        from (
-            select
-                ${webhookDeliveries.id} as id,
-                ${webhookDeliveries.nextAttemptAt} as next_attempt_at,
-                row_number() over (
-                    partition by ${webhookDeliveries.userId}
-                    order by ${webhookDeliveries.nextAttemptAt} asc, ${webhookDeliveries.id} asc
-                ) as user_rank
-            from ${webhookDeliveries}
-            inner join ${webhookEndpoints}
-                on ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
-            where (
-                (${webhookDeliveries.status} = 'pending' and ${webhookDeliveries.nextAttemptAt} <= ${nowParam})
-                or (${webhookDeliveries.status} = 'processing' and ${webhookDeliveries.nextAttemptAt} <= ${nowParam})
-            )
-            and ${webhookEndpoints.enabled} = true
-        ) ranked_deliveries
-        where user_rank <= ${PER_USER_DELIVERY_LIMIT}
-        order by next_attempt_at asc, id asc
-        limit ${DELIVERY_LIMIT}
-    `);
-
-    const candidateRows = rowsFromQueryResult(
-        candidateResult as unknown as QueryResultRows<CandidateDeliveryRow>,
-    );
-
-    if (candidateRows.length === 0) return [];
-
-    const ids = candidateRows.map((row) => row.id);
-    const claimExpiresAt = new Date(now.getTime() + PROCESSING_LEASE_MS);
-    const claimedRows = await db
-        .update(webhookDeliveries)
-        .set({
-            status: "processing",
-            nextAttemptAt: claimExpiresAt,
-            updatedAt: now,
-        })
-        .where(
-            and(
-                inArray(webhookDeliveries.id, ids),
-                dueDeliveryPredicate(now),
-                sql`exists (
-                    select 1
-                    from ${webhookEndpoints}
-                    where ${webhookEndpoints.id} = ${webhookDeliveries.endpointId}
-                    and ${webhookEndpoints.enabled} = true
-                )`,
-            ),
-        )
-        .returning({ id: webhookDeliveries.id });
-
-    const claimedIds = new Set(claimedRows.map((row) => row.id));
-    if (claimedIds.size === 0) return [];
-
-    const rows = await db
-        .select({
-            delivery: webhookDeliveries,
-            endpoint: webhookEndpoints,
-        })
-        .from(webhookDeliveries)
-        .innerJoin(
-            webhookEndpoints,
-            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
-        )
-        .where(
-            and(
-                inArray(webhookDeliveries.id, Array.from(claimedIds)),
-                eq(webhookEndpoints.enabled, true),
-            ),
-        );
-
-    const order = new Map(ids.map((id, index) => [id, index]));
-    return rows.sort((a, b) => {
-        return (
-            (order.get(a.delivery.id) ?? Number.MAX_SAFE_INTEGER) -
-            (order.get(b.delivery.id) ?? Number.MAX_SAFE_INTEGER)
-        );
-    });
-}
-
-async function reloadClaimedDeliveryForSend(
-    claimed: ClaimedDelivery,
-): Promise<ClaimedDelivery | null> {
-    const [row] = await db
-        .select({
-            delivery: webhookDeliveries,
-            endpoint: webhookEndpoints,
-        })
-        .from(webhookDeliveries)
-        .innerJoin(
-            webhookEndpoints,
-            eq(webhookEndpoints.id, webhookDeliveries.endpointId),
-        )
-        .where(
-            and(
-                eq(webhookDeliveries.id, claimed.delivery.id),
-                eq(webhookDeliveries.userId, claimed.delivery.userId),
-                eq(webhookDeliveries.endpointId, claimed.endpoint.id),
-                eq(webhookDeliveries.status, "processing"),
-                eq(webhookEndpoints.id, claimed.endpoint.id),
-                eq(webhookEndpoints.userId, claimed.endpoint.userId),
-                eq(webhookEndpoints.enabled, true),
-            ),
-        )
-        .limit(1);
-
-    return row ?? null;
-}
-
-async function releaseClaimedDelivery(
-    delivery: typeof webhookDeliveries.$inferSelect,
-): Promise<void> {
-    const now = new Date();
-    await db
-        .update(webhookDeliveries)
-        .set({
-            status: "pending",
-            nextAttemptAt: now,
-            updatedAt: now,
-        })
-        .where(
-            and(
-                eq(webhookDeliveries.id, delivery.id),
-                eq(webhookDeliveries.userId, delivery.userId),
-                eq(webhookDeliveries.status, "processing"),
-            ),
-        );
 }
 
 export async function deliverDueWebhooks(): Promise<void> {

--- a/src/tests/admin/queries-pii.test.ts
+++ b/src/tests/admin/queries-pii.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
  */
 describe("admin queries PII guard", () => {
     const raw = readFileSync(
-        join(process.cwd(), "src/lib/admin/queries.ts"),
+        join(process.cwd(), "src/db/queries/admin.ts"),
         "utf8",
     );
     // Strip block comments and line comments so the file-level docstring
@@ -41,7 +41,7 @@ describe("admin queries PII guard", () => {
         it(`does not reference ${tok}`, () => {
             expect(
                 file.includes(tok),
-                `src/lib/admin/queries.ts references ${tok}; admin must not surface this column`,
+                `src/db/queries/admin.ts references ${tok}; admin must not surface this column`,
             ).toBe(false);
         });
     }

--- a/src/tests/rate-limit-bucket.test.ts
+++ b/src/tests/rate-limit-bucket.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression coverage for the rate-limit bucket upsert. Two distinct
+ * failure modes are pinned here:
+ *
+ *   1. `upsertRateLimitBucket` must never hand a `Date` instance to the
+ *      postgres-js driver via a raw `sql\`\`` template literal. Drizzle
+ *      only runs its column encoders for `.values({...})` and bare
+ *      column-mapped values in `.set({...})`; values interpolated into
+ *      `sql\`case when ... <= ${now}\`` bypass the encoder and reach the
+ *      driver as raw JS objects. postgres-js then crashes with
+ *      `ERR_INVALID_ARG_TYPE` (TypeError: "The 'string' argument must
+ *      be of type string or an instance of Buffer or ArrayBuffer.
+ *      Received an instance of Date") and every v1 API request +
+ *      Plaud sync starts returning 500. The fix encodes Date params
+ *      as ISO strings with explicit `::timestamp` casts; this test
+ *      walks the SQL fragments and fails if any `Date` instance is
+ *      still embedded in them.
+ *
+ *   2. `consumeRateLimitBucket` must fail OPEN when the bucket store is
+ *      unreachable. A broken rate limiter taking down the API is worse
+ *      than a brief enforcement gap, especially since upstream
+ *      (Cloudflare / ALB) still rate-limits at the edge and the v1
+ *      surface has per-token auth as a second gate.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    BETTER_AUTH_SECRET: "better-auth-secret-with-32-chars",
+    API_TOKEN_HASH_SECRET: undefined as string | undefined,
+    RATE_LIMIT_TRUST_PROXY_HEADERS: undefined as boolean | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+    },
+}));
+
+import { db } from "@/db";
+import { consumeRateLimitBucket } from "@/lib/rate-limit";
+
+interface CapturedConflictConfig {
+    set: Record<string, unknown>;
+}
+
+function captureOnConflictArgs(): {
+    captured: { last?: CapturedConflictConfig };
+} {
+    const captured: { last?: CapturedConflictConfig } = {};
+    (db.insert as unknown as Mock).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+            onConflictDoUpdate: vi.fn((cfg: CapturedConflictConfig) => {
+                captured.last = cfg;
+                return {
+                    returning: vi.fn().mockResolvedValue([
+                        {
+                            count: 1,
+                            resetAt: new Date("2025-01-01T00:01:00.000Z"),
+                        },
+                    ]),
+                };
+            }),
+        }),
+    });
+    return { captured };
+}
+
+/**
+ * Deep-walks an object graph and returns the dotted paths at which any
+ * `Date` instance is found. Used to assert no Date leaks into a raw
+ * `sql\`\`` template's chunk tree.
+ *
+ * Tracks visited objects with a WeakSet so cyclic graphs (Drizzle's
+ * internal SQL nodes do reference each other) don't loop forever.
+ */
+function findDatePaths(
+    value: unknown,
+    path: string,
+    seen: WeakSet<object>,
+): string[] {
+    if (value instanceof Date) return [path || "<root>"];
+    if (value === null || typeof value !== "object") return [];
+    if (seen.has(value as object)) return [];
+    seen.add(value as object);
+    const out: string[] = [];
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out.push(...findDatePaths(v, path ? `${path}.${k}` : k, seen));
+    }
+    return out;
+}
+
+describe("rate-limit bucket upsert", () => {
+    beforeEach(() => {
+        mockEnv.BETTER_AUTH_SECRET = "better-auth-secret-with-32-chars";
+        mockEnv.API_TOKEN_HASH_SECRET = undefined;
+        (db.insert as unknown as Mock).mockReset();
+    });
+
+    it("never embeds a Date instance in the raw-sql update fragments", async () => {
+        const { captured } = captureOnConflictArgs();
+
+        await consumeRateLimitBucket("ip:198.51.100.1", {
+            limit: 60,
+            windowMs: 60_000,
+            now: new Date("2025-01-01T00:00:00.000Z"),
+        });
+
+        expect(captured.last).toBeDefined();
+        if (!captured.last) return;
+
+        // `set.count` and `set.resetAt` are SQL fragments built via the
+        // `sql\`\`` tag. Walk both fragment trees -- any Date inside is
+        // exactly the bug that crashed postgres-js in production.
+        const countFragment = captured.last.set.count;
+        const resetAtFragment = captured.last.set.resetAt;
+
+        expect(
+            findDatePaths(countFragment, "set.count", new WeakSet()),
+        ).toEqual([]);
+        expect(
+            findDatePaths(resetAtFragment, "set.resetAt", new WeakSet()),
+        ).toEqual([]);
+
+        // Sanity: `set.updatedAt` is a column-bound assignment, not a
+        // raw sql template, so it IS allowed (and expected) to be a
+        // Date -- Drizzle's column encoder will serialise it. If this
+        // ever stops being a Date the column encoding has regressed.
+        expect(captured.last.set.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("fails open with a synthetic full bucket when the store throws", async () => {
+        (db.insert as unknown as Mock).mockImplementation(() => {
+            throw new Error("simulated DB outage");
+        });
+
+        // Silence the expected console.warn so test output stays clean.
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const result = await consumeRateLimitBucket("user:abc", {
+            limit: 60,
+            windowMs: 60_000,
+            now: new Date("2025-01-01T00:00:00.000Z"),
+        });
+
+        expect(result.allowed).toBe(true);
+        expect(result.limit).toBe(60);
+        expect(result.remaining).toBe(60);
+        expect(result.resetAt).toBeInstanceOf(Date);
+        expect(warnSpy).toHaveBeenCalledWith(
+            "[rate-limit] bucket store unavailable; failing open",
+            "simulated DB outage",
+        );
+
+        warnSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Description

Centralize all raw-SQL queries into a new `src/db/queries/` layer and fix the rate-limit Date crash that triggered the audit.

The bug: every `/api/v1/*` and `/api/plaud/sync` request returned 500 with `postgres-js`'s `ERR_INVALID_ARG_TYPE` ("Received an instance of Date"). Root cause was the rate-limit bucket upsert interpolating a `Date` into a raw `` sql`case when reset_at <= ${now}` `` template — Drizzle only runs column encoders for `.values({...})` and bare column-mapped values; raw `` sql`` `` template params reach the driver as-is, and `postgres-js` only accepts strings/buffers.

Fixing it surfaced the bigger problem: raw SQL was scattered across nine files with no consistent policy. This PR consolidates them, audits each, and writes the rule into `AGENTS.md`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring

## Related Issues

Fixes # _(no tracking issue opened; happy to file one for the regression test path if preferred)_

## Changes Made

**Bug fixes**
- Cast `Date` params to `${iso}::timestamp` in the rate-limit bucket upsert (`src/db/queries/rate-limit.ts`). Column is `timestamp` (TZ-naive); `::timestamptz` would skew comparisons in non-UTC server timezones.
- Same explicit cast applied to six implicit text→timestamp comparisons in admin analytics queries (`listUsers`, `topServerTranscriptionUsers`, `syncHealth`, `pricingSnapshot`). They worked via Postgres's implicit coercion but could defeat index usage.

**Safety**
- Rate limiter now **fails open** when the bucket store is unreachable: catches the DB error, `console.warn`s for Sentry visibility, returns `allowed: true`. A broken safety net shouldn't take down the API; Cloudflare/ALB still rate-limit at the edge and `/api/v1/*` has per-token auth as a second gate.
- Escape `%` and `_` in admin user-search `ILIKE` pattern with `` escape '\' `` — closes a low-severity wildcard-injection footgun (admin-only surface).

**Refactor**
- New `src/db/queries/` layer (5 files):
  - `admin.ts` — moved verbatim from `src/lib/admin/queries.ts`
  - `admin-pricing-snapshot-csv.ts` — extracted from `export.csv/route.ts`
  - `webhook-deliveries.ts` — `claimDueWebhookDeliveries` / `releaseClaimedDelivery` / `reloadClaimedDeliveryForSend` lifted out of the worker
  - `rate-limit.ts` — atomic bucket upsert
  - `plaud-locks.ts` — `acquirePlaudConnectLock(tx, userId)` advisory-lock helper
- Replaced inline `` sql`waveform_peaks is null` `` in the peaks route with Drizzle's `isNull()` (already imported in that file).
- `AGENTS.md` documents the new policy: raw-SQL queries (`db.execute(sql\`...\`)` or full `SELECT/INSERT/UPDATE/DELETE`) **must** live in `src/db/queries/`. Expression fragments inside Drizzle's fluent builder (`set: { col: sql\`col + 1\` }`, `` where(sql`a @> b`) ``, `orderBy(sql\`...\`)`) stay inline — operator helpers, not queries. Added a `` sql`` `` security checklist covering param binding, Date casts, ILIKE escaping, and identifier allowlists.

## Testing

### Test Environment
- OS: macOS
- Node: as per project `.nvmrc`
- Browser: n/a (no UI changes)

### Test Steps
1. `pnpm install`
2. `pnpm type-check` → clean
3. `pnpm format-and-lint:fix` → clean on changed files (pre-existing infos in `src/tests/admin/elevated-cookie.test.ts` untouched)
4. `pnpm test` → **50 test files, 371 tests passed, 5 skipped** (skipped are opt-in `PLAUD_BEARER_TOKEN` / `WEBSHARE_API_KEY` integration tests)

New regression test at `src/tests/rate-limit-bucket.test.ts`:
- *"never embeds a Date instance in the raw-sql update fragments"* — deep-walks the `onConflictDoUpdate.set` SQL fragment tree and fails if any `Date` is present. Pins the original crash in place.
- *"fails open with synthetic full bucket when the store throws"* — mocks `db.insert` to throw, asserts `allowed: true / remaining: 60`, asserts the warn log fires.

Path note: dropped at `src/tests/` (not `src/tests/regressions/`) because there's no tracking issue number. Trivially renameable if an issue is opened.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`AGENTS.md`)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None — no schema changes, no new migrations.

## Breaking Changes

None at the deploy surface (DB schema, env vars, `docker-compose.yml`, install script all untouched). Internal-only refactor: `@/lib/admin/queries` callers updated to `@/db/queries/admin`. AGENTS.md explicitly allows internal API refactors without back-compat.

Behavior change worth flagging: rate-limit now fails **open** under bucket-store outage (previously failed with a 500). Trade-off discussed in the inline comment in `src/lib/rate-limit.ts`.

## Additional Notes

Verified the move with grep: only two `` sql`` `` calls remain outside `src/db/queries/`, both pure expression fragments matching the new policy:
- `src/lib/webhooks/emit.ts` — `` sql`${webhookEndpoints.events} @> ${JSON.stringify([event])}::jsonb` `` (jsonb operator not modelled by Drizzle)
- `src/lib/admin/install-hits.ts` — `` sql`${installScriptHits.count} + 1` `` (atomic increment in `onConflictDoUpdate.set`)

## For Reviewers

- The `::timestamp` cast on every Date param is now mandatory per `AGENTS.md`. Worth confirming this lines up with how the team wants to handle `timestamptz` columns going forward (the rule explicitly says "match the column type").
- The fail-open rate-limit change is the only user-visible behavior change. Confirm the trade-off (brief over-admit vs. API outage) is the right call for hosted. Sentry will surface every fail-open via the `[rate-limit] bucket store unavailable; failing open` warn.
- `src/db/queries/admin.ts` is a verbatim move from `src/lib/admin/queries.ts` plus the search-pattern escape, the explicit `::timestamp` casts on six comparisons, and dropping a dead `export { adminActionLog, adminAuditLog }` re-export (no consumers — verified via grep).
