### PR TITLE
fix(release): finalize step couldn't locate the release commit

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -284,8 +284,22 @@ function phase2Finalize(): void {
 	// is `chore(release): vX.Y.Z`. GitHub's default squash subject is the
 	// PR title, which we set to the same string, so this --grep works for
 	// both merge-commit and squash-merge PRs.
+	//
+	// Two non-obvious things going on here:
+	//   1. The grep pattern is SINGLE-QUOTED inside the JS template so the
+	//      backslashes (`\(` / `\)`) survive `/bin/sh -c`. Without quoting,
+	//      sh strips them and git sees `^chore(release): vX.Y.Z$` under
+	//      `--extended-regexp`, where `(release)` becomes a capture group
+	//      around the literal text "release" and the pattern stops matching
+	//      the actual commit subject `chore(release): vX.Y.Z`. Result was
+	//      zero matches and `Error: no commit on origin/main matches`.
+	//   2. `--no-merges` excludes GitHub's auto-generated merge commit,
+	//      whose body includes the PR title verbatim. Without it the grep
+	//      finds BOTH the release commit and its merge commit and the
+	//      script bails with `multiple commits match`. Squash-merge PRs
+	//      produce a non-merge commit, so this stays compatible.
 	const matches = run(
-		`git log origin/main --grep=^chore\\(release\\):\\ v${version}$ --extended-regexp --format=%H`,
+		`git log origin/main --no-merges --grep='^chore\\(release\\): v${version}$' --extended-regexp --format=%H`,
 		{ silent: true },
 	)
 		.trim()


### PR DESCRIPTION
## Description

Phase 2 of `scripts/release.ts finalize` could never find the release commit. Two distinct bugs collided:

1. **Quoting bug.** The `--grep` pattern reached `/bin/sh -c` unquoted, so sh stripped the backslashes from `\(` `\)` `\ `. Git then saw `--grep=^chore(release): vX.Y.Z$` under `--extended-regexp`, where `(release)` is a capture group around literal text "release" — not the literal characters `(release)`. The pattern never matched the actual commit subject `chore(release): vX.Y.Z`, so phase 2 always bailed with `Error: no commit on origin/main matches`.
2. **Merge-commit duplication.** Even with quoting fixed, GitHub's auto-generated merge commit includes the PR title verbatim in its message body, and `git log --grep` searches the whole message. The pattern matched BOTH the release commit and its merge commit, so the script bailed with `multiple commits match`.

This bit during the v0.5.5 release — the tag had to be pushed manually after diagnosing both bugs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes # _(no issue filed; surfaced during the v0.5.5 finalize)_

## Changes Made

`scripts/release.ts`:
- Single-quote the grep pattern inside the JS template so the `\(` / `\)` escapes survive `sh -c`.
- Add `--no-merges` so GitHub's merge commit (which echoes the PR title in its body) doesn't collide with the release commit.

Squash-merge compatibility is preserved: squash-merge PRs produce regular (non-merge) commits whose subject is the PR title, so they still match.

Inline comment in the script captures both bugs so the next person who touches this doesn't undo either fix.

## Testing

### Test Environment
- OS: macOS
- Shell: `/bin/sh`
- Git: standard

### Test Steps

Verified all four cases against the live `origin/main` (where the v0.5.5 release commit lives at `aca0b3d` and its merge commit at `ea073e1`):

```text
=== Current broken pattern (unquoted, ERE) ===
(zero matches)
=== Without --extended-regexp (sh strips backslashes -> BRE treats () literal) ===
ea073e1027c90fd3835c9b3010b1aebeef3836c9
aca0b3df28b34ef1a052e1e73f322bde4052aa94
=== Fixed: single-quoted ERE with --no-merges ===
aca0b3df28b34ef1a052e1e73f322bde4052aa94
=== Fixed but without --no-merges (would falsely match the merge commit body) ===
ea073e1027c90fd3835c9b3010b1aebeef3836c9
aca0b3df28b34ef1a052e1e73f322bde4052aa94
```

Also ran:
- `pnpm format-and-lint:fix scripts/release.ts` → clean
- `pnpm type-check` → clean

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (both bugs explained inline)
- [ ] I have made corresponding changes to the documentation — not needed; BRANCHING.md describes the script behavior, not the implementation detail.
- [x] My changes generate no new warnings or errors
- [ ] I have added tests — `scripts/release.ts` is a one-shot maintainer tool with no harness; verified manually against live `origin/main`.
- [x] New and existing unit tests pass locally with my changes (`pnpm test` not re-run; this change is in a script that is not exercised by the test suite)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None. Internal maintainer script.

## Additional Notes

This is not changelog material per `AGENTS.md`: the change touches a maintainer-only script, not the deploy surface, not user-facing behavior, not env vars or schema. Self-hosters never run `scripts/release.ts`.

## For Reviewers

- Worth confirming the squash-merge claim: GitHub's squash-merge produces a commit with subject = PR title, and our release PR titles are `chore(release): vX.Y.Z`, so `--no-merges` keeps the squash path matchable. The script's existing comment ("GitHub's default squash subject is the PR title") supports this.
- The single-quoting trick relies on POSIX `/bin/sh` semantics; `execSync` uses sh by default on Linux/macOS, which is what the script targets. If we ever switch to passing args as an array (`spawnSync`), this whole class of bug goes away — but that's a larger refactor and not needed today.
