### PR TITLE
refactor(plaud): use runtime-native proxy instead of undici ProxyAgent

### DIFF
--- a/src/lib/plaud/fetch.ts
+++ b/src/lib/plaud/fetch.ts
@@ -1,4 +1,3 @@
-import { ProxyAgent } from "undici";
 import {
     getPlaudProxyUrl,
     invalidatePlaudProxy,
@@ -9,29 +8,14 @@ import {
 const MAX_PROXY_ROTATIONS = 1;
 const PLAUD_WEB_ORIGIN = "https://web.plaud.ai";
 
-const agentCache = new Map<string, ProxyAgent>();
-
-function getOrCreateAgent(proxy: SelectedProxy): ProxyAgent {
-    let agent = agentCache.get(proxy.id);
-    if (!agent) {
-        agent = new ProxyAgent({ uri: proxy.url });
-        agentCache.set(proxy.id, agent);
-    }
-    return agent;
-}
-
-function evictAgent(proxyId: string): void {
-    const agent = agentCache.get(proxyId);
-    if (!agent) return;
-    agentCache.delete(proxyId);
-    agent.close().catch(() => undefined);
-}
-
 /**
  * `fetch`-shaped wrapper. When `WEBSHARE_API_KEY` is configured and the URL
  * targets a Plaud host, routes the request through an HTTP proxy from the
  * configured pool with one rotation on 403/407. Otherwise behaves as a
  * pass-through to the global `fetch`.
+ *
+ * Uses the runtime's native `proxy` option so the same TLS stack handles
+ * both proxied and direct requests.
  */
 export async function plaudFetch(
     url: string,
@@ -50,14 +34,13 @@ export async function plaudFetch(
 
     let attempt = 0;
     while (true) {
-        const dispatcher = getOrCreateAgent(currentProxy);
         let response: Response;
         try {
             response = await fetch(url, {
                 ...init,
                 headers,
-                // @ts-expect-error -- undici extension to RequestInit
-                dispatcher,
+                // @ts-expect-error -- Bun extension to RequestInit
+                proxy: currentProxy.url,
             });
         } catch (err) {
             if (attempt < MAX_PROXY_ROTATIONS) {
@@ -67,7 +50,6 @@ export async function plaudFetch(
                     currentProxy.label,
                     err instanceof Error ? err.message : String(err),
                 );
-                evictAgent(currentProxy.id);
                 invalidatePlaudProxy(currentProxy);
                 const next = await getPlaudProxyUrl();
                 if (!next) return fetch(url, init);
@@ -88,7 +70,6 @@ export async function plaudFetch(
                 currentProxy.label,
                 response.statusText,
             );
-            evictAgent(currentProxy.id);
             invalidatePlaudProxy(currentProxy);
 
             const next = await getPlaudProxyUrl();
@@ -156,10 +137,7 @@ function logProxyEvent(
     );
 }
 
-/** Test-only: close and clear cached proxy agents. */
+/** Test-only: no-op kept for backward compat with existing test imports. */
 export function _resetPlaudFetchForTest(): void {
-    for (const agent of agentCache.values()) {
-        agent.close().catch(() => undefined);
-    }
-    agentCache.clear();
+    // Nothing to reset — proxy is now stateless (no agent cache).
 }

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -15,21 +15,6 @@ const mockEnv = vi.hoisted(() => ({
 
 vi.mock("@/lib/env", () => ({ env: mockEnv }));
 
-const mockProxyAgent = vi.hoisted(() => ({
-    ctor: vi.fn() as Mock,
-}));
-
-vi.mock("undici", () => ({
-    ProxyAgent: class {
-        constructor(opts: unknown) {
-            mockProxyAgent.ctor(opts);
-        }
-        close(): Promise<void> {
-            return Promise.resolve();
-        }
-    },
-}));
-
 import { _resetPlaudFetchForTest, plaudFetch } from "@/lib/plaud/fetch";
 import {
     _resetPlaudProxyCacheForTest,
@@ -84,7 +69,6 @@ const otherProxy = {
 beforeEach(() => {
     mockFetch = vi.fn();
     global.fetch = mockFetch as typeof global.fetch;
-    mockProxyAgent.ctor.mockReset();
     mockEnv.WEBSHARE_API_KEY = undefined;
     mockEnv.PLAUD_PROXY_SCOPE = "all";
     _resetPlaudProxyCacheForTest();
@@ -122,20 +106,28 @@ describe("shouldProxyPlaud", () => {
 });
 
 describe("plaudFetch without a proxy configured", () => {
-    it("calls global fetch directly with no dispatcher", async () => {
+    it("calls global fetch directly without a proxy", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
         expect(isPlaudProxyConfigured()).toBe(false);
+
+        const opts = mockFetch.mock.calls[0][1] as
+            | { proxy?: unknown }
+            | undefined;
+        expect(opts?.proxy).toBeUndefined();
     });
 
     it("does not proxy non-Plaud URLs", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://example.com/x");
-        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
+
+        const opts = mockFetch.mock.calls[0][1] as
+            | { proxy?: unknown }
+            | undefined;
+        expect(opts?.proxy).toBeUndefined();
     });
 });
 
@@ -144,7 +136,7 @@ describe("plaudFetch with a proxy configured", () => {
         mockEnv.WEBSHARE_API_KEY = "test-key";
     });
 
-    it("fetches the Webshare list and attaches a ProxyAgent dispatcher to the Plaud call", async () => {
+    it("fetches the Webshare list and passes the proxy URL to the Plaud call", async () => {
         mockFetch
             .mockResolvedValueOnce(webshareList([sampleProxy]))
             .mockResolvedValueOnce(okResponse());
@@ -158,12 +150,11 @@ describe("plaudFetch with a proxy configured", () => {
 
         const [plaudUrl, opts] = mockFetch.mock.calls[1];
         expect(String(plaudUrl)).toBe(PLAUD_API_URL);
-        expect((opts as { dispatcher?: unknown }).dispatcher).toBeDefined();
 
-        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(1);
-        expect(mockProxyAgent.ctor).toHaveBeenCalledWith({
-            uri: `http://${sampleProxy.username}:${sampleProxy.password}@${sampleProxy.proxy_address}:${sampleProxy.port}`,
-        });
+        const proxyUrl = (opts as { proxy?: string }).proxy;
+        expect(proxyUrl).toBe(
+            `http://${sampleProxy.username}:${sampleProxy.password}@${sampleProxy.proxy_address}:${sampleProxy.port}`,
+        );
 
         const sentHeaders = (opts as { headers: Headers }).headers;
         expect(sentHeaders.get("user-agent")).toMatch(/Chrome/);
@@ -179,7 +170,13 @@ describe("plaudFetch with a proxy configured", () => {
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(403);
         expect(mockFetch).toHaveBeenCalledTimes(3);
-        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(2);
+
+        // Verify two different proxies were used
+        const proxy1 = (mockFetch.mock.calls[1][1] as { proxy?: string }).proxy;
+        const proxy2 = (mockFetch.mock.calls[2][1] as { proxy?: string }).proxy;
+        expect(proxy1).toBeDefined();
+        expect(proxy2).toBeDefined();
+        expect(proxy1).not.toBe(proxy2);
     });
 
     it("returns a readable body when rotation is exhausted (no second proxy)", async () => {
@@ -201,7 +198,12 @@ describe("plaudFetch with a proxy configured", () => {
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockProxyAgent.ctor).toHaveBeenCalledTimes(2);
+
+        const proxy1 = (mockFetch.mock.calls[1][1] as { proxy?: string }).proxy;
+        const proxy2 = (mockFetch.mock.calls[2][1] as { proxy?: string }).proxy;
+        expect(proxy1).toBeDefined();
+        expect(proxy2).toBeDefined();
+        expect(proxy1).not.toBe(proxy2);
     });
 
     it("falls through to direct fetch when the proxy list is empty", async () => {
@@ -211,13 +213,21 @@ describe("plaudFetch with a proxy configured", () => {
 
         const res = await plaudFetch(PLAUD_API_URL);
         expect(res.status).toBe(200);
-        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
+
+        const opts = mockFetch.mock.calls[1][1] as
+            | { proxy?: unknown }
+            | undefined;
+        expect(opts?.proxy).toBeUndefined();
     });
 
     it("does not proxy non-Plaud URLs even when configured", async () => {
         mockFetch.mockResolvedValueOnce(okResponse());
         await plaudFetch("https://s3.amazonaws.com/some-bucket/file");
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockProxyAgent.ctor).not.toHaveBeenCalled();
+
+        const opts = mockFetch.mock.calls[0][1] as
+            | { proxy?: unknown }
+            | undefined;
+        expect(opts?.proxy).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Description

Replace undici's `ProxyAgent` with the runtime-native `proxy` option on `fetch()` for Plaud API proxying. This removes the agent cache and connection lifecycle management, and ensures proxied requests use the same TLS stack as direct requests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Relates to proxy reliability on hosted.

## Changes Made

- Removed `undici` import and `ProxyAgent` instantiation from `src/lib/plaud/fetch.ts`
- Removed agent cache (`agentCache` map, `getOrCreateAgent`, `evictAgent`) — proxy is now stateless per-request
- Switched from `{ dispatcher: ProxyAgent }` to `{ proxy: url }` on `fetch()` calls
- Updated `src/tests/plaud-proxy.test.ts`: removed `vi.mock("undici")` block, assertions now check `proxy` option instead of `dispatcher`
- `_resetPlaudFetchForTest()` kept as a no-op for import compatibility

## Screenshots (if applicable)

N/A

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0

### Test Steps
1. `pnpm format-and-lint:fix` — clean
2. `pnpm type-check` — clean
3. `pnpm test` — 371 passed, 5 skipped, 0 failed

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

N/A

## Breaking Changes

N/A — `undici` is still in `package.json` as a direct dependency but is no longer imported. Can be removed in a follow-up.

## Additional Notes

The previous implementation used undici's `ProxyAgent` which manages its own TLS connections independently from the runtime's `fetch()`. By switching to the native `proxy` option, proxied and direct requests now share the same TLS configuration, which simplifies the code and removes the need for agent lifecycle management.

## For Reviewers

- Verify the `proxy` option behaviour matches the old `dispatcher` approach (rotation on 403/407, fallback to direct on empty pool)
- `undici` dep removal is intentionally deferred
