### PR TITLE
perf(confirm-dialog): memoize the context value

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, type ReactNode, use, useRef, useState } from "react";
+import {
+    createContext,
+    type ReactNode,
+    use,
+    useCallback,
+    useRef,
+    useState,
+} from "react";
 import { toast } from "sonner";
 import {
     AlertDialog,
@@ -87,7 +94,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
     // without having to read state (which is one render behind).
     const activeRef = useRef<ActiveConfirm | null>(null);
 
-    const confirm: ConfirmFn = (opts) => {
+    const confirm = useCallback<ConfirmFn>((opts) => {
         if (activeRef.current) {
             return Promise.reject(
                 new Error(
@@ -100,7 +107,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
             activeRef.current = entry;
             setActive(entry);
         });
-    };
+    }, []);
 
     const closeWithResult = (result: boolean) => {
         const entry = activeRef.current;


### PR DESCRIPTION
## Description

`ConfirmDialogProvider` rebuilt the `confirm` function on every render, so its context value changed each time the dialog opened, ran, or closed -- re-rendering every `useConfirm()` consumer for no reason. The function only references a ref and a state setter (both stable), so this wraps it in `useCallback` with an empty dependency list to give consumers a stable reference. Flagged by the react.review audit in #135 (`jsx-no-constructed-context-values`).

## Type of Change

- [x] Performance improvement

## Related Issues

Relates to #135

## Changes Made

- Wrap `confirm` in `useCallback` (empty deps) in `src/components/confirm-dialog.tsx` so the context value is stable across the provider's re-renders.

## Testing

- `pnpm format-and-lint:fix`, `pnpm type-check`, `pnpm test` (371 passing), `pnpm build` all clean. Behavior-preserving: same imperative `confirm()` semantics, only the reference identity is now stable.
