### PR TITLE
feat(summary): expose custom summary prompts in the UI (#199)

### DIFF
--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -16,6 +16,11 @@ import {
     getSummaryPromptById,
     type SummaryPromptConfiguration,
 } from "@/lib/ai/summary-presets";
+import {
+    buildSummarySystemMessage,
+    buildSummaryUserPrompt,
+} from "@/lib/ai/summary-prompt";
+import { parseSummaryResponse } from "@/lib/ai/summary-response";
 import { requireApiSession } from "@/lib/auth-server";
 import { DEMO_SUMMARIES, isDemoRecordingId } from "@/lib/demo/fixtures";
 import { decrypt } from "@/lib/encryption";
@@ -90,7 +95,12 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
             ) ?? getDefaultSummaryPromptConfig();
         promptConfig = {
             selectedPrompt: config.selectedPrompt || "general",
-            customPrompts: config.customPrompts || [],
+            // Guard against a malformed stored shape (e.g. a non-array
+            // written by a non-UI client): getSummaryPromptById calls
+            // `.find()` on this, which would otherwise throw a 500.
+            customPrompts: Array.isArray(config.customPrompts)
+                ? config.customPrompts
+                : [],
         };
     }
 
@@ -182,24 +192,24 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
 
     // Apply AI output language directive (if configured) via the system
     // message rather than the user prompt. This separates concerns: the
-    // user prompt carries the JSON-shape contract (English keys), the
-    // system message carries the output-language preference. Smaller
+    // system message carries the JSON-shape contract and the output-
+    // language preference; the user prompt carries only intent. Smaller
     // models tend to honor this split more reliably than a combined
     // prompt where language and JSON-shape rules compete.
     const languageDirective = getAiOutputLanguageDirective(
         userSettingsRow?.aiOutputLanguage ?? null,
     );
 
-    const prompt = promptTemplate.replace(
-        "{transcription}",
+    // The system message owns the output-shape contract (see
+    // `buildSummarySystemMessage`), so a custom prompt (issue #199) only
+    // needs to express intent — it doesn't have to restate the JSON
+    // schema, and the transcript is guaranteed to be included even if the
+    // prompt omits the `{transcription}` placeholder.
+    const prompt = buildSummaryUserPrompt(
+        promptTemplate,
         truncatedTranscription,
     );
-
-    const baseSystem =
-        "You are a helpful assistant that summarizes audio transcriptions. Always respond with valid JSON only, no markdown formatting or code fences.";
-    const systemContent = languageDirective
-        ? `${baseSystem} ${languageDirective}`
-        : baseSystem;
+    const systemContent = buildSummarySystemMessage(languageDirective);
 
     const response = await openai.chat.completions.create(
         buildChatCompletionParams({
@@ -221,27 +231,13 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
 
     const rawContent = response.choices[0]?.message?.content?.trim() || "";
 
-    // Parse the JSON response
-    let summary = "";
-    let keyPoints: string[] = [];
-    let actionItems: string[] = [];
-
-    try {
-        // Strip markdown code fences if present
-        const cleanContent = rawContent
-            .replace(/^```(?:json)?\s*/i, "")
-            .replace(/\s*```$/i, "")
-            .trim();
-        const parsed = JSON.parse(cleanContent);
-        summary = parsed.summary || "";
-        keyPoints = Array.isArray(parsed.keyPoints) ? parsed.keyPoints : [];
-        actionItems = Array.isArray(parsed.actionItems)
-            ? parsed.actionItems
-            : [];
-    } catch {
-        // Fallback: treat entire response as summary text
-        summary = rawContent;
-    }
+    // Parse the model output into the stored shape. Hardened for custom
+    // prompts (issue #199): a user-authored prompt may emit prose or a
+    // JSON shape whose `summary` isn't a string. `parseSummaryResponse`
+    // guarantees `summary` is always a string so it never reaches
+    // `encryptText` (which throws on non-string input) as an object.
+    const { summary, keyPoints, actionItems } =
+        parseSummaryResponse(rawContent);
 
     // Atomic tombstone re-check + upsert.
     //

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -49,6 +49,7 @@ export function TranscriptionPanel({
         setSummaryExpanded,
         summaryPreset,
         setSummaryPreset,
+        customPrompts,
         handleSummarize,
         handleDeleteSummary,
     } = useTranscriptionSummary({
@@ -168,6 +169,14 @@ export function TranscriptionPanel({
                                                     </SelectItem>
                                                 ),
                                             )}
+                                            {customPrompts.map((prompt) => (
+                                                <SelectItem
+                                                    key={prompt.id}
+                                                    value={prompt.id}
+                                                >
+                                                    {prompt.name}
+                                                </SelectItem>
+                                            ))}
                                         </SelectContent>
                                     </Select>
                                 )}

--- a/src/components/recordings/transcription-section.tsx
+++ b/src/components/recordings/transcription-section.tsx
@@ -49,6 +49,7 @@ export function TranscriptionSection({
         setSummaryExpanded,
         summaryPreset,
         setSummaryPreset,
+        customPrompts,
         handleSummarize,
         handleDeleteSummary,
         refetchSummary,
@@ -201,6 +202,14 @@ export function TranscriptionSection({
                                                     </SelectItem>
                                                 ),
                                             )}
+                                            {customPrompts.map((prompt) => (
+                                                <SelectItem
+                                                    key={prompt.id}
+                                                    value={prompt.id}
+                                                >
+                                                    {prompt.name}
+                                                </SelectItem>
+                                            ))}
                                         </SelectContent>
                                     </Select>
                                 )}

--- a/src/components/settings-sections/summary-prompt-manager.tsx
+++ b/src/components/settings-sections/summary-prompt-manager.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { nanoid } from "nanoid";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useConfirm } from "@/components/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useSettings } from "@/hooks/use-settings";
+import {
+    type CustomSummaryPrompt,
+    SUMMARY_PRESETS,
+    type SummaryPromptConfiguration,
+} from "@/lib/ai/summary-presets";
+
+type EditingPrompt = {
+    id?: string;
+    name: string;
+    prompt: string;
+};
+
+/**
+ * Summary-generation prompt management. Mirrors PromptManager (title
+ * prompts): active selector across presets + customs, read-only preset
+ * list, custom prompt CRUD with confirm-delete, view + edit dialogs.
+ *
+ * Persists via PUT /api/settings/user, `summaryPrompt` field. The old
+ * SummarySection dropdown wrote `customPrompts: []` on every preset
+ * change, silently wiping any custom prompts stored via the API; this
+ * component preserves them on every write.
+ */
+export function SummaryPromptManager() {
+    const confirm = useConfirm();
+    const { isLoadingSettings, isSavingSettings, setIsLoadingSettings } =
+        useSettings();
+    const [selectedPromptId, setSelectedPromptId] = useState<string>("general");
+    const [customPrompts, setCustomPrompts] = useState<CustomSummaryPrompt[]>(
+        [],
+    );
+    const [editingCustomPrompt, setEditingCustomPrompt] =
+        useState<EditingPrompt | null>(null);
+    const [viewingPromptId, setViewingPromptId] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchSettings = async () => {
+            try {
+                const response = await fetch("/api/settings/user");
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.summaryPrompt) {
+                        const promptConfig =
+                            data.summaryPrompt as SummaryPromptConfiguration;
+                        setSelectedPromptId(
+                            promptConfig.selectedPrompt || "general",
+                        );
+                        setCustomPrompts(promptConfig.customPrompts || []);
+                    } else {
+                        setSelectedPromptId("general");
+                        setCustomPrompts([]);
+                    }
+                }
+            } catch (error) {
+                console.error("Failed to fetch settings:", error);
+            } finally {
+                setIsLoadingSettings(false);
+            }
+        };
+        fetchSettings();
+    }, [setIsLoadingSettings]);
+
+    const handlePromptSettingChange = async (
+        config: SummaryPromptConfiguration,
+    ) => {
+        try {
+            const response = await fetch("/api/settings/user", {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ summaryPrompt: config }),
+            });
+            if (!response.ok) {
+                throw new Error("Failed to save prompt settings");
+            }
+            toast.success("Summary prompt settings saved");
+        } catch {
+            toast.error("Failed to save summary prompt settings");
+        }
+    };
+
+    const handleSaveCustomPrompt = async (prompt: EditingPrompt) => {
+        const isEdit = !!prompt.id;
+        const newPrompt: CustomSummaryPrompt = {
+            id: prompt.id || nanoid(),
+            name: prompt.name,
+            prompt: prompt.prompt,
+            createdAt: isEdit
+                ? customPrompts.find((p) => p.id === prompt.id)?.createdAt ||
+                  new Date().toISOString()
+                : new Date().toISOString(),
+        };
+
+        const updatedPrompts = isEdit
+            ? customPrompts.map((p) => (p.id === prompt.id ? newPrompt : p))
+            : [...customPrompts, newPrompt];
+
+        setCustomPrompts(updatedPrompts);
+        setEditingCustomPrompt(null);
+
+        await handlePromptSettingChange({
+            selectedPrompt: selectedPromptId,
+            customPrompts: updatedPrompts,
+        });
+    };
+
+    const handleDeleteCustomPrompt = (id: string) => {
+        void confirm({
+            title: "Delete this custom prompt?",
+            description:
+                "Recordings already summarized with this prompt keep their existing summaries, but you won't be able to apply it again.",
+            confirmLabel: "Delete",
+            destructive: true,
+            onConfirm: async () => {
+                const updatedPrompts = customPrompts.filter((p) => p.id !== id);
+                setCustomPrompts(updatedPrompts);
+                const newSelectedPrompt =
+                    selectedPromptId === id ? "general" : selectedPromptId;
+                setSelectedPromptId(newSelectedPrompt);
+                await handlePromptSettingChange({
+                    selectedPrompt: newSelectedPrompt,
+                    customPrompts: updatedPrompts,
+                });
+            },
+        });
+    };
+
+    if (isLoadingSettings) {
+        return (
+            <div className="flex items-center justify-center py-8">
+                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
+            </div>
+        );
+    }
+
+    const viewingText =
+        viewingPromptId &&
+        (SUMMARY_PRESETS[viewingPromptId as keyof typeof SUMMARY_PRESETS]
+            ?.prompt ||
+            customPrompts.find((p) => p.id === viewingPromptId)?.prompt ||
+            "");
+
+    const viewingName =
+        viewingPromptId &&
+        (SUMMARY_PRESETS[viewingPromptId as keyof typeof SUMMARY_PRESETS]
+            ?.name ||
+            customPrompts.find((p) => p.id === viewingPromptId)?.name ||
+            "Prompt");
+
+    const viewingDescription =
+        viewingPromptId &&
+        (SUMMARY_PRESETS[viewingPromptId as keyof typeof SUMMARY_PRESETS]
+            ?.description ||
+            "Custom prompt");
+
+    return (
+        <div className="space-y-6">
+            {/* Active prompt selector */}
+            <div className="space-y-2">
+                <Label htmlFor="selected-summary-prompt">
+                    Default summary prompt
+                </Label>
+                <Select
+                    value={selectedPromptId}
+                    onValueChange={(value) => {
+                        setSelectedPromptId(value);
+                        handlePromptSettingChange({
+                            selectedPrompt: value,
+                            customPrompts,
+                        });
+                    }}
+                    disabled={isSavingSettings}
+                >
+                    <SelectTrigger id="selected-summary-prompt">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {Object.values(SUMMARY_PRESETS).map((preset) => (
+                            <SelectItem key={preset.id} value={preset.id}>
+                                {preset.name} (Preset)
+                            </SelectItem>
+                        ))}
+                        {customPrompts.map((prompt) => (
+                            <SelectItem key={prompt.id} value={prompt.id}>
+                                {prompt.name} (Custom)
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                    The default prompt used when generating summaries. You can
+                    override this per-recording.
+                </p>
+            </div>
+
+            {/* Preset prompts (read-only) */}
+            <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Preset Prompts</h3>
+                </div>
+                <div className="space-y-2">
+                    {Object.values(SUMMARY_PRESETS).map((preset) => (
+                        <div key={preset.id} className="p-4 border rounded-lg">
+                            <div className="flex items-start justify-between mb-2">
+                                <div className="flex-1">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <h4 className="font-medium">
+                                            {preset.name}
+                                        </h4>
+                                        {selectedPromptId === preset.id && (
+                                            <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
+                                                Active
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground mb-2">
+                                        {preset.description}
+                                    </p>
+                                </div>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                        setViewingPromptId(preset.id)
+                                    }
+                                >
+                                    View Prompt
+                                </Button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* Custom prompts */}
+            <div className="space-y-4 pt-4 border-t">
+                <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Custom Prompts</h3>
+                    <Button
+                        onClick={() =>
+                            setEditingCustomPrompt({ name: "", prompt: "" })
+                        }
+                        size="sm"
+                    >
+                        <Plus className="size-4 mr-2" />
+                        Add Custom Prompt
+                    </Button>
+                </div>
+                {customPrompts.length === 0 ? (
+                    <p className="text-sm text-muted-foreground text-center py-4">
+                        No custom prompts yet. Create one to get started.
+                    </p>
+                ) : (
+                    <div className="space-y-2">
+                        {customPrompts.map((prompt) => (
+                            <div
+                                key={prompt.id}
+                                className="p-4 border rounded-lg"
+                            >
+                                <div className="flex items-start justify-between mb-2">
+                                    <div className="flex-1">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <h4 className="font-medium">
+                                                {prompt.name}
+                                            </h4>
+                                            {selectedPromptId === prompt.id && (
+                                                <span className="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded border border-primary/20">
+                                                    Active
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                setViewingPromptId(prompt.id)
+                                            }
+                                        >
+                                            View
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                setEditingCustomPrompt({
+                                                    id: prompt.id,
+                                                    name: prompt.name,
+                                                    prompt: prompt.prompt,
+                                                })
+                                            }
+                                        >
+                                            <Pencil className="size-4" />
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                handleDeleteCustomPrompt(
+                                                    prompt.id,
+                                                )
+                                            }
+                                        >
+                                            <Trash2 className="size-4 text-destructive" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* View prompt dialog */}
+            {viewingPromptId && (
+                <Dialog
+                    open={!!viewingPromptId}
+                    onOpenChange={(open) => !open && setViewingPromptId(null)}
+                >
+                    <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+                        <DialogTitle>{viewingName}</DialogTitle>
+                        <DialogDescription>
+                            {viewingDescription}
+                        </DialogDescription>
+                        <div className="mt-4">
+                            <pre className="p-4 bg-muted rounded-md text-sm font-mono whitespace-pre-wrap overflow-x-auto">
+                                {viewingText}
+                            </pre>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
+
+            {/* Edit/create custom prompt dialog */}
+            {editingCustomPrompt && (
+                <Dialog
+                    open={!!editingCustomPrompt}
+                    onOpenChange={(open) =>
+                        !open && setEditingCustomPrompt(null)
+                    }
+                >
+                    <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+                        <DialogTitle>
+                            {editingCustomPrompt.id
+                                ? "Edit Custom Prompt"
+                                : "Create Custom Prompt"}
+                        </DialogTitle>
+                        <DialogDescription>
+                            Just describe what you want the summary to focus on
+                            — Riffado handles the output format and adds the
+                            transcript automatically, so you don't need to
+                            mention JSON or any placeholder. (Advanced: include{" "}
+                            <code className="px-1 py-0.5 bg-muted rounded">
+                                {"{transcription}"}
+                            </code>{" "}
+                            to control where the transcript is inserted.)
+                        </DialogDescription>
+                        <div className="space-y-4 mt-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="custom-summary-prompt-name">
+                                    Name
+                                </Label>
+                                <Input
+                                    id="custom-summary-prompt-name"
+                                    value={editingCustomPrompt.name}
+                                    onChange={(e) =>
+                                        setEditingCustomPrompt((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      name: e.target.value,
+                                                  }
+                                                : prev,
+                                        )
+                                    }
+                                    placeholder="My Custom Summary"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="custom-summary-prompt-text">
+                                    Prompt
+                                </Label>
+                                <textarea
+                                    id="custom-summary-prompt-text"
+                                    className="w-full min-h-[300px] px-3 py-2 text-sm border rounded-md resize-y font-mono"
+                                    value={editingCustomPrompt.prompt}
+                                    onChange={(e) =>
+                                        setEditingCustomPrompt((prev) =>
+                                            prev
+                                                ? {
+                                                      ...prev,
+                                                      prompt: e.target.value,
+                                                  }
+                                                : prev,
+                                        )
+                                    }
+                                    placeholder={`Summarize this recording. Detect whether it's a meeting, a personal note, a lecture, or a phone call, and lead with whatever matters most for that type — decisions and action items for meetings, key takeaways for notes, the main argument for a lecture.
+
+Keep the summary concise and skip filler.`}
+                                />
+                            </div>
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    variant="outline"
+                                    onClick={() => setEditingCustomPrompt(null)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={() => {
+                                        if (
+                                            !editingCustomPrompt.name ||
+                                            !editingCustomPrompt.prompt
+                                        ) {
+                                            toast.error(
+                                                "Name and prompt are required",
+                                            );
+                                            return;
+                                        }
+                                        handleSaveCustomPrompt(
+                                            editingCustomPrompt,
+                                        );
+                                    }}
+                                    disabled={
+                                        !editingCustomPrompt.name ||
+                                        !editingCustomPrompt.prompt
+                                    }
+                                >
+                                    {editingCustomPrompt.id ? "Save" : "Create"}
+                                </Button>
+                            </div>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
+        </div>
+    );
+}

--- a/src/components/settings-sections/summary-section.tsx
+++ b/src/components/settings-sections/summary-section.tsx
@@ -4,6 +4,7 @@ import { ListChecks } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { SettingsSectionHeader } from "@/components/settings/section-header";
+import { SummaryPromptManager } from "@/components/settings-sections/summary-prompt-manager";
 import { Label } from "@/components/ui/label";
 import {
     Select,
@@ -13,16 +14,10 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { useSettings } from "@/hooks/use-settings";
-import {
-    AI_OUTPUT_LANGUAGES,
-    SUMMARY_PRESETS,
-    type SummaryPromptConfiguration,
-} from "@/lib/ai/summary-presets";
+import { AI_OUTPUT_LANGUAGES } from "@/lib/ai/summary-presets";
 
 export function SummarySection() {
-    const { isLoadingSettings, isSavingSettings, setIsLoadingSettings } =
-        useSettings();
-    const [selectedPrompt, setSelectedPrompt] = useState("general");
+    const { isSavingSettings } = useSettings();
     const [outputLanguage, setOutputLanguage] = useState<string>("auto");
 
     useEffect(() => {
@@ -31,11 +26,6 @@ export function SummarySection() {
                 const response = await fetch("/api/settings/user");
                 if (response.ok) {
                     const data = await response.json();
-                    const config =
-                        data.summaryPrompt as SummaryPromptConfiguration | null;
-                    if (config?.selectedPrompt) {
-                        setSelectedPrompt(config.selectedPrompt);
-                    }
                     if (typeof data.aiOutputLanguage === "string") {
                         setOutputLanguage(data.aiOutputLanguage);
                     } else {
@@ -44,37 +34,10 @@ export function SummarySection() {
                 }
             } catch (error) {
                 console.error("Failed to fetch settings:", error);
-            } finally {
-                setIsLoadingSettings(false);
             }
         };
         fetchSettings();
-    }, [setIsLoadingSettings]);
-
-    const handlePresetChange = async (value: string) => {
-        const previous = selectedPrompt;
-        setSelectedPrompt(value);
-
-        try {
-            const response = await fetch("/api/settings/user", {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    summaryPrompt: {
-                        selectedPrompt: value,
-                        customPrompts: [],
-                    },
-                }),
-            });
-
-            if (!response.ok) {
-                throw new Error("Failed to save settings");
-            }
-        } catch {
-            setSelectedPrompt(previous);
-            toast.error("Failed to save settings. Changes reverted.");
-        }
-    };
+    }, []);
 
     const handleLanguageChange = async (value: string) => {
         const previous = outputLanguage;
@@ -99,14 +62,6 @@ export function SummarySection() {
         }
     };
 
-    if (isLoadingSettings) {
-        return (
-            <div className="flex items-center justify-center py-8">
-                <div className="animate-spin size-6 border-2 border-primary border-t-transparent rounded-full" />
-            </div>
-        );
-    }
-
     return (
         <div className="space-y-6">
             <SettingsSectionHeader
@@ -114,73 +69,33 @@ export function SummarySection() {
                 description="Prompt presets and provider used when generating recording summaries."
                 icon={ListChecks}
             />
-            <div className="space-y-4">
-                <div className="space-y-2">
-                    <Label htmlFor="summary-preset">
-                        Default summary prompt
-                    </Label>
-                    <Select
-                        value={selectedPrompt}
-                        onValueChange={handlePresetChange}
-                        disabled={isSavingSettings}
-                    >
-                        <SelectTrigger id="summary-preset" className="w-full">
-                            <SelectValue>
-                                {SUMMARY_PRESETS[
-                                    selectedPrompt as keyof typeof SUMMARY_PRESETS
-                                ]?.name || "General Summary"}
-                            </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                            {Object.values(SUMMARY_PRESETS).map((preset) => (
-                                <SelectItem key={preset.id} value={preset.id}>
-                                    <div>
-                                        <div>{preset.name}</div>
-                                        <div className="text-xs text-muted-foreground">
-                                            {preset.description}
-                                        </div>
-                                    </div>
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground">
-                        The default prompt preset used when generating
-                        summaries. You can override this per-recording.
-                    </p>
-                </div>
-                <div className="space-y-2">
-                    <Label htmlFor="ai-output-language">
-                        AI output language
-                    </Label>
-                    <Select
-                        value={outputLanguage}
-                        onValueChange={handleLanguageChange}
-                        disabled={isSavingSettings}
-                    >
-                        <SelectTrigger
-                            id="ai-output-language"
-                            className="w-full"
-                        >
-                            <SelectValue>
-                                {AI_OUTPUT_LANGUAGES.find(
-                                    (l) => l.code === outputLanguage,
-                                )?.label ?? "Auto (match transcript)"}
-                            </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                            {AI_OUTPUT_LANGUAGES.map((lang) => (
-                                <SelectItem key={lang.code} value={lang.code}>
-                                    {lang.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                    <p className="text-xs text-muted-foreground">
-                        Applies to AI-generated summaries and titles. Auto lets
-                        the model match the transcript's language.
-                    </p>
-                </div>
+            <SummaryPromptManager />
+            <div className="space-y-2 pt-4 border-t">
+                <Label htmlFor="ai-output-language">AI output language</Label>
+                <Select
+                    value={outputLanguage}
+                    onValueChange={handleLanguageChange}
+                    disabled={isSavingSettings}
+                >
+                    <SelectTrigger id="ai-output-language" className="w-full">
+                        <SelectValue>
+                            {AI_OUTPUT_LANGUAGES.find(
+                                (l) => l.code === outputLanguage,
+                            )?.label ?? "Auto (match transcript)"}
+                        </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                        {AI_OUTPUT_LANGUAGES.map((lang) => (
+                            <SelectItem key={lang.code} value={lang.code}>
+                                {lang.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                    Applies to AI-generated summaries and titles. Auto lets the
+                    model match the transcript's language.
+                </p>
             </div>
         </div>
     );

--- a/src/hooks/use-transcription-summary.ts
+++ b/src/hooks/use-transcription-summary.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import type {
+    CustomSummaryPrompt,
+    SummaryPromptConfiguration,
+} from "@/lib/ai/summary-presets";
 
 export interface SummaryData {
     summary: string | null;
@@ -41,6 +45,43 @@ export function useTranscriptionSummary({
     const [isSummarizing, setIsSummarizing] = useState(false);
     const [summaryExpanded, setSummaryExpanded] = useState(true);
     const [summaryPreset, setSummaryPreset] = useState("general");
+    const [customPrompts, setCustomPrompts] = useState<CustomSummaryPrompt[]>(
+        [],
+    );
+
+    // Once the user picks a preset, the mount fetch below must not clobber
+    // their choice when it resolves (slow network → the user already
+    // selected before the saved default arrived).
+    const userPickedPresetRef = useRef(false);
+    const selectSummaryPreset = useCallback((preset: string) => {
+        userPickedPresetRef.current = true;
+        setSummaryPreset(preset);
+    }, []);
+
+    // Pull the saved default preset + customs from /api/settings/user
+    // once on mount so the per-recording dropdown reflects the user's
+    // configured default (instead of hard-coding "general") and can
+    // list custom prompts alongside the presets.
+    useEffect(() => {
+        const controller = new AbortController();
+        fetch("/api/settings/user", { signal: controller.signal })
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data) => {
+                if (!data) return;
+                const config =
+                    data.summaryPrompt as SummaryPromptConfiguration | null;
+                // Don't override a selection the user already made while
+                // this request was in flight.
+                if (config?.selectedPrompt && !userPickedPresetRef.current) {
+                    setSummaryPreset(config.selectedPrompt);
+                }
+                if (Array.isArray(config?.customPrompts)) {
+                    setCustomPrompts(config.customPrompts);
+                }
+            })
+            .catch(() => {});
+        return () => controller.abort();
+    }, []);
 
     // Re-fetch trigger separate from the URL/id key so callers can
     // bump it imperatively (e.g. right after a re-transcribe finishes,
@@ -149,7 +190,8 @@ export function useTranscriptionSummary({
         summaryExpanded,
         setSummaryExpanded,
         summaryPreset,
-        setSummaryPreset,
+        setSummaryPreset: selectSummaryPreset,
+        customPrompts,
         handleSummarize,
         handleDeleteSummary,
         refetchSummary,

--- a/src/lib/ai/summary-prompt.ts
+++ b/src/lib/ai/summary-prompt.ts
@@ -1,0 +1,62 @@
+/**
+ * Server-side scaffolding for summary generation. Custom summary prompts
+ * (issue #199) should carry only the user's *intent* — Riffado owns the
+ * output-shape contract and guarantees the transcript reaches the model.
+ * This keeps the JSON schema out of the user's hands: the built-in
+ * presets still embed it (harmless, reinforcing), but a hand-written
+ * custom prompt needs nothing more than "summarize this, emphasize X".
+ *
+ * Pairs with `parseSummaryResponse` (the read side): this builds the
+ * request so the model is told the shape; that parses the response and
+ * degrades gracefully if the model deviates anyway.
+ */
+
+const TRANSCRIPTION_PLACEHOLDER = "{transcription}";
+
+/**
+ * Canonical output contract injected into the system message for every
+ * summary call. Stating the exact shape server-side is what lets custom
+ * prompts omit it. Kept in sync with `parseSummaryResponse`'s expected
+ * `{ summary, keyPoints, actionItems }` shape.
+ */
+export const SUMMARY_OUTPUT_CONTRACT = [
+    "Respond with a single valid JSON object and nothing else — no markdown, no code fences, no commentary.",
+    "The object must have exactly these keys:",
+    '- "summary": a string containing a concise prose summary of the transcription.',
+    '- "keyPoints": an array of strings (use [] when there are none).',
+    '- "actionItems": an array of strings (use [] when there are none).',
+].join("\n");
+
+/**
+ * Build the user message from a prompt template + transcript. Substitutes
+ * every `{transcription}` placeholder; if the template has none (a custom
+ * prompt that forgot it), the transcript is appended so it always reaches
+ * the model rather than being silently dropped.
+ */
+export function buildSummaryUserPrompt(
+    template: string,
+    transcription: string,
+): string {
+    if (template.includes(TRANSCRIPTION_PLACEHOLDER)) {
+        return template.replaceAll(TRANSCRIPTION_PLACEHOLDER, transcription);
+    }
+    return `${template}\n\nTranscription:\n${transcription}`;
+}
+
+/**
+ * Build the system message: role + the output contract, plus an optional
+ * output-language directive. The contract lives here (not in the user
+ * prompt) so the shape requirement is constant across presets and customs.
+ */
+export function buildSummarySystemMessage(
+    languageDirective?: string | null,
+): string {
+    const parts = [
+        "You are a helpful assistant that summarizes audio transcriptions.",
+        SUMMARY_OUTPUT_CONTRACT,
+    ];
+    if (languageDirective) {
+        parts.push(languageDirective);
+    }
+    return parts.join("\n\n");
+}

--- a/src/lib/ai/summary-response.ts
+++ b/src/lib/ai/summary-response.ts
@@ -1,0 +1,63 @@
+/**
+ * Parse an LLM summary response into the stored shape
+ * `{ summary: string, keyPoints: string[], actionItems: string[] }`.
+ *
+ * Hardened for custom summary prompts (issue #199): the four built-in
+ * presets pin the exact JSON contract, so in practice the model returns
+ * a string `summary`. A user-authored custom prompt has no such
+ * guarantee — it can make the model emit prose, a different JSON shape,
+ * or a `summary` that is a nested object. None of that may crash the
+ * summary route: `summary` in particular must always be a string before
+ * it reaches `encryptText`, which throws on non-string input. Array
+ * elements are coerced too, since the UI renders them as text and an
+ * object element would otherwise blow up React rendering on read-back.
+ */
+
+export interface ParsedSummary {
+    summary: string;
+    keyPoints: string[];
+    actionItems: string[];
+}
+
+const coerceToString = (value: unknown): string =>
+    typeof value === "string" ? value : JSON.stringify(value);
+
+export function parseSummaryResponse(rawContent: string): ParsedSummary {
+    const trimmed = rawContent.trim();
+
+    try {
+        // Strip markdown code fences if present.
+        const cleanContent = trimmed
+            .replace(/^```(?:json)?\s*/i, "")
+            .replace(/\s*```$/i, "")
+            .trim();
+        const parsed = JSON.parse(cleanContent);
+
+        const hasStringSummary = typeof parsed.summary === "string";
+        const summary = hasStringSummary ? parsed.summary : "";
+        const keyPoints = Array.isArray(parsed.keyPoints)
+            ? parsed.keyPoints.map(coerceToString)
+            : [];
+        const actionItems = Array.isArray(parsed.actionItems)
+            ? parsed.actionItems.map(coerceToString)
+            : [];
+
+        // Keep a present-but-empty summary string as-is (e.g. a custom
+        // prompt that asks for bullet points only and leaves summary
+        // blank). Only when the JSON carried no usable content at all —
+        // no string summary and no points — do we fall back to the raw
+        // model output; otherwise a legitimately empty summary would be
+        // replaced by the raw JSON blob.
+        const hasUsableContent =
+            hasStringSummary || keyPoints.length > 0 || actionItems.length > 0;
+
+        return {
+            summary: hasUsableContent ? summary : trimmed,
+            keyPoints,
+            actionItems,
+        };
+    } catch {
+        // Not JSON — treat the whole response as the summary text.
+        return { summary: trimmed, keyPoints: [], actionItems: [] };
+    }
+}

--- a/src/tests/summary-prompt-build.test.ts
+++ b/src/tests/summary-prompt-build.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Pins the server-side scaffolding that makes custom summary prompts
+ * (issue #199) seamless: the user writes intent only, while Riffado
+ * guarantees (a) the transcript reaches the model and (b) the output
+ * shape is specified — neither of which the user must encode by hand.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+    buildSummarySystemMessage,
+    buildSummaryUserPrompt,
+    SUMMARY_OUTPUT_CONTRACT,
+} from "@/lib/ai/summary-prompt";
+
+describe("buildSummaryUserPrompt", () => {
+    it("substitutes the {transcription} placeholder", () => {
+        const out = buildSummaryUserPrompt(
+            "Summarize this: {transcription}",
+            "hello world",
+        );
+        expect(out).toBe("Summarize this: hello world");
+    });
+
+    it("substitutes every occurrence of the placeholder", () => {
+        const out = buildSummaryUserPrompt(
+            "{transcription} ... and again: {transcription}",
+            "X",
+        );
+        expect(out).toBe("X ... and again: X");
+    });
+
+    it("appends the transcript when the prompt omits the placeholder", () => {
+        // The seamless case: a custom prompt that never mentions
+        // {transcription} must still receive the transcript.
+        const out = buildSummaryUserPrompt(
+            "Give me the gist, in three sentences.",
+            "the transcript body",
+        );
+        expect(out).toContain("Give me the gist, in three sentences.");
+        expect(out).toContain("the transcript body");
+        expect(out.endsWith("the transcript body")).toBe(true);
+    });
+
+    it("does not re-scan inserted transcript text for further placeholders", () => {
+        const out = buildSummaryUserPrompt(
+            "{transcription}",
+            "literally {transcription}",
+        );
+        expect(out).toBe("literally {transcription}");
+    });
+});
+
+describe("buildSummarySystemMessage", () => {
+    it("always states the JSON output contract", () => {
+        const msg = buildSummarySystemMessage();
+        expect(msg).toContain(SUMMARY_OUTPUT_CONTRACT);
+        // The three stored keys must be named so a custom prompt need not.
+        expect(msg).toContain('"summary"');
+        expect(msg).toContain('"keyPoints"');
+        expect(msg).toContain('"actionItems"');
+    });
+
+    it("appends the language directive when provided", () => {
+        const directive = "IMPORTANT: Write all output in Czech.";
+        const msg = buildSummarySystemMessage(directive);
+        expect(msg).toContain(directive);
+        expect(msg).toContain(SUMMARY_OUTPUT_CONTRACT);
+    });
+
+    it("omits the language directive when null/empty", () => {
+        const msg = buildSummarySystemMessage(null);
+        expect(msg).not.toContain("IMPORTANT: Write all output");
+    });
+});

--- a/src/tests/summary-prompt-config.test.ts
+++ b/src/tests/summary-prompt-config.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Pins the storage and resolver contract that the issue #199 feature
+ * depends on:
+ *
+ *   - `SummaryPromptConfiguration` (the JSON shape stored in
+ *     `userSettings.summaryPrompt`) round-trips losslessly through
+ *     `encryptJsonField` / `decryptJsonField` with a populated
+ *     `customPrompts` array. If this regresses, every custom summary
+ *     prompt a user has saved becomes unreadable on the next request.
+ *
+ *   - `getSummaryPromptById` resolves both built-in preset ids and
+ *     user-created custom ids to the underlying prompt template
+ *     string. The summary route's only resolution path is
+ *     `presetId || promptConfig.selectedPrompt`, both of which fall
+ *     through `getSummaryPromptById`. If this regresses, custom
+ *     prompts become unreachable even though they're stored.
+ *
+ *   - Unknown ids return null so the route's "fall back to general"
+ *     guard fires instead of crashing.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/env", () => ({
+    env: {
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+const { decryptJsonField, encryptJsonField } = await import(
+    "../lib/encryption/fields"
+);
+const { SUMMARY_PRESETS, getSummaryPromptById, getDefaultSummaryPromptConfig } =
+    await import("../lib/ai/summary-presets");
+
+import type {
+    CustomSummaryPrompt,
+    SummaryPromptConfiguration,
+} from "../lib/ai/summary-presets";
+
+const CUSTOM_PROMPTS: CustomSummaryPrompt[] = [
+    {
+        id: "abc123XYZxxxxxxxxxxxx",
+        name: "Detect & format by type",
+        prompt: "Summarize this audio. If it's a meeting, list attendees and decisions. If it's a personal note, list highlights. Transcription: {transcription}",
+        createdAt: "2026-06-19T10:00:00.000Z",
+    },
+    {
+        id: "def456WVUtttttttttttt",
+        name: "Bullet points only",
+        prompt: "Return only a bulleted list of the key points from: {transcription}",
+        createdAt: "2026-06-19T10:05:00.000Z",
+    },
+];
+
+const CONFIG_WITH_CUSTOMS: SummaryPromptConfiguration = {
+    selectedPrompt: CUSTOM_PROMPTS[0].id,
+    customPrompts: CUSTOM_PROMPTS,
+};
+
+describe("summaryPrompt config — encryption round-trip", () => {
+    it("preserves a populated customPrompts array losslessly", () => {
+        const envelope = encryptJsonField(CONFIG_WITH_CUSTOMS);
+        expect(envelope).toBeTruthy();
+        const decoded = decryptJsonField<SummaryPromptConfiguration>(envelope);
+        expect(decoded).toEqual(CONFIG_WITH_CUSTOMS);
+    });
+
+    it("preserves the default config", () => {
+        const envelope = encryptJsonField(getDefaultSummaryPromptConfig());
+        const decoded = decryptJsonField<SummaryPromptConfiguration>(envelope);
+        expect(decoded).toEqual({
+            selectedPrompt: "general",
+            customPrompts: [],
+        });
+    });
+
+    it("passes null through both directions (column-level 'no setting')", () => {
+        expect(encryptJsonField(null)).toBeNull();
+        expect(decryptJsonField(null)).toBeNull();
+    });
+});
+
+describe("getSummaryPromptById — resolves presets and customs", () => {
+    it("returns the preset prompt for a built-in id", () => {
+        const prompt = getSummaryPromptById("general", CONFIG_WITH_CUSTOMS);
+        expect(prompt).toBe(SUMMARY_PRESETS.general.prompt);
+    });
+
+    it("returns the custom prompt for a stored custom id", () => {
+        const prompt = getSummaryPromptById(
+            CUSTOM_PROMPTS[0].id,
+            CONFIG_WITH_CUSTOMS,
+        );
+        expect(prompt).toBe(CUSTOM_PROMPTS[0].prompt);
+    });
+
+    it("returns the second custom too (not just the first)", () => {
+        const prompt = getSummaryPromptById(
+            CUSTOM_PROMPTS[1].id,
+            CONFIG_WITH_CUSTOMS,
+        );
+        expect(prompt).toBe(CUSTOM_PROMPTS[1].prompt);
+    });
+
+    it("returns null for an unknown id so the route can fall back", () => {
+        const prompt = getSummaryPromptById(
+            "totally-not-a-real-id",
+            CONFIG_WITH_CUSTOMS,
+        );
+        expect(prompt).toBeNull();
+    });
+
+    it("does not crash when the config carries an empty customPrompts array", () => {
+        const prompt = getSummaryPromptById(
+            "totally-not-a-real-id",
+            getDefaultSummaryPromptConfig(),
+        );
+        expect(prompt).toBeNull();
+    });
+});

--- a/src/tests/summary-response-parse.test.ts
+++ b/src/tests/summary-response-parse.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Pins `parseSummaryResponse`, the LLM-output parser for the summary
+ * route. The load-bearing case is issue #199: a custom summary prompt
+ * can make the model return JSON whose `summary` is a nested object
+ * (or a different shape entirely). Before the fix, that object flowed
+ * straight into `encryptText` and threw:
+ *
+ *   Encryption failed: The "data" argument must be of type string ...
+ *   Received an instance of Object
+ *
+ * surfacing as an opaque 500 with no summary stored. The parser must
+ * always return a string `summary` and string[] for the two arrays.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseSummaryResponse } from "@/lib/ai/summary-response";
+
+describe("parseSummaryResponse", () => {
+    it("parses the well-formed preset shape", () => {
+        const raw = JSON.stringify({
+            summary: "A concise summary.",
+            keyPoints: ["point one", "point two"],
+            actionItems: ["do the thing"],
+        });
+        expect(parseSummaryResponse(raw)).toEqual({
+            summary: "A concise summary.",
+            keyPoints: ["point one", "point two"],
+            actionItems: ["do the thing"],
+        });
+    });
+
+    it("strips ```json fences before parsing", () => {
+        const raw =
+            '```json\n{"summary":"fenced","keyPoints":[],"actionItems":[]}\n```';
+        expect(parseSummaryResponse(raw).summary).toBe("fenced");
+    });
+
+    it("never returns an object summary (issue #199 crash case)", () => {
+        // A custom prompt that asks the model to 'format by recording
+        // type' can yield a nested object for `summary`.
+        const raw = JSON.stringify({
+            summary: { meeting: { attendees: ["A", "B"], decisions: [] } },
+            keyPoints: ["k"],
+            actionItems: [],
+        });
+        const result = parseSummaryResponse(raw);
+        // The non-string summary must never reach encryptText; with usable
+        // points present we keep an empty summary and surface the points,
+        // rather than dumping the raw JSON blob as the summary text.
+        expect(typeof result.summary).toBe("string");
+        expect(result.summary).toBe("");
+        expect(result.keyPoints).toEqual(["k"]);
+    });
+
+    it("falls back to raw text when JSON has no usable content at all", () => {
+        // Non-string summary AND no points -> nothing usable, so show the
+        // raw model output instead of a blank summary.
+        const raw = JSON.stringify({
+            summary: { nested: "object" },
+            keyPoints: [],
+            actionItems: [],
+        });
+        const result = parseSummaryResponse(raw);
+        expect(result.summary).toBe(raw);
+    });
+
+    it("keeps a deliberately empty summary when points are present", () => {
+        // A 'bullet points only' custom prompt may return summary:"" with
+        // populated keyPoints — that empty summary must be preserved, not
+        // replaced by the raw JSON.
+        const raw = JSON.stringify({
+            summary: "",
+            keyPoints: ["a", "b"],
+            actionItems: [],
+        });
+        const result = parseSummaryResponse(raw);
+        expect(result.summary).toBe("");
+        expect(result.keyPoints).toEqual(["a", "b"]);
+    });
+
+    it("coerces non-string array elements to strings", () => {
+        const raw = JSON.stringify({
+            summary: "ok",
+            keyPoints: [{ point: "nested" }, "plain"],
+            actionItems: [42],
+        });
+        const result = parseSummaryResponse(raw);
+        expect(result.keyPoints).toEqual(['{"point":"nested"}', "plain"]);
+        expect(result.actionItems).toEqual(["42"]);
+        expect(result.keyPoints.every((p) => typeof p === "string")).toBe(true);
+    });
+
+    it("treats non-JSON output as the summary text", () => {
+        const raw = "Just a plain prose summary, no JSON at all.";
+        expect(parseSummaryResponse(raw)).toEqual({
+            summary: "Just a plain prose summary, no JSON at all.",
+            keyPoints: [],
+            actionItems: [],
+        });
+    });
+
+    it("omits the summary key but keeps points -> empty summary, points surfaced", () => {
+        const raw = JSON.stringify({ keyPoints: ["only points"] });
+        const result = parseSummaryResponse(raw);
+        expect(result.summary).toBe("");
+        expect(result.keyPoints).toEqual(["only points"]);
+    });
+
+    it("defaults missing arrays to empty", () => {
+        const raw = JSON.stringify({ summary: "just a summary" });
+        expect(parseSummaryResponse(raw)).toEqual({
+            summary: "just a summary",
+            keyPoints: [],
+            actionItems: [],
+        });
+    });
+
+    it("handles a non-string array (non-array keyPoints) gracefully", () => {
+        const raw = JSON.stringify({
+            summary: "s",
+            keyPoints: "not an array",
+            actionItems: null,
+        });
+        expect(parseSummaryResponse(raw)).toEqual({
+            summary: "s",
+            keyPoints: [],
+            actionItems: [],
+        });
+    });
+});


### PR DESCRIPTION
## Description

Custom **summary** prompts are a half-wired feature today: the backend and data model fully support them (`summaryPrompt: { selectedPrompt, customPrompts }` round-trips through `/api/settings/user`, and the summary route already resolves a custom id via `getSummaryPromptById`), but there is no UI to create or select one — so the capability is unreachable for self-hosters. Worse, the existing Settings → Summary dropdown writes `customPrompts: []` on **every** preset change, silently wiping any custom prompts stored via the API.

This PR makes custom summary prompts reachable and seamless, mirroring the existing **title** prompt manager.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #199

## Changes Made

- **`SummaryPromptManager`** (new) — mirrors `prompt-manager.tsx`: an active selector across presets + customs, create/edit/view/delete with confirm-delete. Every write preserves `customPrompts`, fixing the data-loss bug in the old dropdown.
- **Settings → Summary** — replaces the broken default-summary dropdown with `<SummaryPromptManager />`; keeps the AI output-language selector.
- **`useTranscriptionSummary`** — seeds `summaryPreset` from the saved default and returns `customPrompts`, so the per-recording dropdowns list customs alongside presets. A `userPickedPreset` guard stops the on-mount settings fetch from clobbering a selection made while it was in flight.
- **Per-recording dropdowns** (`recordings/transcription-section`, `dashboard/transcription-panel`) — render custom prompts after the presets.
- **Seamless authoring** — the server now owns the output contract and the transcript, so a custom prompt carries *intent only*:
  - `buildSummarySystemMessage` states the canonical `{ summary, keyPoints, actionItems }` contract in the system message (it was previously only "respond with valid JSON", with the shape buried in each preset body), so a custom prompt no longer has to restate the JSON schema.
  - `buildSummaryUserPrompt` substitutes every `{transcription}` placeholder and **appends** the transcript when a custom prompt omits it, so it is never silently dropped.
  - The custom-prompt modal copy now describes plain-intent authoring.
- **`parseSummaryResponse`** (extracted, hardened) — guarantees `summary` is always a string (a non-string value previously threw inside `encryptText`, surfacing as an opaque 500 with no summary stored), coerces array elements to strings, preserves a deliberately-empty summary when points are present, and falls back to the raw model output only when nothing usable was returned. The summary route's stored-config read is also guarded with `Array.isArray` on `customPrompts`.

All new helpers are provider-agnostic (no `response_format` dependency — works with any OpenAI-compatible backend).

## Screenshots (if applicable)

UI changes (Settings → Summary):
- "Default summary prompt" selector now lists presets **and** custom prompts.
- New "Custom Prompts" section with Add / View / Edit / Delete.
- Create/Edit modal asks for plain intent; no JSON schema required.

## Testing

### Test Environment
- OS: macOS (dev) + Linux/Docker (deployed)
- Runtime: Bun
- Browser: Chrome (UI changes verified)

### Test Steps
1. `bun run test` — three new suites (`summary-prompt-config`, `summary-prompt-build`, `summary-response-parse`) covering the storage/resolver contract, the request scaffolding (placeholder substitution + append-when-missing, system-message contract), and the response parser (object summary → never crashes; empty summary preserved when points exist; raw-text fallback; non-string array element coercion).
2. Settings → Summary: create a custom prompt, set it as the default, reload — it persists; toggling a preset no longer wipes it.
3. Open a recording: the summary dropdown lists the custom prompt; selecting it and summarizing produces a clean result. A prompt that returns a non-`{summary,keyPoints,actionItems}` shape degrades gracefully instead of 500-ing.

> Note: the full suite has three pre-existing failures in `src/tests/regressions/{59,70,90}*` (a zod import quirk in `src/lib/env.ts` under vitest) that also fail on `main` and are unrelated to this change.

## Checklist

- [x] My code follows the style guidelines of this project (`bun run format-and-lint` clean)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (in-app modal copy)
- [x] My changes generate no new warnings or errors (`bun run type-check` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (modulo the pre-existing unrelated failures noted above)
