### PR TITLE
fix(settings): keep webhook actions visible for long URLs

### DIFF
--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -183,7 +183,7 @@ function WebhookRow({
                     Last delivery: {formatWebhookDate(webhook.lastDeliveryAt)}
                 </p>
             </div>
-            <div className="flex shrink-0 gap-2">
+            <div className="flex gap-2">
                 <Button
                     variant="outline"
                     size="sm"

--- a/src/components/settings/webhooks-section.tsx
+++ b/src/components/settings/webhooks-section.tsx
@@ -145,71 +145,68 @@ function WebhookRow({
     onShowDeliveries: (webhook: WebhookEndpoint) => void;
 }) {
     return (
-        <div className="space-y-3 rounded-lg border p-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="min-w-0 space-y-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <h3 className="truncate font-medium">
-                            {webhook.description || webhook.url}
-                        </h3>
-                        <span
-                            className={`rounded border px-2 py-0.5 text-xs ${
-                                webhook.enabled
-                                    ? "text-primary"
-                                    : "text-muted-foreground"
-                            }`}
-                        >
-                            {webhook.enabled ? "Enabled" : "Disabled"}
+        <div className="grid gap-3 rounded-lg border p-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+            <div className="min-w-0 space-y-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <h3 className="min-w-0 truncate font-medium">
+                        {webhook.description || webhook.url}
+                    </h3>
+                    <span
+                        className={`rounded border px-2 py-0.5 text-xs ${
+                            webhook.enabled
+                                ? "text-primary"
+                                : "text-muted-foreground"
+                        }`}
+                    >
+                        {webhook.enabled ? "Enabled" : "Disabled"}
+                    </span>
+                    {webhook.lastDeliveryStatus && (
+                        <span className="rounded border px-2 py-0.5 text-xs">
+                            {webhook.lastDeliveryStatus}
                         </span>
-                        {webhook.lastDeliveryStatus && (
-                            <span className="rounded border px-2 py-0.5 text-xs">
-                                {webhook.lastDeliveryStatus}
-                            </span>
-                        )}
-                    </div>
-                    <p className="truncate font-mono text-xs text-muted-foreground">
-                        {webhook.url}
-                    </p>
-                    <div className="flex flex-wrap gap-1">
-                        {webhook.events.map((event) => (
-                            <span
-                                key={event}
-                                className="rounded bg-muted px-2 py-0.5 text-xs"
-                            >
-                                {event}
-                            </span>
-                        ))}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                        Last delivery:{" "}
-                        {formatWebhookDate(webhook.lastDeliveryAt)}
-                    </p>
+                    )}
                 </div>
-                <div className="flex gap-2">
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onShowDeliveries(webhook)}
-                    >
-                        Deliveries
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={() => onEdit(webhook)}
-                        aria-label="Edit webhook"
-                    >
-                        <Pencil className="size-4" />
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={() => onDelete(webhook.id)}
-                        aria-label="Delete webhook"
-                    >
-                        <Trash2 className="size-4 text-destructive" />
-                    </Button>
+                <p className="break-all font-mono text-xs text-muted-foreground">
+                    {webhook.url}
+                </p>
+                <div className="flex flex-wrap gap-1">
+                    {webhook.events.map((event) => (
+                        <span
+                            key={event}
+                            className="rounded bg-muted px-2 py-0.5 text-xs"
+                        >
+                            {event}
+                        </span>
+                    ))}
                 </div>
+                <p className="text-xs text-muted-foreground">
+                    Last delivery: {formatWebhookDate(webhook.lastDeliveryAt)}
+                </p>
+            </div>
+            <div className="flex shrink-0 gap-2">
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onShowDeliveries(webhook)}
+                >
+                    Deliveries
+                </Button>
+                <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => onEdit(webhook)}
+                    aria-label="Edit webhook"
+                >
+                    <Pencil className="size-4" />
+                </Button>
+                <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => onDelete(webhook.id)}
+                    aria-label="Delete webhook"
+                >
+                    <Trash2 className="size-4 text-destructive" />
+                </Button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Description

Fixes the webhook settings row layout so long unbroken destination URLs wrap inside the row instead of pushing the edit/delete actions out of view.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #212

## Changes Made

- Constrained webhook row content with a `minmax(0, 1fr)` grid column.
- Allowed long webhook URLs to wrap with `break-all`.
- Kept webhook action buttons in a non-shrinking action column.

## Screenshots (if applicable)

Not included.

## Testing

### Test Environment
- OS: macOS
- Node version: Not checked
- Browser (if UI changes): Not run in browser

### Test Steps
1. Ran `./node_modules/.bin/biome check . --write`.
2. Ran `./node_modules/.bin/tsc --noEmit`.
3. Attempted `pnpm format-and-lint:fix && pnpm type-check`, but pnpm failed before scripts ran due ignored dependency build scripts in this environment.

## Checklist

- [ ] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

No database changes.

## Breaking Changes

None.

## Additional Notes

No deploy-surface impact: no schema, env var, docker-compose, or installer changes.

## For Reviewers

- Confirm webhook actions remain visible for long localhost/n8n/Zapier-style destination URLs.
- Confirm the row still looks correct on narrow settings layouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents webhook action buttons from being pushed off-screen by long destination URLs in Settings. Long URLs now wrap while actions stay visible on the right. Fixes #212.

- **Bug Fixes**
  - Switched row to a two-column grid (`minmax(0,1fr)` content + non-shrinking actions) and removed a redundant shrink class.
  - Applied `break-all` so very long URLs wrap inside the row.

<sup>Written for commit 8216babbcc6cfeaab01fcd2a5271ede297d115de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

