### PR TITLE
fix(auth): rate-limit email/password endpoints

### DIFF
--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,13 @@
 import { toNextJsHandler } from "better-auth/next-js";
 import { auth } from "@/lib/auth";
+import { enforceAuthRateLimit } from "@/lib/auth-rate-limit";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const handlers = toNextJsHandler(auth);
+
+export const GET = handlers.GET;
+
+export async function POST(request: Request): Promise<Response> {
+    const limited = await enforceAuthRateLimit(request);
+    if (limited) return limited;
+    return handlers.POST(request);
+}

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -37,10 +37,21 @@ export function ForgotPasswordForm({
             // We intentionally don't surface the better-auth response: we
             // always show the same success message so this endpoint can't
             // be used to enumerate which emails have accounts.
-            await forgetPassword({
+            const result = await forgetPassword({
                 email,
                 redirectTo: "/reset-password",
             });
+            // Rate-limit rejections (429) are a request-volume signal, not an
+            // account-existence signal, so surfacing them doesn't leak
+            // enumeration. Show the limiter's message instead of a false
+            // "check your email" when no email was actually sent.
+            if (result?.error?.status === 429) {
+                toast.error(
+                    result.error.message ||
+                        "Too many requests. Please wait a moment and try again.",
+                );
+                return;
+            }
             setSubmitted(true);
         } catch (error) {
             // Network-level failures still get surfaced -- those aren't an

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,11 +1,22 @@
-import { env } from "./lib/env";
-
 type WebhookWorkerModule = {
     startWebhookWorker: () => void;
 };
 
+type EnvModule = {
+    env: {
+        IS_HOSTED: boolean;
+        RATE_LIMIT_TRUST_PROXY_HEADERS?: boolean;
+    };
+};
+
 export async function register() {
     if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+    // Deferred require (matches the worker import below): a top-level
+    // `import { env }` would run full env validation at module load in every
+    // runtime -- including edge, where this hook must no-op -- before the
+    // guard above. Loading it here keeps validation inside the nodejs branch.
+    const { env } = require("./lib/env") as EnvModule;
 
     // Per-IP auth rate limiting needs a trustworthy client IP. When proxy
     // headers aren't trusted, `getClientIp` returns "unknown" and the per-IP

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,26 @@
+import { env } from "./lib/env";
+
 type WebhookWorkerModule = {
     startWebhookWorker: () => void;
 };
 
 export async function register() {
     if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+    // Per-IP auth rate limiting needs a trustworthy client IP. When proxy
+    // headers aren't trusted, `getClientIp` returns "unknown" and the per-IP
+    // cap on /sign-in, /sign-up and /reset-password is skipped to avoid
+    // collapsing every client into one cross-user-lockout bucket. Warn loudly
+    // at startup so a self-host operator knows credential-stuffing protection
+    // on those routes is inactive until they front the app with a proxy that
+    // sets X-Forwarded-For (or cf-connecting-ip / x-real-ip) and set
+    // RATE_LIMIT_TRUST_PROXY_HEADERS=true. (/forget-password keeps its
+    // IP-independent per-email cap regardless.)
+    if (!env.IS_HOSTED && env.RATE_LIMIT_TRUST_PROXY_HEADERS !== true) {
+        console.warn(
+            "[rate-limit] RATE_LIMIT_TRUST_PROXY_HEADERS is not true: per-IP rate limiting on sign-in/sign-up/reset-password is INACTIVE. Set it to true behind a trusted reverse proxy to enable credential-stuffing protection.",
+        );
+    }
 
     const { startWebhookWorker } =
         require("./lib/webhooks/worker") as WebhookWorkerModule;

--- a/src/lib/auth-rate-limit.ts
+++ b/src/lib/auth-rate-limit.ts
@@ -111,11 +111,24 @@ export async function enforceAuthRateLimit(
     const rule = RULES[path];
     if (!rule) return null;
 
-    const ipResult = await consumeRateLimitBucket(
-        `auth:ip:${path}:${getClientIp(request)}`,
-        { limit: rule.ipLimit, windowMs: WINDOW_MS },
-    );
-    if (!ipResult.allowed) return tooManyRequests(ipResult);
+    // Only enforce the per-IP cap when we can actually distinguish clients.
+    // `getClientIp` returns "unknown" when proxy-header trust is off
+    // (`RATE_LIMIT_TRUST_PROXY_HEADERS` unset, the self-host default) or the
+    // header is absent. Bucketing every client under one `unknown` key would
+    // turn a low auth limit into a trivial cross-user lockout: one actor
+    // burns the shared bucket and locks everyone out. Failing open on the IP
+    // dimension here is the safer default -- the per-email cap below is
+    // IP-independent and still guards the SMTP-burn vector, and operators who
+    // want per-IP auth throttling set `RATE_LIMIT_TRUST_PROXY_HEADERS=true`
+    // (already required under `IS_HOSTED`).
+    const clientIp = getClientIp(request);
+    if (clientIp !== "unknown") {
+        const ipResult = await consumeRateLimitBucket(
+            `auth:ip:${path}:${clientIp}`,
+            { limit: rule.ipLimit, windowMs: WINDOW_MS },
+        );
+        if (!ipResult.allowed) return tooManyRequests(ipResult);
+    }
 
     if (rule.emailLimit !== undefined) {
         const email = await readEmail(request);

--- a/src/lib/auth-rate-limit.ts
+++ b/src/lib/auth-rate-limit.ts
@@ -1,0 +1,132 @@
+import { ErrorCode } from "@/lib/errors";
+import {
+    consumeRateLimitBucket,
+    getClientIp,
+    type RateLimitResult,
+} from "@/lib/rate-limit";
+
+/**
+ * Rate limiting for better-auth's email/password endpoints.
+ *
+ * better-auth ships its own limiter, but it defaults to an in-memory store
+ * that is per-process -- useless under the hosted multi-process deployment
+ * (see AGENTS.md hosted invariants). Instead we reuse the project's
+ * DB-backed bucket store (`consumeRateLimitBucket`), the same primitive the
+ * `/api/v1` surface and plaud sync use. One rate-limit mechanism, multi-
+ * process safe by default, fail-open on bucket-store outage.
+ *
+ * Threat model:
+ * - `/forget-password` triggers outbound SMTP. An attacker hammering it
+ *   with one victim's address burns sender quota and bounce-spams the
+ *   victim, hurting the instance's mail reputation. Needs a per-EMAIL cap,
+ *   not just per-IP, because a distributed attacker rotates IPs.
+ * - `/sign-in/email` is credential-stuffing surface (per-IP).
+ * - `/sign-up/email` is spam-account surface (per-IP).
+ * - `/reset-password` consumes a reset token (per-IP).
+ */
+
+const WINDOW_MS = 60_000;
+
+interface AuthRateRule {
+    /** Max requests per client IP per window. */
+    ipLimit: number;
+    /**
+     * Optional max requests per target email per window. Set on paths that
+     * trigger outbound email so a single victim can't be targeted from many
+     * IPs. The email is read from the JSON request body.
+     */
+    emailLimit?: number;
+}
+
+/** Keyed by the better-auth endpoint path (the part after `/api/auth`). */
+const RULES: Record<string, AuthRateRule> = {
+    "/sign-in/email": { ipLimit: 10 },
+    "/sign-up/email": { ipLimit: 5 },
+    "/forget-password": { ipLimit: 5, emailLimit: 3 },
+    "/reset-password": { ipLimit: 5 },
+};
+
+function authPath(request: Request): string {
+    const { pathname } = new URL(request.url);
+    const marker = "/api/auth";
+    const index = pathname.indexOf(marker);
+    return index === -1 ? pathname : pathname.slice(index + marker.length);
+}
+
+async function readEmail(request: Request): Promise<string | null> {
+    // Clone so better-auth still gets an unconsumed body downstream.
+    try {
+        const body = (await request.clone().json()) as unknown;
+        if (
+            body &&
+            typeof body === "object" &&
+            "email" in body &&
+            typeof (body as { email: unknown }).email === "string"
+        ) {
+            const email = (body as { email: string }).email
+                .trim()
+                .toLowerCase();
+            return email.length > 0 ? email : null;
+        }
+    } catch {
+        // Malformed/empty body -- let better-auth reject it; no email bucket.
+    }
+    return null;
+}
+
+function tooManyRequests(result: RateLimitResult): Response {
+    const retryAfter = Math.max(
+        1,
+        Math.ceil((result.resetAt.getTime() - Date.now()) / 1000),
+    );
+
+    return Response.json(
+        {
+            message: `Too many attempts. Please wait ${retryAfter}s and try again.`,
+            code: ErrorCode.RATE_LIMITED,
+        },
+        {
+            status: 429,
+            headers: {
+                "Retry-After": retryAfter.toString(),
+                "X-RateLimit-Limit": result.limit.toString(),
+                "X-RateLimit-Remaining": result.remaining.toString(),
+                "X-RateLimit-Reset": Math.ceil(
+                    result.resetAt.getTime() / 1000,
+                ).toString(),
+            },
+        },
+    );
+}
+
+/**
+ * Enforce per-IP (and where configured, per-email) rate limits on
+ * better-auth email/password endpoints. Returns a 429 `Response` when the
+ * request should be rejected, or `null` to let it through.
+ */
+export async function enforceAuthRateLimit(
+    request: Request,
+): Promise<Response | null> {
+    const path = authPath(request);
+    const rule = RULES[path];
+    if (!rule) return null;
+
+    const ipResult = await consumeRateLimitBucket(
+        `auth:ip:${path}:${getClientIp(request)}`,
+        { limit: rule.ipLimit, windowMs: WINDOW_MS },
+    );
+    if (!ipResult.allowed) return tooManyRequests(ipResult);
+
+    if (rule.emailLimit !== undefined) {
+        const email = await readEmail(request);
+        if (email) {
+            const emailResult = await consumeRateLimitBucket(
+                `auth:email:${path}:${email}`,
+                { limit: rule.emailLimit, windowMs: WINDOW_MS },
+            );
+            if (!emailResult.allowed) return tooManyRequests(emailResult);
+        }
+    }
+
+    return null;
+}

--- a/src/lib/auth-rate-limit.ts
+++ b/src/lib/auth-rate-limit.ts
@@ -80,9 +80,15 @@ function tooManyRequests(result: RateLimitResult): Response {
         Math.ceil((result.resetAt.getTime() - Date.now()) / 1000),
     );
 
+    const text = `Too many attempts. Please wait ${retryAfter}s and try again.`;
     return Response.json(
         {
-            message: `Too many attempts. Please wait ${retryAfter}s and try again.`,
+            // `error` is the app's standard envelope field (AppErrorJSON); a
+            // direct API client expecting `{ error, code }` reads it. `message`
+            // is kept so better-auth's better-fetch surfaces it as
+            // `result.error.message` in the auth forms.
+            error: text,
+            message: text,
             code: ErrorCode.RATE_LIMITED,
         },
         {

--- a/src/tests/regressions/85-auth-rate-limit.test.ts
+++ b/src/tests/regressions/85-auth-rate-limit.test.ts
@@ -93,6 +93,12 @@ describe("enforceAuthRateLimit", () => {
         const retryAfter = result?.headers.get("Retry-After");
         expect(retryAfter).toBeTruthy();
         expect(Number(retryAfter)).toBeGreaterThan(0);
+        // Body follows the app envelope (`error` + `code`) and keeps `message`
+        // for better-auth's better-fetch -> result.error.message in the forms.
+        const body = (await result?.json()) as Record<string, unknown>;
+        expect(body.code).toBe("RATE_LIMITED");
+        expect(typeof body.error).toBe("string");
+        expect(body.message).toBe(body.error);
     });
 
     it("skips the per-IP bucket when the client IP is unknown (no cross-user lockout)", async () => {

--- a/src/tests/regressions/85-auth-rate-limit.test.ts
+++ b/src/tests/regressions/85-auth-rate-limit.test.ts
@@ -18,10 +18,11 @@ import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { RateLimitResult } from "@/lib/rate-limit";
 
 const consumeRateLimitBucket = vi.hoisted(() => vi.fn());
+const clientIp = vi.hoisted(() => ({ value: "198.51.100.1" }));
 
 vi.mock("@/lib/rate-limit", () => ({
     consumeRateLimitBucket,
-    getClientIp: () => "198.51.100.1",
+    getClientIp: () => clientIp.value,
 }));
 
 import { enforceAuthRateLimit } from "@/lib/auth-rate-limit";
@@ -55,6 +56,7 @@ function authRequest(path: string, body?: unknown): Request {
 describe("enforceAuthRateLimit", () => {
     beforeEach(() => {
         (consumeRateLimitBucket as Mock).mockReset();
+        clientIp.value = "198.51.100.1";
     });
 
     it("passes through unknown auth paths without touching the limiter", async () => {
@@ -91,6 +93,31 @@ describe("enforceAuthRateLimit", () => {
         const retryAfter = result?.headers.get("Retry-After");
         expect(retryAfter).toBeTruthy();
         expect(Number(retryAfter)).toBeGreaterThan(0);
+    });
+
+    it("skips the per-IP bucket when the client IP is unknown (no cross-user lockout)", async () => {
+        // Proxy-header trust off: every client resolves to "unknown". A shared
+        // low-limit IP bucket would let one actor lock everyone out, so the IP
+        // dimension fails open. forget-password still gets its per-email cap.
+        clientIp.value = "unknown";
+        (consumeRateLimitBucket as Mock).mockResolvedValue(allowed());
+
+        const signIn = await enforceAuthRateLimit(
+            authRequest("/sign-in/email", { email: "a@b.com", password: "x" }),
+        );
+        expect(signIn).toBeNull();
+        expect(consumeRateLimitBucket).not.toHaveBeenCalled();
+
+        const forget = await enforceAuthRateLimit(
+            authRequest("/forget-password", { email: "a@b.com" }),
+        );
+        expect(forget).toBeNull();
+        // only the email bucket runs, never an `auth:ip:...:unknown` bucket
+        expect(consumeRateLimitBucket).toHaveBeenCalledTimes(1);
+        expect(consumeRateLimitBucket).toHaveBeenCalledWith(
+            "auth:email:/forget-password:a@b.com",
+            expect.objectContaining({ limit: 3 }),
+        );
     });
 
     it("applies a per-email bucket on forget-password without consuming the body", async () => {

--- a/src/tests/regressions/85-auth-rate-limit.test.ts
+++ b/src/tests/regressions/85-auth-rate-limit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression coverage for issue #85: better-auth's email/password endpoints
+ * were entirely un-throttled. `enforceAuthRateLimit` wraps the
+ * `/api/auth/[...all]` POST handler and enforces per-IP (and, for the
+ * SMTP-triggering `/forget-password` path, per-email) limits using the
+ * project's DB-backed bucket store.
+ *
+ * Pinned behaviours:
+ *   1. Unknown auth paths pass through untouched (return null).
+ *   2. A known path under its IP limit passes through.
+ *   3. An exceeded IP limit returns 429 with a Retry-After header.
+ *   4. `/forget-password` applies a per-email bucket so a single victim
+ *      can't be targeted from rotating IPs, and reading the email does NOT
+ *      consume the request body (better-auth must still parse it).
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { RateLimitResult } from "@/lib/rate-limit";
+
+const consumeRateLimitBucket = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/rate-limit", () => ({
+    consumeRateLimitBucket,
+    getClientIp: () => "198.51.100.1",
+}));
+
+import { enforceAuthRateLimit } from "@/lib/auth-rate-limit";
+
+function allowed(): RateLimitResult {
+    return {
+        allowed: true,
+        limit: 10,
+        remaining: 9,
+        resetAt: new Date(Date.now() + 60_000),
+    };
+}
+
+function blocked(): RateLimitResult {
+    return {
+        allowed: false,
+        limit: 10,
+        remaining: 0,
+        resetAt: new Date(Date.now() + 60_000),
+    };
+}
+
+function authRequest(path: string, body?: unknown): Request {
+    return new Request(`https://example.com/api/auth${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body === undefined ? undefined : JSON.stringify(body),
+    });
+}
+
+describe("enforceAuthRateLimit", () => {
+    beforeEach(() => {
+        (consumeRateLimitBucket as Mock).mockReset();
+    });
+
+    it("passes through unknown auth paths without touching the limiter", async () => {
+        const result = await enforceAuthRateLimit(authRequest("/get-session"));
+        expect(result).toBeNull();
+        expect(consumeRateLimitBucket).not.toHaveBeenCalled();
+    });
+
+    it("allows a sign-in under the IP limit", async () => {
+        (consumeRateLimitBucket as Mock).mockResolvedValue(allowed());
+        const result = await enforceAuthRateLimit(
+            authRequest("/sign-in/email", {
+                email: "a@b.com",
+                password: "x",
+            }),
+        );
+        expect(result).toBeNull();
+        expect(consumeRateLimitBucket).toHaveBeenCalledWith(
+            "auth:ip:/sign-in/email:198.51.100.1",
+            expect.objectContaining({ limit: 10 }),
+        );
+    });
+
+    it("returns 429 with Retry-After when the IP limit is exceeded", async () => {
+        (consumeRateLimitBucket as Mock).mockResolvedValue(blocked());
+        const result = await enforceAuthRateLimit(
+            authRequest("/sign-in/email", {
+                email: "a@b.com",
+                password: "x",
+            }),
+        );
+        expect(result).not.toBeNull();
+        expect(result?.status).toBe(429);
+        const retryAfter = result?.headers.get("Retry-After");
+        expect(retryAfter).toBeTruthy();
+        expect(Number(retryAfter)).toBeGreaterThan(0);
+    });
+
+    it("applies a per-email bucket on forget-password without consuming the body", async () => {
+        (consumeRateLimitBucket as Mock)
+            .mockResolvedValueOnce(allowed()) // IP bucket
+            .mockResolvedValueOnce(blocked()); // email bucket
+
+        const request = authRequest("/forget-password", {
+            email: "Victim@Example.com",
+        });
+        const result = await enforceAuthRateLimit(request);
+
+        expect(result?.status).toBe(429);
+        // email is lowercased into the bucket key
+        expect(consumeRateLimitBucket).toHaveBeenLastCalledWith(
+            "auth:email:/forget-password:victim@example.com",
+            expect.objectContaining({ limit: 3 }),
+        );
+        // body must still be readable by better-auth downstream
+        await expect(request.json()).resolves.toEqual({
+            email: "Victim@Example.com",
+        });
+    });
+});


### PR DESCRIPTION
## Description

The better-auth email/password endpoints exposed under `/api/auth/[...all]` (`sign-in`, `sign-up`, `forget-password`, `reset-password`) were entirely un-throttled. The most abusable surface is `/forget-password`: it triggers outbound SMTP, so hammering it with a victim's address burns sender quota, bounce-spams the victim, and degrades the instance's mail reputation. Sign-in is open to credential stuffing.

This wraps the auth POST handler with the project's existing DB-backed rate-limit primitive (`consumeRateLimitBucket`) rather than enabling better-auth's built-in limiter, whose default in-memory store is per-process and therefore unsafe under the hosted multi-process deployment (see AGENTS.md hosted invariants). One rate-limit mechanism, multi-process safe, fail-open on bucket-store outage.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #85
Relates to #82

## Changes Made

- Add `src/lib/auth-rate-limit.ts`: `enforceAuthRateLimit()` keyed off `consumeRateLimitBucket`. Per-IP caps on `/sign-in/email` (10/min), `/sign-up/email` (5/min), `/reset-password` (5/min), `/forget-password` (5/min), plus a per-email cap (3/min) on `/forget-password` so a single victim can't be targeted from rotating IPs.
- Wrap POST in `src/app/api/auth/[...all]/route.ts` to run the limiter before `toNextJsHandler`, returning 429 + `Retry-After` on block. The request body is read via `request.clone()` so better-auth still parses it downstream.
- `src/components/auth/forgot-password-form.tsx`: surface 429 cleanly instead of falsely showing "check your email" when no mail was sent. The other three forms already render `result.error.message`, which carries the limiter's friendly text.
- Add regression test `src/tests/regressions/85-auth-rate-limit.test.ts`.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): n/a

### Test Steps
1. `npx vitest run src/tests/regressions/85-auth-rate-limit.test.ts` -> 4 passed (passthrough on unknown path, allow under limit, 429 with Retry-After on IP block, per-email block on forget-password without consuming the body).
2. `npx biome check` on changed files -> clean.
3. `npx tsc --noEmit` -> exit 0.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

None. No schema, migration, or new env vars (reuses `RATE_LIMIT_TRUST_PROXY_HEADERS`).

## Breaking Changes

None.

## Additional Notes

No new env vars introduced, so no README change required. better-auth's own global limiter (enabled in production) still sits underneath as a looser backstop; our interceptor runs first.

## For Reviewers

- Limit values in `RULES` (`src/lib/auth-rate-limit.ts`) -- are the per-IP/per-email windows reasonable defaults?
- Confirm the `request.clone()` read in `readEmail()` is the right way to avoid consuming the body before `toNextJsHandler`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DB-backed rate limiting to `better-auth` email/password endpoints to block abuse and protect SMTP quota, fixing #85. Surfaces 429s in the forgot-password form, aligns the 429 body with the app error envelope, and warns at startup when per-IP throttling is inactive; skips per-IP limits when the client IP is unknown to avoid cross-user lockouts.

- **Bug Fixes**
  - Wrapped `/api/auth/[...all]` POST with a DB-backed limiter (`consumeRateLimitBucket`), safe for multi-process deployments.
  - Limits: per-IP 10/min for `/sign-in/email`, 5/min for `/sign-up/email`, `/reset-password`, and `/forget-password`; `/forget-password` also has a per-email cap of 3/min.
  - Skips per-IP throttling when client IP is unknown; logs a startup warning if `RATE_LIMIT_TRUST_PROXY_HEADERS` is not true on self-host. Deferred env load inside the Node.js runtime guard in `instrumentation.ts` to avoid edge-time env validation.
  - Returns 429 with `Retry-After` and `X-RateLimit-*` headers; JSON matches the app envelope (`error`, `code`) while keeping `message` for `better-auth` forms. Reads the body via `request.clone()`. Updated forgot-password UI to show the limiter message on 429; added regression tests including the unknown-IP case.

<sup>Written for commit 444d9340eace9785777647e30683b8212c76d4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

