### PR TITLE
fix(ai): send full transcript to summary model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Google Gemini as a native transcription provider. Gemini's OpenAI-compatibility layer does not implement `POST /v1/audio/transcriptions`, so configuring a Gemini API key under the existing Whisper/chat styles couldn't work. New `gemini` transcription style routes audio through `@google/generative-ai`'s `generateContent` with `inlineData`. 20 MB inline-data limit applies; larger files error out cleanly (File API upload support is planned follow-up). Preset is selectable in Settings → AI Providers ([#176](https://github.com/riffado/riffado/pull/176) by [@amateo8282](https://github.com/amateo8282)).
 
+### Fixed
+
+- Long-meeting summaries no longer drop the end of the transcript. The summary endpoint hard-truncated transcripts to the first 8000 characters (~2000 tokens) before sending them to the model, silently discarding everything after — so end-of-call decisions and action items never reached the summary. The full transcript is now sent. If a transcript exceeds the configured model's context window, the provider error is surfaced as a clear 400 ("transcript too long, pick a larger-context model") instead of a generic 500 ([#213](https://github.com/riffado/riffado/issues/213)).
+
 ### Removed
 
 - Dropped the unused `storage_config` table. Storage has been configured at the instance level via env vars (`DEFAULT_STORAGE_TYPE`, `S3_*`, `LOCAL_STORAGE_PATH`) since v0.4.x; this table held orphan per-user S3 config rows that nothing has read or written since the move. Migration `0024_sour_serpent_society.sql` issues a `DROP TABLE ... CASCADE`. Self-hosters: if for any reason you still want the historical rows, dump them before running `pnpm db:migrate` ([#83](https://github.com/riffado/riffado/issues/83)).

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -183,7 +183,13 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         userSettingsRow?.aiOutputLanguage ?? null,
     );
 
-    const prompt = promptTemplate.replace("{transcription}", transcriptText);
+    // Use a replacement function so `$` sequences in the transcript (e.g.
+    // `$1`, `$&`, `$$`) are inserted verbatim instead of being interpreted
+    // as `String.prototype.replace` special patterns.
+    const prompt = promptTemplate.replace(
+        "{transcription}",
+        () => transcriptText,
+    );
 
     const baseSystem =
         "You are a helpful assistant that summarizes audio transcriptions. Always respond with valid JSON only, no markdown formatting or code fences.";

--- a/src/app/api/recordings/[id]/summary/route.ts
+++ b/src/app/api/recordings/[id]/summary/route.ts
@@ -173,13 +173,6 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
     // the LLM's input contract; ciphertext lives only in the DB.
     const transcriptText = decryptText(transcription.text);
 
-    // Truncate transcription if too long
-    const maxLength = 8000;
-    const truncatedTranscription =
-        transcriptText.length > maxLength
-            ? `${transcriptText.substring(0, maxLength)}...`
-            : transcriptText;
-
     // Apply AI output language directive (if configured) via the system
     // message rather than the user prompt. This separates concerns: the
     // user prompt carries the JSON-shape contract (English keys), the
@@ -190,10 +183,7 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
         userSettingsRow?.aiOutputLanguage ?? null,
     );
 
-    const prompt = promptTemplate.replace(
-        "{transcription}",
-        truncatedTranscription,
-    );
+    const prompt = promptTemplate.replace("{transcription}", transcriptText);
 
     const baseSystem =
         "You are a helpful assistant that summarizes audio transcriptions. Always respond with valid JSON only, no markdown formatting or code fences.";

--- a/src/lib/ai/generate-title.ts
+++ b/src/lib/ai/generate-title.ts
@@ -122,9 +122,12 @@ export async function generateTitleFromTranscription(
             userSettingsRow?.aiOutputLanguage ?? null,
         );
 
+        // Replacement function so `$` sequences in the transcript are
+        // inserted verbatim, not treated as `String.prototype.replace`
+        // special patterns.
         const prompt = promptTemplate.replace(
             "{transcription}",
-            truncatedTranscription,
+            () => truncatedTranscription,
         );
 
         const baseSystem =

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { APIError as OpenAIAPIError } from "openai";
 
 export enum ErrorCode {
     UNAUTHORIZED = "UNAUTHORIZED",
@@ -40,6 +41,7 @@ export enum ErrorCode {
     AI_PROVIDER_NOT_CONFIGURED = "AI_PROVIDER_NOT_CONFIGURED",
     AI_PROVIDER_API_ERROR = "AI_PROVIDER_API_ERROR",
     AI_RATE_LIMITED = "AI_RATE_LIMITED",
+    AI_CONTEXT_LENGTH_EXCEEDED = "AI_CONTEXT_LENGTH_EXCEEDED",
 
     RECORDING_NOT_FOUND = "RECORDING_NOT_FOUND",
     RECORDING_STREAM_INVALID_RANGE = "RECORDING_STREAM_INVALID_RANGE",
@@ -137,6 +139,38 @@ function attachErrorId(app: AppError): string {
 export function mapErrorToAppError(error: unknown): AppError {
     if (error instanceof AppError) {
         return error;
+    }
+
+    // Errors from any OpenAI-compatible provider (summary, title, etc.).
+    // Surface a useful message instead of a generic 500 -- the common case
+    // is an over-long transcript exceeding the model's context window.
+    if (error instanceof OpenAIAPIError) {
+        if (error.code === "context_length_exceeded") {
+            return new AppError(
+                ErrorCode.AI_CONTEXT_LENGTH_EXCEEDED,
+                "Transcript is too long for the selected model's context window. Choose a model with a larger context or a different provider.",
+                400,
+            );
+        }
+        if (error.status === 429) {
+            return new AppError(
+                ErrorCode.AI_RATE_LIMITED,
+                "Too many requests to the AI provider. Please try again later.",
+                429,
+            );
+        }
+        if (typeof error.status === "number" && error.status >= 500) {
+            return new AppError(
+                ErrorCode.UPSTREAM_BAD_RESPONSE,
+                "The AI provider is temporarily unavailable. Please try again later.",
+                502,
+            );
+        }
+        return new AppError(
+            ErrorCode.AI_PROVIDER_API_ERROR,
+            error.message || "The AI provider rejected the request.",
+            400,
+        );
     }
 
     if (error instanceof Error) {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -126,6 +126,31 @@ export function apiHandler<Ctx = unknown>(
     };
 }
 
+// Detect a context-window-overflow error across OpenAI-compatible
+// providers. OpenAI/Groq use the `context_length_exceeded` code, but
+// providers reached through a custom `baseURL` (OpenRouter, Together,
+// local servers) report it under different codes or only in the message,
+// so we also match on common message phrasing. Used purely for
+// classification; the outbound message is always our own fixed copy.
+function isContextLengthError(error: OpenAIAPIError): boolean {
+    const code = typeof error.code === "string" ? error.code.toLowerCase() : "";
+    if (
+        code.includes("context_length") ||
+        code.includes("context_window") ||
+        code === "string_above_max_length"
+    ) {
+        return true;
+    }
+    const message = (error.message ?? "").toLowerCase();
+    return (
+        message.includes("context length") ||
+        message.includes("context window") ||
+        message.includes("maximum context") ||
+        message.includes("too many tokens") ||
+        message.includes("reduce the length")
+    );
+}
+
 function attachErrorId(app: AppError): string {
     const existing = app.details?.errorId;
     if (typeof existing === "string" && existing.startsWith("err_")) {
@@ -145,30 +170,40 @@ export function mapErrorToAppError(error: unknown): AppError {
     // Surface a useful message instead of a generic 500 -- the common case
     // is an over-long transcript exceeding the model's context window.
     if (error instanceof OpenAIAPIError) {
-        if (error.code === "context_length_exceeded") {
+        const status =
+            typeof error.status === "number" ? error.status : undefined;
+
+        if (isContextLengthError(error)) {
             return new AppError(
                 ErrorCode.AI_CONTEXT_LENGTH_EXCEEDED,
                 "Transcript is too long for the selected model's context window. Choose a model with a larger context or a different provider.",
                 400,
             );
         }
-        if (error.status === 429) {
+        if (status === 429) {
             return new AppError(
                 ErrorCode.AI_RATE_LIMITED,
                 "Too many requests to the AI provider. Please try again later.",
                 429,
             );
         }
-        if (typeof error.status === "number" && error.status >= 500) {
+        // No HTTP status means a connection/transport failure (DNS, TLS,
+        // timeout) -- the provider was never reached. That is upstream
+        // unavailability, not a client error, so it maps the same as a
+        // provider 5xx.
+        if (status === undefined || status >= 500) {
             return new AppError(
                 ErrorCode.UPSTREAM_BAD_RESPONSE,
                 "The AI provider is temporarily unavailable. Please try again later.",
                 502,
             );
         }
+        // Other 4xx: a generic provider rejection. Never echo the raw
+        // provider message back to the client -- it can carry upstream
+        // request details (or key fragments). Keep the detail server-side.
         return new AppError(
             ErrorCode.AI_PROVIDER_API_ERROR,
-            error.message || "The AI provider rejected the request.",
+            "The AI provider rejected the request.",
             400,
         );
     }

--- a/src/tests/regressions/213-summary-truncation.test.ts
+++ b/src/tests/regressions/213-summary-truncation.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression test for issue #213:
+ *   "8000 limit for transcription crops important information from longer
+ *    meetings"
+ *
+ * The summary endpoint used to hard-truncate the decrypted transcript to
+ * the first 8000 characters before sending it to the model, silently
+ * dropping everything after — so end-of-call decisions and action items in
+ * long meetings never reached the summary. The fix removes the truncation
+ * and instead maps the provider's context-window error to a clear 400 so
+ * over-long transcripts fail loudly instead of being silently clipped.
+ *
+ * These tests cover:
+ *   1. POST /api/recordings/[id]/summary sends the FULL transcript to the
+ *      chat model (no 8000-char clip), including text past the old limit.
+ *   2. mapErrorToAppError turns an OpenAI `context_length_exceeded` error
+ *      into a 400 AI_CONTEXT_LENGTH_EXCEEDED instead of a generic 500, and
+ *      maps the other provider failure classes (429 / 5xx / generic 4xx).
+ */
+
+import { APIError } from "openai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCode, mapErrorToAppError } from "@/lib/errors";
+
+// Capture the chat-completion request without a real provider call.
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+// Keep the real `APIError` (so `instanceof` in errors.ts works) but swap
+// the OpenAI client for a stub that records the request params.
+vi.mock("openai", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("openai")>();
+    return {
+        ...actual,
+        OpenAI: class {
+            chat = { completions: { create: createMock } };
+        },
+        default: class {
+            chat = { completions: { create: createMock } };
+        },
+    };
+});
+
+// Identity encryption — the route decrypts the stored transcript before
+// building the prompt; we assert on the plaintext it forwards.
+vi.mock("@/lib/encryption", () => ({
+    decrypt: (v: string) => v,
+}));
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: (v: string) => v,
+    encryptText: (v: string) => v,
+    decryptJsonField: <T>(v: T) => v,
+    encryptJsonField: <T>(v: T) => v,
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn(async () => ({ user: { id: "user-1" } })),
+}));
+
+// Queue of rows consumed (in order) by each `.limit(1)` select.
+const selectResults: unknown[][] = [];
+
+function selectChain() {
+    const c = {
+        from: () => c,
+        where: () => c,
+        for: () => c,
+        orderBy: () => c,
+        limit: () => Promise.resolve(selectResults.shift() ?? []),
+    };
+    return c;
+}
+
+const tx = {
+    select: () => selectChain(),
+    insert: () => ({ values: () => Promise.resolve() }),
+    update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+};
+
+vi.mock("@/db", () => ({
+    db: {
+        select: () => selectChain(),
+        transaction: (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+    },
+}));
+
+describe("POST /api/recordings/[id]/summary — no transcript truncation (#213)", () => {
+    beforeEach(() => {
+        createMock.mockReset();
+        selectResults.length = 0;
+    });
+
+    it("forwards the entire transcript to the model, including text past the old 8000-char limit", async () => {
+        // > 8000 chars, with unique markers at the very start and very end.
+        // The old code clipped at 8000, so END_MARKER would have been lost.
+        const transcript = `START_MARKER ${"x".repeat(20000)} END_MARKER`;
+        expect(transcript.length).toBeGreaterThan(8000);
+
+        selectResults.push(
+            [{ id: "rec-1", userId: "user-1", deletedAt: null }], // recording
+            [{ recordingId: "rec-1", userId: "user-1", text: transcript }], // transcription
+            [{ summaryPrompt: null, aiOutputLanguage: null }], // userSettings
+            [
+                {
+                    apiKey: "enc-key",
+                    baseUrl: "",
+                    provider: "openai",
+                    defaultModel: "gpt-4o-mini",
+                    isDefaultEnhancement: true,
+                    userId: "user-1",
+                },
+            ], // enhancement credentials
+            [], // transcription credentials (unused)
+            [{ deletedAt: null }], // still-active re-check inside the tx
+            [], // no existing enhancement -> insert path
+        );
+
+        createMock.mockResolvedValue({
+            choices: [
+                {
+                    message: {
+                        content: JSON.stringify({
+                            summary: "s",
+                            keyPoints: [],
+                            actionItems: [],
+                        }),
+                    },
+                },
+            ],
+        });
+
+        const { POST } = await import(
+            "@/app/api/recordings/[id]/summary/route"
+        );
+
+        const request = new Request(
+            "http://localhost/api/recordings/rec-1/summary",
+            {
+                method: "POST",
+                body: JSON.stringify({}),
+                headers: { "Content-Type": "application/json" },
+            },
+        );
+        const res = await POST(request, {
+            params: Promise.resolve({ id: "rec-1" }),
+        });
+
+        expect(res.status).toBe(200);
+        expect(createMock).toHaveBeenCalledTimes(1);
+
+        const params = createMock.mock.calls[0][0] as {
+            messages: { role: string; content: string }[];
+        };
+        const userMessage = params.messages.find((m) => m.role === "user");
+        expect(userMessage).toBeDefined();
+        const prompt = userMessage?.content ?? "";
+
+        // Both ends of the transcript survive — proves no mid-transcript clip.
+        expect(prompt).toContain("START_MARKER");
+        expect(prompt).toContain("END_MARKER");
+        // And it's not silently shortened to the old ~8000-char ceiling.
+        expect(prompt.length).toBeGreaterThan(20000);
+        expect(prompt).not.toContain(`${"x".repeat(20)}...`);
+    });
+});
+
+describe("mapErrorToAppError — OpenAI provider errors (#213)", () => {
+    function apiError(status: number, code: string | undefined) {
+        return new APIError(
+            status,
+            code
+                ? { code, message: `provider says ${code}` }
+                : { message: "boom" },
+            undefined,
+            undefined,
+        );
+    }
+
+    it("maps context_length_exceeded to 400 AI_CONTEXT_LENGTH_EXCEEDED", () => {
+        const app = mapErrorToAppError(
+            apiError(400, "context_length_exceeded"),
+        );
+        expect(app.statusCode).toBe(400);
+        expect(app.code).toBe(ErrorCode.AI_CONTEXT_LENGTH_EXCEEDED);
+    });
+
+    it("maps 429 to AI_RATE_LIMITED", () => {
+        const app = mapErrorToAppError(apiError(429, "rate_limit_exceeded"));
+        expect(app.statusCode).toBe(429);
+        expect(app.code).toBe(ErrorCode.AI_RATE_LIMITED);
+    });
+
+    it("maps provider 5xx to a 502 upstream error", () => {
+        const app = mapErrorToAppError(apiError(503, undefined));
+        expect(app.statusCode).toBe(502);
+        expect(app.code).toBe(ErrorCode.UPSTREAM_BAD_RESPONSE);
+    });
+
+    it("maps a generic 4xx to 400 AI_PROVIDER_API_ERROR", () => {
+        const app = mapErrorToAppError(apiError(400, "invalid_request_error"));
+        expect(app.statusCode).toBe(400);
+        expect(app.code).toBe(ErrorCode.AI_PROVIDER_API_ERROR);
+    });
+});

--- a/src/tests/regressions/213-summary-truncation.test.ts
+++ b/src/tests/regressions/213-summary-truncation.test.ts
@@ -20,6 +20,13 @@
 
 import { APIError } from "openai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    aiEnhancements,
+    apiCredentials,
+    recordings,
+    transcriptions,
+    userSettings,
+} from "@/db/schema";
 import { ErrorCode, mapErrorToAppError } from "@/lib/errors";
 
 // Capture the chat-completion request without a real provider call.
@@ -56,16 +63,25 @@ vi.mock("@/lib/auth-server", () => ({
     requireApiSession: vi.fn(async () => ({ user: { id: "user-1" } })),
 }));
 
-// Queue of rows consumed (in order) by each `.limit(1)` select.
-const selectResults: unknown[][] = [];
+// Per-table result queues keyed by the Drizzle table object the route
+// passes to `.from(...)`. Keying by table (rather than one global
+// positional array) keeps the fixture order-independent across tables:
+// adding/removing/reordering a select on one table can't silently shift
+// the rows returned for another. Tables queried more than once
+// (apiCredentials, recordings) still consume their own queue in order.
+const selectResults = new Map<unknown, unknown[][]>();
 
 function selectChain() {
+    let table: unknown;
     const c = {
-        from: () => c,
+        from: (t: unknown) => {
+            table = t;
+            return c;
+        },
         where: () => c,
         for: () => c,
         orderBy: () => c,
-        limit: () => Promise.resolve(selectResults.shift() ?? []),
+        limit: () => Promise.resolve(selectResults.get(table)?.shift() ?? []),
     };
     return c;
 }
@@ -86,19 +102,35 @@ vi.mock("@/db", () => ({
 describe("POST /api/recordings/[id]/summary — no transcript truncation (#213)", () => {
     beforeEach(() => {
         createMock.mockReset();
-        selectResults.length = 0;
+        selectResults.clear();
     });
 
     it("forwards the entire transcript to the model, including text past the old 8000-char limit", async () => {
         // > 8000 chars, with unique markers at the very start and very end.
         // The old code clipped at 8000, so END_MARKER would have been lost.
-        const transcript = `START_MARKER ${"x".repeat(20000)} END_MARKER`;
+        // The `$&$1$$` sequence guards the `String.prototype.replace`
+        // special-pattern bug: a string replacement would mangle it; a
+        // replacement function inserts it verbatim.
+        const dollarMarker = "DOLLAR_$&$1$$_MARKER";
+        const transcript = `START_MARKER ${"x".repeat(20000)} ${dollarMarker} END_MARKER`;
         expect(transcript.length).toBeGreaterThan(8000);
 
-        selectResults.push(
-            [{ id: "rec-1", userId: "user-1", deletedAt: null }], // recording
-            [{ recordingId: "rec-1", userId: "user-1", text: transcript }], // transcription
-            [{ summaryPrompt: null, aiOutputLanguage: null }], // userSettings
+        // recordings is selected twice: the initial lookup and the
+        // still-active re-check inside the upsert transaction.
+        selectResults.set(recordings, [
+            [{ id: "rec-1", userId: "user-1", deletedAt: null }],
+            [{ deletedAt: null }],
+        ]);
+        selectResults.set(transcriptions, [
+            [{ recordingId: "rec-1", userId: "user-1", text: transcript }],
+        ]);
+        selectResults.set(userSettings, [
+            [{ summaryPrompt: null, aiOutputLanguage: null }],
+        ]);
+        // apiCredentials is selected twice: default-enhancement then
+        // default-transcription. The enhancement row wins, so the second
+        // (transcription) query result is unused.
+        selectResults.set(apiCredentials, [
             [
                 {
                     apiKey: "enc-key",
@@ -108,11 +140,11 @@ describe("POST /api/recordings/[id]/summary — no transcript truncation (#213)"
                     isDefaultEnhancement: true,
                     userId: "user-1",
                 },
-            ], // enhancement credentials
-            [], // transcription credentials (unused)
-            [{ deletedAt: null }], // still-active re-check inside the tx
-            [], // no existing enhancement -> insert path
-        );
+            ],
+            [],
+        ]);
+        // No existing enhancement row -> insert path.
+        selectResults.set(aiEnhancements, [[]]);
 
         createMock.mockResolvedValue({
             choices: [
@@ -160,6 +192,8 @@ describe("POST /api/recordings/[id]/summary — no transcript truncation (#213)"
         // And it's not silently shortened to the old ~8000-char ceiling.
         expect(prompt.length).toBeGreaterThan(20000);
         expect(prompt).not.toContain(`${"x".repeat(20)}...`);
+        // `$` sequences survive verbatim (not interpreted by replace()).
+        expect(prompt).toContain(dollarMarker);
     });
 });
 
@@ -199,5 +233,50 @@ describe("mapErrorToAppError — OpenAI provider errors (#213)", () => {
         const app = mapErrorToAppError(apiError(400, "invalid_request_error"));
         expect(app.statusCode).toBe(400);
         expect(app.code).toBe(ErrorCode.AI_PROVIDER_API_ERROR);
+    });
+
+    it("does not echo the raw provider message on a generic 4xx", () => {
+        const app = mapErrorToAppError(
+            new APIError(
+                400,
+                {
+                    code: "invalid_request_error",
+                    message: "key sk-secret-1234 is invalid",
+                },
+                undefined,
+                undefined,
+            ),
+        );
+        expect(app.message).toBe("The AI provider rejected the request.");
+        expect(app.message).not.toContain("sk-secret");
+    });
+
+    it("maps a connection/transport failure (no HTTP status) to 502", () => {
+        // APIConnectionError / timeouts surface as an APIError with an
+        // undefined status -- the provider was never reached.
+        const app = mapErrorToAppError(
+            new APIError(undefined, undefined, "Connection error.", undefined),
+        );
+        expect(app.statusCode).toBe(502);
+        expect(app.code).toBe(ErrorCode.UPSTREAM_BAD_RESPONSE);
+    });
+
+    it("detects a provider context-window error reported only in the message", () => {
+        // A non-OpenAI provider returns 400 without the OpenAI-specific
+        // code, describing the overflow only in the message.
+        const app = mapErrorToAppError(
+            new APIError(
+                400,
+                {
+                    code: "invalid_request_error",
+                    message:
+                        "This model's maximum context length is 8192 tokens.",
+                },
+                undefined,
+                undefined,
+            ),
+        );
+        expect(app.statusCode).toBe(400);
+        expect(app.code).toBe(ErrorCode.AI_CONTEXT_LENGTH_EXCEEDED);
     });
 });


### PR DESCRIPTION
## Description

The summary endpoint hard-truncated decrypted transcripts to the first 8000 characters (~2000 tokens) before sending them to the chat model, silently dropping everything after. End-of-call decisions and action items in long meetings never reached the summary. This removes the truncation and sends the full transcript, and surfaces provider context-window errors clearly instead of as a generic 500.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #213

## Changes Made

- Remove the `maxLength = 8000` substring clip in `POST /api/recordings/[id]/summary`; the full decrypted transcript is now passed to the model.
- Add an OpenAI `APIError` branch to `mapErrorToAppError`: `context_length_exceeded` -> 400 `AI_CONTEXT_LENGTH_EXCEEDED`, 429 -> `AI_RATE_LIMITED`, 5xx -> 502 `UPSTREAM_BAD_RESPONSE`, other 4xx -> 400 `AI_PROVIDER_API_ERROR`. Lives in the shared error layer, so title generation and any future AI call benefit too.
- Add `AI_CONTEXT_LENGTH_EXCEEDED` to the `ErrorCode` enum.
- Add regression test `src/tests/regressions/213-summary-truncation.test.ts` (full-transcript forwarding + the four provider error mappings).
- CHANGELOG `### Fixed` entry under `[Unreleased]`.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): n/a

### Test Steps
1. `npx vitest run src/tests/regressions/213-summary-truncation.test.ts` - 5 passed
2. `npx tsc --noEmit` - clean
3. `npx biome check` on changed files - clean

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

None.

## Breaking Changes

None. Behavioral change: long transcripts that previously summarized from a silent 8000-char slice now use the full text. A transcript exceeding the configured model's context window now returns a clear 400 instead of a generic 500 (and instead of a silently clipped summary). No schema, env, or docker-compose impact.

## For Reviewers

- Error-mapping placement: the `OpenAIAPIError` branch sits at the top of `mapErrorToAppError`, before the generic `Error` message heuristics, so provider errors can't be misclassified.
- Confirm there's no other call site relying on the old 8000-char cap (title generation has its own separate 2000-char cap, intentionally left untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the full transcript to the summary model and improves provider error handling for clearer failures. Also fixes prompt interpolation so `$` sequences are preserved.

- **Bug Fixes**
  - Removed the 8000-char clip in `POST /api/recordings/[id]/summary`; the full decrypted transcript is now sent.
  - Hardened provider error mapping for `openai`-compatible APIs: added `AI_CONTEXT_LENGTH_EXCEEDED`, broadened context-window detection (code and message), map 429 → `AI_RATE_LIMITED`, 5xx and transport failures (no HTTP status) → 502 `UPSTREAM_BAD_RESPONSE`, other 4xx → 400 `AI_PROVIDER_API_ERROR`, and stop echoing raw upstream messages.
  - Fixed prompt interpolation in summary and `src/lib/ai/generate-title.ts` to insert transcripts via a replacement function so `$` sequences (`$1`, `$&`, `$$`) are passed verbatim.
  - Expanded regression tests to cover full-transcript forwarding, the above error mappings (incl. transport failures and message-only detection), and `$`-sequence handling.

<sup>Written for commit 18be6503700020de43dfff4672fccd1bf40b8276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

