### PR TITLE
feat(transcription): ship in-browser Whisper transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- In-browser transcription is now wired end to end. `BrowserTranscriber` (Whisper via Transformers.js / WebAssembly) previously had no callers and no storage route, so the advertised "free browser transcription" did nothing. Recordings now expose an **In browser** option (Whisper Tiny / Base / Small) that decodes audio to mono 16 kHz client-side, runs Whisper in a Web Worker, and persists only the resulting transcript through the same encrypted-at-rest path as server transcripts (`transcription_type: browser`). No API key, no audio leaves the device. New guide at `docs/guides/browser-transcription` ([#130](https://github.com/riffado/riffado/issues/130)).
 - Google Gemini as a native transcription provider. Gemini's OpenAI-compatibility layer does not implement `POST /v1/audio/transcriptions`, so configuring a Gemini API key under the existing Whisper/chat styles couldn't work. New `gemini` transcription style routes audio through `@google/generative-ai`'s `generateContent` with `inlineData`. 20 MB inline-data limit applies; larger files error out cleanly (File API upload support is planned follow-up). Preset is selectable in Settings → AI Providers ([#176](https://github.com/riffado/riffado/pull/176) by [@amateo8282](https://github.com/amateo8282)).
 
 ### Removed

--- a/content/docs/guides/browser-transcription.mdx
+++ b/content/docs/guides/browser-transcription.mdx
@@ -1,0 +1,65 @@
+---
+title: Browser transcription
+description: Free, private transcription that runs Whisper entirely in your browser — no API key, no audio upload.
+---
+
+Riffado can transcribe a recording without any AI provider configured,
+by running [Whisper](https://github.com/openai/whisper) directly in your
+browser via [Transformers.js](https://huggingface.co/docs/transformers.js)
+(WebAssembly). The model and the audio never leave your machine, and it
+costs nothing.
+
+This is the default zero-config path: if you haven't set up a provider,
+or you just want a quick transcript without spending API credits, use
+browser transcription.
+
+## How to use it
+
+On a recording's detail view, open the **In browser** dropdown next to
+the Transcribe button and pick a model:
+
+- **Whisper Tiny** — fastest, smallest download (~75 MB). Good for clear
+  speech and quick drafts.
+- **Whisper Base** — balanced (~145 MB). The recommended default.
+- **Whisper Small** — most accurate, largest download (~485 MB). Best
+  for noisy audio or accents.
+
+The first run with a given model downloads its weights. The browser
+caches them afterwards, so subsequent transcriptions with the same model
+skip the download.
+
+## What happens under the hood
+
+1. Riffado downloads the recording's audio from your own instance.
+2. The audio is decoded to mono 16 kHz PCM in your browser (Whisper's
+   native format).
+3. Whisper runs in a Web Worker so the UI stays responsive.
+4. Only the resulting transcript text is sent back to the server, where
+   it is stored exactly like a server-side transcript — encrypted at
+   rest, with a browser/model label, and an auto-generated title if you
+   have that enabled.
+
+No audio and no model weights ever touch a third-party server. Model
+weights are fetched once from the Hugging Face CDN; the audio is never
+uploaded anywhere.
+
+## Trade-offs
+
+- **Speed** scales with your device. Whisper Small on a long recording
+  can take several minutes on a laptop. For long meetings, a server-side
+  provider (see [AI providers](/docs/guides/ai-providers)) is faster.
+- **Accuracy** is lower than large hosted Whisper models. Tiny/Base are
+  draft-quality; Small is solid for most speech.
+- **First-run download** is large. Subsequent runs reuse the cached
+  model.
+- Requires a browser with WebAssembly and the Web Audio API (all current
+  desktop browsers; mobile works but is slower).
+
+## When to use which
+
+| Situation | Recommendation |
+| --- | --- |
+| No API key, want it free | Browser (Tiny/Base) |
+| Privacy-critical, nothing leaves the device | Browser, or a local provider (Ollama / LM Studio) |
+| Long recordings, want speed | Server-side provider |
+| Highest accuracy | Server-side large Whisper, or Browser Small |

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -3,6 +3,7 @@
     "pages": [
         "connect-plaud-account",
         "ai-providers",
+        "browser-transcription",
         "notifications",
         "automation-and-webhooks",
         "backup-and-restore"

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,27 @@ const nextConfig: NextConfig = {
         loaderFile: "./loader.ts",
         remotePatterns: [],
     },
+    // @xenova/transformers (in-browser Whisper transcription) lists
+    // `onnxruntime-node` and `sharp` as optional native deps it only
+    // uses on a Node server. We run it exclusively in a browser Web
+    // Worker (onnxruntime-web), so stub those out to keep the bundler
+    // from trying to resolve native binaries. Both the Turbopack (dev)
+    // and webpack (build) resolvers need the alias.
+    turbopack: {
+        resolveAlias: {
+            "onnxruntime-node": "./src/lib/transcription/empty-module.ts",
+            sharp: "./src/lib/transcription/empty-module.ts",
+        },
+    },
+    webpack: (config) => {
+        config.resolve = config.resolve ?? {};
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            "onnxruntime-node": false,
+            sharp: false,
+        };
+        return config;
+    },
 };
 
 const withMDX = createMDX({ outDir: "src/.source" });

--- a/src/app/api/recordings/[id]/transcribe/browser/route.ts
+++ b/src/app/api/recordings/[id]/transcribe/browser/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { storeBrowserTranscription } from "@/lib/transcription/store-transcript";
+import type { TranscribeErrorCode } from "@/lib/transcription/transcribe-recording";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+// Whisper transcripts are bounded by recording length; this cap only
+// exists to reject pathological / abusive payloads, not legitimate
+// long-meeting transcripts (a 3 h recording is well under this).
+const MAX_TRANSCRIPT_CHARS = 5_000_000;
+
+const browserTranscriptSchema = z.object({
+    text: z.string().min(1).max(MAX_TRANSCRIPT_CHARS),
+    // ISO 639-1-ish code Whisper attaches; nullable when the model
+    // didn't report one. Capped defensively.
+    detectedLanguage: z.string().max(16).nullish(),
+    model: z.enum(["whisper-tiny", "whisper-base", "whisper-small"]),
+});
+
+/**
+ * Store a transcript produced in the user's browser via Transformers.js
+ * (Whisper in WebAssembly). The heavy lifting -- model download, audio
+ * decode, inference -- happens client-side; this endpoint only persists
+ * the result through the same path as server-side transcripts
+ * (encrypted at rest, title auto-generation, webhook emission).
+ *
+ * Request body:
+ *   - `text`: the transcript (required, non-empty)
+ *   - `detectedLanguage`: Whisper-detected language code (optional)
+ *   - `model`: which Whisper model produced it (recorded as metadata)
+ */
+export const POST = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+
+    const parsed = browserTranscriptSchema.safeParse(
+        await request.json().catch(() => null),
+    );
+    if (!parsed.success) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "Invalid browser transcript payload",
+            400,
+        );
+    }
+
+    // Reject whitespace-only transcripts (Whisper can emit these for
+    // silent audio) so we don't store an empty transcript that the UI
+    // would render as a successful result.
+    if (!parsed.data.text.trim()) {
+        throw new AppError(ErrorCode.INVALID_INPUT, "Transcript is empty", 400);
+    }
+
+    const result = await storeBrowserTranscription(session.user.id, id, {
+        text: parsed.data.text,
+        detectedLanguage: parsed.data.detectedLanguage ?? null,
+        model: parsed.data.model,
+    });
+
+    if (!result.success) {
+        throw mapErrorCodeToAppError(result.errorCode, result.error);
+    }
+
+    return NextResponse.json({
+        transcription: result.text ?? "",
+        detectedLanguage: result.detectedLanguage ?? null,
+    });
+});
+
+function mapErrorCodeToAppError(
+    code: TranscribeErrorCode | undefined,
+    message: string | undefined,
+): AppError {
+    const msg = message ?? "Failed to store transcript";
+    switch (code) {
+        case "RECORDING_NOT_FOUND":
+            return new AppError(ErrorCode.RECORDING_NOT_FOUND, msg, 404);
+        case "RECORDING_DELETED":
+            return new AppError(ErrorCode.NOT_FOUND, msg, 410);
+        default:
+            return new AppError(ErrorCode.TRANSCRIPTION_FAILED, msg, 500);
+    }
+}

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -3,6 +3,7 @@
 import {
     ChevronDown,
     ChevronUp,
+    Cpu,
     FileText,
     Languages,
     ListChecks,
@@ -14,6 +15,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
     Select,
     SelectContent,
     SelectItem,
@@ -23,17 +32,40 @@ import {
 import { useTranscriptionSummary } from "@/hooks/use-transcription-summary";
 import { SUMMARY_PRESETS } from "@/lib/ai/summary-presets";
 import type { Recording } from "@/types/recording";
+import type { TranscriptionModel } from "@/types/transcription";
 
 interface Transcription {
     text?: string;
     language?: string;
 }
 
+const BROWSER_MODELS: {
+    model: TranscriptionModel;
+    label: string;
+    hint: string;
+}[] = [
+    { model: "whisper-tiny", label: "Whisper Tiny", hint: "fastest, ~75 MB" },
+    { model: "whisper-base", label: "Whisper Base", hint: "balanced, ~145 MB" },
+    {
+        model: "whisper-small",
+        label: "Whisper Small",
+        hint: "most accurate, ~485 MB",
+    },
+];
+
 interface TranscriptionPanelProps {
     recording: Recording;
     transcription?: Transcription;
     isTranscribing: boolean;
     onTranscribe: () => void;
+    /**
+     * Run transcription in the browser via Transformers.js with the
+     * chosen Whisper model. Optional -- when omitted, only the
+     * server-side path is offered.
+     */
+    onTranscribeBrowser?: (model: TranscriptionModel) => void;
+    /** Human-readable progress string while a browser transcribe runs. */
+    browserStatus?: string | null;
 }
 
 export function TranscriptionPanel({
@@ -41,6 +73,8 @@ export function TranscriptionPanel({
     transcription,
     isTranscribing,
     onTranscribe,
+    onTranscribeBrowser,
+    browserStatus,
 }: TranscriptionPanelProps) {
     const {
         summaryData,
@@ -67,7 +101,7 @@ export function TranscriptionPanel({
                             Transcription
                         </CardTitle>
                         <div className="flex items-center gap-2">
-                            {transcription?.text && (
+                            {transcription?.text ? (
                                 <Button
                                     onClick={onTranscribe}
                                     size="sm"
@@ -77,16 +111,56 @@ export function TranscriptionPanel({
                                     <RefreshCw className="size-4 mr-2" />
                                     Re-transcribe
                                 </Button>
+                            ) : (
+                                !isTranscribing && (
+                                    <Button
+                                        onClick={onTranscribe}
+                                        size="sm"
+                                        disabled={isTranscribing}
+                                    >
+                                        <Sparkles className="size-4 mr-2" />
+                                        Transcribe
+                                    </Button>
+                                )
                             )}
-                            {!transcription?.text && !isTranscribing && (
-                                <Button
-                                    onClick={onTranscribe}
-                                    size="sm"
-                                    disabled={isTranscribing}
-                                >
-                                    <Sparkles className="size-4 mr-2" />
-                                    Transcribe
-                                </Button>
+                            {onTranscribeBrowser && !isTranscribing && (
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            aria-label="Transcribe in browser"
+                                        >
+                                            <Cpu className="size-4 mr-2" />
+                                            In browser
+                                            <ChevronDown className="size-4 ml-1" />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end">
+                                        <DropdownMenuLabel>
+                                            Transcribe in browser (free)
+                                        </DropdownMenuLabel>
+                                        <DropdownMenuSeparator />
+                                        {BROWSER_MODELS.map(
+                                            ({ model, label, hint }) => (
+                                                <DropdownMenuItem
+                                                    key={model}
+                                                    onClick={() =>
+                                                        onTranscribeBrowser(
+                                                            model,
+                                                        )
+                                                    }
+                                                    className="flex flex-col items-start gap-0.5"
+                                                >
+                                                    <span>{label}</span>
+                                                    <span className="text-xs text-muted-foreground">
+                                                        {hint}
+                                                    </span>
+                                                </DropdownMenuItem>
+                                            ),
+                                        )}
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
                             )}
                         </div>
                     </div>
@@ -96,8 +170,14 @@ export function TranscriptionPanel({
                         <div className="flex flex-col items-center justify-center py-12">
                             <div className="animate-spin size-8 border-2 border-primary border-t-transparent rounded-full mb-4" />
                             <p className="text-sm text-muted-foreground">
-                                Transcribing audio…
+                                {browserStatus ?? "Transcribing audio…"}
                             </p>
+                            {browserStatus && (
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    Running in your browser — nothing leaves
+                                    this device.
+                                </p>
+                            )}
                         </div>
                     ) : transcription?.text ? (
                         <div className="space-y-4">

--- a/src/components/dashboard/workstation-detail-pane.tsx
+++ b/src/components/dashboard/workstation-detail-pane.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import type { Recording } from "@/types/recording";
+import type { TranscriptionModel } from "@/types/transcription";
 
 interface TranscriptionData {
     text?: string;
@@ -19,6 +20,8 @@ interface Props {
     isCurrentTranscribing: boolean;
     visibleRecordings: Recording[];
     onTranscribe: () => void;
+    onTranscribeBrowser: (model: TranscriptionModel) => void;
+    browserStatus: string | null;
     onSelectRecording: (r: Recording) => void;
     onBackToList: () => void;
     /** When true, the pane is hidden (mobile list view active). */
@@ -45,6 +48,8 @@ export function WorkstationDetailPane({
     isCurrentTranscribing,
     visibleRecordings,
     onTranscribe,
+    onTranscribeBrowser,
+    browserStatus,
     onSelectRecording,
     onBackToList,
     hiddenOnMobile,
@@ -102,6 +107,8 @@ export function WorkstationDetailPane({
                         transcription={currentTranscription}
                         isTranscribing={isCurrentTranscribing}
                         onTranscribe={onTranscribe}
+                        onTranscribeBrowser={onTranscribeBrowser}
+                        browserStatus={browserStatus}
                     />
                 </>
             ) : (

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -28,6 +28,7 @@ import type { InitialSettings } from "@/lib/settings/initial-settings";
 import { SYNC_CONFIG } from "@/lib/sync-config";
 import { cn } from "@/lib/utils";
 import type { Recording } from "@/types/recording";
+import type { TranscriptionModel } from "@/types/transcription";
 
 interface TranscriptionData {
     text?: string;
@@ -210,7 +211,12 @@ export function Workstation({
         triggerUpload,
     } = useUploadQueue({ onUploadComplete: refresh });
 
-    const { inFlightActions, transcribeById } = useTranscribeQueue({
+    const {
+        inFlightActions,
+        transcribeById,
+        transcribeInBrowser,
+        browserStatus,
+    } = useTranscribeQueue({
         onTranscribeComplete: refresh,
     });
 
@@ -231,6 +237,14 @@ export function Workstation({
         if (!currentRecording) return;
         await transcribeById(currentRecording.id);
     }, [currentRecording, transcribeById]);
+
+    const handleTranscribeBrowser = useCallback(
+        async (model: TranscriptionModel) => {
+            if (!currentRecording) return;
+            await transcribeInBrowser(currentRecording.id, model);
+        },
+        [currentRecording, transcribeInBrowser],
+    );
 
     const handleDelete = useCallback(
         async (recording: Recording) => {
@@ -363,6 +377,8 @@ export function Workstation({
                                 isCurrentTranscribing={isCurrentTranscribing}
                                 visibleRecordings={visibleRecordings}
                                 onTranscribe={handleTranscribe}
+                                onTranscribeBrowser={handleTranscribeBrowser}
+                                browserStatus={browserStatus}
                                 onSelectRecording={setCurrentRecording}
                                 onBackToList={() => setMobileView("list")}
                                 hiddenOnMobile={mobileView === "list"}

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -17,7 +17,9 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
+import { useBrowserTranscription } from "@/hooks/use-browser-transcription";
 import type { Recording } from "@/types/recording";
+import type { TranscriptionModel } from "@/types/transcription";
 
 interface Transcription {
     text?: string;
@@ -53,6 +55,8 @@ export function RecordingWorkstation({
     const [isTranscribing, setIsTranscribing] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const { run: runBrowserTranscription, status: browserStatus } =
+        useBrowserTranscription();
 
     const handleTranscribe = useCallback(async () => {
         setIsTranscribing(true);
@@ -77,6 +81,29 @@ export function RecordingWorkstation({
             setIsTranscribing(false);
         }
     }, [recording.id, refresh]);
+
+    const handleTranscribeBrowser = useCallback(
+        async (model: TranscriptionModel) => {
+            setIsTranscribing(true);
+            try {
+                await runBrowserTranscription({
+                    recordingId: recording.id,
+                    model,
+                });
+                toast.success("Transcription complete");
+                refresh();
+            } catch (error) {
+                toast.error(
+                    error instanceof Error
+                        ? error.message
+                        : "Browser transcription failed",
+                );
+            } finally {
+                setIsTranscribing(false);
+            }
+        },
+        [recording.id, refresh, runBrowserTranscription],
+    );
 
     const handleDelete = useCallback(async () => {
         setIsDeleting(true);
@@ -146,6 +173,8 @@ export function RecordingWorkstation({
                         transcription={transcription}
                         isTranscribing={isTranscribing}
                         onTranscribe={handleTranscribe}
+                        onTranscribeBrowser={handleTranscribeBrowser}
+                        browserStatus={browserStatus}
                     />
 
                     {/* Metadata */}

--- a/src/hooks/use-browser-transcription.ts
+++ b/src/hooks/use-browser-transcription.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { BrowserTranscriber } from "@/lib/transcription/browser-transcriber";
+import { decodeAudioToMono16k } from "@/lib/transcription/decode-audio";
+import type { TranscriptionModel } from "@/types/transcription";
+
+interface RunOptions {
+    recordingId: string;
+    model: TranscriptionModel;
+}
+
+/**
+ * Drives the full in-browser transcription flow for one recording:
+ *
+ *   1. download the audio from our own API
+ *   2. decode it to mono 16 kHz PCM (main thread; OfflineAudioContext)
+ *   3. run Whisper in a Web Worker via Transformers.js
+ *   4. POST the resulting transcript to be stored server-side
+ *
+ * Nothing but the final transcript text leaves the browser. The heavy
+ * Transformers.js bundle + model weights are only fetched the first
+ * time `run` is invoked, so importing this hook is cheap.
+ *
+ * `status` is a human-readable progress string (or null when idle) the
+ * caller can surface in the UI.
+ */
+export function useBrowserTranscription() {
+    const [status, setStatus] = useState<string | null>(null);
+    const transcriberRef = useRef<BrowserTranscriber | null>(null);
+
+    // Tear the worker down on unmount so its loaded model is freed.
+    useEffect(() => {
+        return () => {
+            transcriberRef.current?.terminate();
+            transcriberRef.current = null;
+        };
+    }, []);
+
+    const run = useCallback(
+        async ({ recordingId, model }: RunOptions): Promise<void> => {
+            setStatus("Downloading audio…");
+            const audioResponse = await fetch(
+                `/api/recordings/${recordingId}/audio`,
+            );
+            if (!audioResponse.ok) {
+                throw new Error("Failed to download audio for transcription");
+            }
+            const blob = await audioResponse.blob();
+
+            setStatus("Decoding audio…");
+            const samples = await decodeAudioToMono16k(blob);
+
+            let transcriber = transcriberRef.current;
+            if (!transcriber) {
+                transcriber = new BrowserTranscriber();
+                transcriberRef.current = transcriber;
+            }
+
+            setStatus("Loading model…");
+            await transcriber.initialize();
+
+            const result = await transcriber.transcribe(
+                samples,
+                model,
+                (progress) => {
+                    if (progress.stage === "loading-model") {
+                        setStatus(
+                            progress.percent != null
+                                ? `Loading model… ${progress.percent}%`
+                                : "Loading model…",
+                        );
+                    } else {
+                        setStatus("Transcribing…");
+                    }
+                },
+            );
+
+            if (!result.text.trim()) {
+                throw new Error(
+                    "Transcription produced no text (the audio may be silent)",
+                );
+            }
+
+            setStatus("Saving…");
+            const saveResponse = await fetch(
+                `/api/recordings/${recordingId}/transcribe/browser`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        text: result.text,
+                        detectedLanguage: result.detectedLanguage,
+                        model,
+                    }),
+                },
+            );
+            if (!saveResponse.ok) {
+                const error = await saveResponse.json().catch(() => ({}));
+                throw new Error(error.error || "Failed to save transcript");
+            }
+
+            setStatus(null);
+        },
+        [],
+    );
+
+    const reset = useCallback(() => setStatus(null), []);
+
+    return { run, status, reset };
+}

--- a/src/hooks/use-transcribe-queue.ts
+++ b/src/hooks/use-transcribe-queue.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
+import { useBrowserTranscription } from "@/hooks/use-browser-transcription";
+import type { TranscriptionModel } from "@/types/transcription";
 
 type ActionKind = "transcribing" | "summarizing";
 
@@ -26,6 +28,11 @@ export function useTranscribeQueue({ onTranscribeComplete }: Options) {
     const [inFlightActions, setInFlightActions] = useState<
         Map<string, ActionKind>
     >(new Map());
+    const {
+        run: runBrowserTranscription,
+        status: browserStatus,
+        reset: resetBrowserStatus,
+    } = useBrowserTranscription();
 
     const markAction = useCallback((id: string, kind: ActionKind | null) => {
         setInFlightActions((prev) => {
@@ -73,9 +80,45 @@ export function useTranscribeQueue({ onTranscribeComplete }: Options) {
         [markAction, onTranscribeComplete],
     );
 
+    /**
+     * Transcribe a recording entirely in the browser via Transformers.js
+     * (Whisper in WebAssembly) -- no provider key required. The model
+     * download + inference run client-side; only the resulting text is
+     * sent to the server for storage. Shares the same `inFlightActions`
+     * marker as the server path so the UI's disabled/spinner states work
+     * uniformly.
+     */
+    const transcribeInBrowser = useCallback(
+        async (id: string, model: TranscriptionModel) => {
+            markAction(id, "transcribing");
+            try {
+                await runBrowserTranscription({ recordingId: id, model });
+                toast.success("Transcription complete");
+                onTranscribeComplete();
+            } catch (error) {
+                toast.error(
+                    error instanceof Error
+                        ? error.message
+                        : "Browser transcription failed",
+                );
+            } finally {
+                resetBrowserStatus();
+                markAction(id, null);
+            }
+        },
+        [
+            markAction,
+            onTranscribeComplete,
+            runBrowserTranscription,
+            resetBrowserStatus,
+        ],
+    );
+
     return {
         inFlightActions,
         markAction,
         transcribeById,
+        transcribeInBrowser,
+        browserStatus,
     };
 }

--- a/src/lib/transcription/browser-transcriber.ts
+++ b/src/lib/transcription/browser-transcriber.ts
@@ -1,6 +1,14 @@
 /**
- * Browser-based transcription using Transformers.js
- * Runs Whisper models in the browser via WebAssembly
+ * Browser-based transcription using Transformers.js.
+ *
+ * Runs Whisper models entirely in the user's browser via WebAssembly --
+ * no API key, no audio leaving the machine. This class lives on the main
+ * thread and drives a Web Worker (`worker.ts`) that owns the heavy
+ * Transformers.js pipeline so inference never blocks the UI thread.
+ *
+ * Audio must be decoded to mono 16 kHz PCM (`Float32Array`) before being
+ * passed in -- see `decode-audio.ts`. The worker feeds those samples
+ * straight to the pipeline.
  */
 
 import type {
@@ -16,12 +24,22 @@ const MODEL_MAP: Record<TranscriptionModel, string> = {
     "whisper-small": "Xenova/whisper-small",
 };
 
+/** Coarse stages reported back to the UI while a transcription runs. */
+export type BrowserTranscriptionStage = "loading-model" | "transcribing";
+
+export interface BrowserTranscriptionProgress {
+    stage: BrowserTranscriptionStage;
+    /** 0-100 model-download progress; only present during `loading-model`. */
+    percent?: number;
+}
+
 export class BrowserTranscriber {
     private worker: Worker | null = null;
     private isReady = false;
 
     /**
-     * Initialize the transcription worker
+     * Initialize the transcription worker. Cheap and idempotent -- the
+     * expensive model download happens lazily on the first `transcribe`.
      */
     async initialize(): Promise<void> {
         if (this.worker) {
@@ -30,25 +48,29 @@ export class BrowserTranscriber {
 
         return new Promise((resolve, reject) => {
             try {
-                this.worker = new Worker(
+                const worker = new Worker(
                     new URL("./worker.ts", import.meta.url),
                     { type: "module" },
                 );
 
-                this.worker.addEventListener("message", (event) => {
-                    if (event.data.type === "ready") {
+                const onReady = (event: MessageEvent) => {
+                    if (event.data?.type === "ready") {
+                        worker.removeEventListener("message", onReady);
                         this.isReady = true;
                         resolve();
                     }
-                });
+                };
 
-                this.worker.addEventListener("error", (error) => {
+                worker.addEventListener("message", onReady);
+                worker.addEventListener("error", (error) => {
                     reject(
                         new Error(
                             `Worker initialization failed: ${error.message}`,
                         ),
                     );
                 });
+
+                this.worker = worker;
             } catch (error) {
                 reject(error);
             }
@@ -56,99 +78,59 @@ export class BrowserTranscriber {
     }
 
     /**
-     * Transcribe audio file using the browser-based model
+     * Transcribe decoded mono 16 kHz PCM samples with the given Whisper
+     * model. The first call for a model downloads it (cached by the
+     * browser afterwards), reported via `onProgress`.
      */
     async transcribe(
-        audioFile: File,
+        samples: Float32Array,
         model: TranscriptionModel = "whisper-base",
-        onProgress?: (status: string) => void,
+        onProgress?: (progress: BrowserTranscriptionProgress) => void,
     ): Promise<TranscriptionResult> {
-        if (!this.worker || !this.isReady) {
+        const worker = this.worker;
+        if (!worker || !this.isReady) {
             throw new Error(
                 "Transcriber not initialized. Call initialize() first.",
             );
         }
 
         return new Promise((resolve, reject) => {
-            if (!this.worker) {
-                reject(new Error("Worker not available"));
-                return;
-            }
+            const messageHandler = (event: MessageEvent) => {
+                const { type, text, detectedLanguage, error, stage, percent } =
+                    event.data ?? {};
 
-            const reader = new FileReader();
-
-            reader.onload = async () => {
-                if (!this.worker) {
-                    reject(new Error("Worker not available"));
-                    return;
+                if (type === "progress") {
+                    onProgress?.({ stage, percent });
+                } else if (type === "complete") {
+                    worker.removeEventListener("message", messageHandler);
+                    resolve({ text, detectedLanguage });
+                } else if (type === "error") {
+                    worker.removeEventListener("message", messageHandler);
+                    reject(new Error(error));
                 }
+            };
 
-                const audioData = reader.result;
-                const modelPath = MODEL_MAP[model];
+            worker.addEventListener("message", messageHandler);
 
-                const messageHandler = (event: MessageEvent) => {
-                    const { type, text, detectedLanguage, error, status } =
-                        event.data;
-
-                    if (type === "progress" && onProgress) {
-                        onProgress(status);
-                    } else if (type === "complete") {
-                        this.worker?.removeEventListener(
-                            "message",
-                            messageHandler,
-                        );
-                        resolve({ text, detectedLanguage });
-                    } else if (type === "error") {
-                        this.worker?.removeEventListener(
-                            "message",
-                            messageHandler,
-                        );
-                        reject(new Error(error));
-                    }
-                };
-
-                this.worker.addEventListener("message", messageHandler);
-
-                this.worker.postMessage({
+            // Transfer the underlying buffer to avoid copying potentially
+            // large sample arrays across the worker boundary.
+            worker.postMessage(
+                {
                     type: "transcribe",
-                    audioData,
-                    model: modelPath,
-                });
-            };
-
-            reader.onerror = () => {
-                reject(new Error("Failed to read audio file"));
-            };
-
-            reader.readAsArrayBuffer(audioFile);
+                    samples,
+                    model: MODEL_MAP[model],
+                },
+                [samples.buffer],
+            );
         });
     }
 
-    /**
-     * Clean up the worker
-     */
+    /** Tear down the worker and free its loaded model. */
     terminate(): void {
         if (this.worker) {
             this.worker.terminate();
             this.worker = null;
             this.isReady = false;
         }
-    }
-}
-
-/**
- * Convenience function to transcribe audio in the browser
- */
-export async function transcribeInBrowser(
-    audioFile: File,
-    model: TranscriptionModel = "whisper-base",
-    onProgress?: (status: string) => void,
-): Promise<TranscriptionResult> {
-    const transcriber = new BrowserTranscriber();
-    try {
-        await transcriber.initialize();
-        return await transcriber.transcribe(audioFile, model, onProgress);
-    } finally {
-        transcriber.terminate();
     }
 }

--- a/src/lib/transcription/decode-audio.ts
+++ b/src/lib/transcription/decode-audio.ts
@@ -1,0 +1,68 @@
+/**
+ * Browser-only audio decoding for in-browser Whisper transcription.
+ *
+ * Transformers.js's automatic-speech-recognition pipeline expects raw
+ * mono PCM samples at 16 kHz (a `Float32Array`), NOT an encoded audio
+ * file. Whisper itself is trained at 16 kHz. Decoding + resampling has
+ * to happen on the main thread because `OfflineAudioContext` is not
+ * available inside a Web Worker. We hand the resulting `Float32Array`
+ * to the worker, which feeds it straight to the pipeline.
+ */
+
+const WHISPER_SAMPLE_RATE = 16000;
+
+type AudioContextCtor = typeof AudioContext;
+
+function getAudioContextCtor(): AudioContextCtor {
+    const w = window as typeof window & {
+        webkitAudioContext?: AudioContextCtor;
+    };
+    const ctor = w.AudioContext ?? w.webkitAudioContext;
+    if (!ctor) {
+        throw new Error(
+            "Web Audio API is unavailable; browser transcription is not supported here.",
+        );
+    }
+    return ctor;
+}
+
+/**
+ * Decode an encoded audio blob (mp3, opus, wav, …) into mono 16 kHz PCM
+ * samples suitable for the Whisper pipeline.
+ */
+export async function decodeAudioToMono16k(blob: Blob): Promise<Float32Array> {
+    const arrayBuffer = await blob.arrayBuffer();
+
+    const AudioCtx = getAudioContextCtor();
+    const decodeCtx = new AudioCtx();
+    let decoded: AudioBuffer;
+    try {
+        // `decodeAudioData` decodes at the file's native sample rate.
+        decoded = await decodeCtx.decodeAudioData(arrayBuffer.slice(0));
+    } finally {
+        // Free the hardware audio context promptly; we only needed it
+        // to decode.
+        void decodeCtx.close();
+    }
+
+    // Already mono at the target rate: downmix is a no-op, just return.
+    if (
+        decoded.numberOfChannels === 1 &&
+        decoded.sampleRate === WHISPER_SAMPLE_RATE
+    ) {
+        return decoded.getChannelData(0).slice();
+    }
+
+    // Resample (and downmix) via an OfflineAudioContext rendered at the
+    // Whisper sample rate. The context downmixes multi-channel input to
+    // its single output channel automatically.
+    const frameCount = Math.ceil(decoded.duration * WHISPER_SAMPLE_RATE || 1);
+    const offline = new OfflineAudioContext(1, frameCount, WHISPER_SAMPLE_RATE);
+    const source = offline.createBufferSource();
+    source.buffer = decoded;
+    source.connect(offline.destination);
+    source.start();
+    const rendered = await offline.startRendering();
+
+    return rendered.getChannelData(0).slice();
+}

--- a/src/lib/transcription/empty-module.ts
+++ b/src/lib/transcription/empty-module.ts
@@ -1,0 +1,12 @@
+// Aliased in for `onnxruntime-node` and `sharp`, the Node-only optional
+// dependencies of `@xenova/transformers`. We run Transformers.js
+// exclusively in a browser Web Worker (onnxruntime-web), so these native
+// packages must never be resolved by the bundler. See the
+// `turbopack`/`webpack` config in `next.config.ts`.
+//
+// Transformers.js statically references both a default import
+// (`import sharp from 'sharp'`) and a namespace `.default` access
+// (`ONNX_NODE.default ?? ONNX_NODE`), so the stub must expose a `default`
+// export. Neither is ever invoked in the browser branch.
+const stub = {};
+export default stub;

--- a/src/lib/transcription/store-transcript.ts
+++ b/src/lib/transcription/store-transcript.ts
@@ -1,0 +1,278 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import {
+    plaudConnections,
+    recordings,
+    transcriptions,
+    userSettings,
+} from "@/db/schema";
+import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
+import { encryptText } from "@/lib/encryption/fields";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
+import type { TranscribeResult } from "@/lib/transcription/transcribe-recording";
+import { emitEvent } from "@/lib/webhooks/emit";
+import type { TranscriptionModel } from "@/types/transcription";
+
+/**
+ * Generate an AI title from a fresh transcript and persist it as the
+ * recording's filename (encrypted at rest), optionally pushing it back
+ * to Plaud. Shared by the server-side and browser transcription paths
+ * so the two cannot drift. Best-effort: failures are logged and
+ * swallowed -- a missing title must never fail an otherwise-successful
+ * transcription.
+ */
+export async function maybeGenerateAndSyncTitle(params: {
+    userId: string;
+    recordingId: string;
+    plaudFileId: string;
+    transcriptionText: string;
+    autoGenerateTitle: boolean;
+    syncTitleToPlaud: boolean;
+}): Promise<void> {
+    const {
+        userId,
+        recordingId,
+        plaudFileId,
+        transcriptionText,
+        autoGenerateTitle,
+        syncTitleToPlaud,
+    } = params;
+
+    if (!autoGenerateTitle || !transcriptionText.trim()) {
+        return;
+    }
+
+    try {
+        const generatedTitle = await generateTitleFromTranscription(
+            userId,
+            transcriptionText,
+        );
+
+        if (!generatedTitle) {
+            return;
+        }
+
+        // Encrypt the generated title before storing it as the
+        // recording's filename. The plaintext is still available
+        // below for the optional sync-to-Plaud push.
+        await db
+            .update(recordings)
+            .set({
+                filename: encryptText(generatedTitle),
+                updatedAt: new Date(),
+            })
+            .where(
+                and(
+                    eq(recordings.id, recordingId),
+                    eq(recordings.userId, userId),
+                    isNull(recordings.deletedAt),
+                ),
+            );
+
+        if (!syncTitleToPlaud) {
+            return;
+        }
+
+        try {
+            const [connection] = await db
+                .select()
+                .from(plaudConnections)
+                .where(eq(plaudConnections.userId, userId))
+                .limit(1);
+
+            if (!connection) {
+                return;
+            }
+
+            const plaudClient = await createPlaudClient(
+                connection.bearerToken,
+                connection.apiBase,
+                connection.workspaceId,
+            );
+            await plaudClient.updateFilename(plaudFileId, generatedTitle);
+
+            // Backfill workspaceId if newly resolved. Always scope
+            // user-owned UPDATEs by userId even when filtering by id
+            // (per AGENTS.md).
+            const resolved = plaudClient.workspaceId;
+            if (resolved && resolved !== connection.workspaceId) {
+                await db
+                    .update(plaudConnections)
+                    .set({ workspaceId: resolved })
+                    .where(
+                        and(
+                            eq(plaudConnections.id, connection.id),
+                            eq(plaudConnections.userId, userId),
+                        ),
+                    );
+            }
+        } catch (error) {
+            console.error("Failed to sync title to Plaud:", error);
+        }
+    } catch (error) {
+        console.error("Failed to generate title:", error);
+    }
+}
+
+/**
+ * Persist a transcript produced in the user's browser (Transformers.js /
+ * Whisper running client-side via WebAssembly). No provider call happens
+ * here -- the text arrives already-computed from the client. We still
+ * own the storage path so a browser transcript is indistinguishable from
+ * a server one downstream: encrypted at rest, title auto-generation,
+ * webhook emission, and the same tombstone-race guard.
+ *
+ * The transcript is always upserted (browser is an explicit user choice,
+ * so it overwrites any existing transcript -- there is no idempotent
+ * short-circuit like the sync-triggered server path has).
+ */
+export async function storeBrowserTranscription(
+    userId: string,
+    recordingId: string,
+    input: {
+        text: string;
+        detectedLanguage: string | null;
+        model: TranscriptionModel;
+    },
+): Promise<TranscribeResult> {
+    try {
+        const [recording] = await db
+            .select()
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.id, recordingId),
+                    eq(recordings.userId, userId),
+                    isNull(recordings.deletedAt),
+                ),
+            )
+            .limit(1);
+
+        if (!recording) {
+            return {
+                success: false,
+                error: "Recording not found",
+                errorCode: "RECORDING_NOT_FOUND",
+            };
+        }
+
+        const [settings] = await db
+            .select()
+            .from(userSettings)
+            .where(eq(userSettings.userId, userId))
+            .limit(1);
+
+        const autoGenerateTitle = settings?.autoGenerateTitle ?? true;
+        const syncTitleToPlaud = settings?.syncTitleToPlaud ?? false;
+
+        const RECORDING_TOMBSTONED = Symbol("recording-tombstoned");
+        try {
+            await db.transaction(async (tx) => {
+                const [stillActive] = await tx
+                    .select({ deletedAt: recordings.deletedAt })
+                    .from(recordings)
+                    .where(
+                        and(
+                            eq(recordings.id, recordingId),
+                            eq(recordings.userId, userId),
+                        ),
+                    )
+                    .for("update")
+                    .limit(1);
+
+                if (!stillActive || stillActive.deletedAt) {
+                    throw RECORDING_TOMBSTONED;
+                }
+
+                const [currentTranscription] = await tx
+                    .select()
+                    .from(transcriptions)
+                    .where(
+                        and(
+                            eq(transcriptions.recordingId, recordingId),
+                            eq(transcriptions.userId, userId),
+                        ),
+                    )
+                    .limit(1);
+
+                const encryptedTranscriptionText = encryptText(input.text);
+
+                if (currentTranscription) {
+                    await tx
+                        .update(transcriptions)
+                        .set({
+                            text: encryptedTranscriptionText,
+                            detectedLanguage: input.detectedLanguage,
+                            transcriptionType: "browser",
+                            provider: "browser",
+                            model: input.model,
+                        })
+                        .where(
+                            and(
+                                eq(transcriptions.id, currentTranscription.id),
+                                eq(transcriptions.userId, userId),
+                            ),
+                        );
+                } else {
+                    await tx.insert(transcriptions).values({
+                        recordingId,
+                        userId,
+                        text: encryptedTranscriptionText,
+                        detectedLanguage: input.detectedLanguage,
+                        transcriptionType: "browser",
+                        provider: "browser",
+                        model: input.model,
+                    });
+                }
+
+                await tx
+                    .update(recordings)
+                    .set({ updatedAt: new Date() })
+                    .where(
+                        and(
+                            eq(recordings.id, recordingId),
+                            eq(recordings.userId, userId),
+                            isNull(recordings.deletedAt),
+                        ),
+                    );
+            });
+        } catch (txError) {
+            if (txError === RECORDING_TOMBSTONED) {
+                return {
+                    success: false,
+                    error: "Recording was deleted before transcription finished",
+                    errorCode: "RECORDING_DELETED",
+                };
+            }
+            throw txError;
+        }
+
+        await maybeGenerateAndSyncTitle({
+            userId,
+            recordingId,
+            plaudFileId: recording.plaudFileId,
+            transcriptionText: input.text,
+            autoGenerateTitle,
+            syncTitleToPlaud,
+        });
+
+        await emitEvent("transcription.completed", userId, recordingId);
+
+        return {
+            success: true,
+            text: input.text,
+            detectedLanguage: input.detectedLanguage,
+        };
+    } catch (error) {
+        console.error("Error storing browser transcription:", error);
+        await emitEvent("transcription.failed", userId, recordingId, {
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return {
+            success: false,
+            error:
+                error instanceof Error ? error.message : "Transcription failed",
+            errorCode: "TRANSCRIPTION_FAILED",
+        };
+    }
+}

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -3,16 +3,13 @@ import { OpenAI } from "openai";
 import { db } from "@/db";
 import {
     apiCredentials,
-    plaudConnections,
     recordings,
     transcriptions,
     userSettings,
 } from "@/db/schema";
-import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
 import { getTranscriptionStyle } from "@/lib/ai/provider-presets";
 import { decrypt } from "@/lib/encryption";
 import { decryptText, encryptText } from "@/lib/encryption/fields";
-import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { createUserStorageProvider } from "@/lib/storage/factory";
 import { buildAudioFile } from "@/lib/transcription/audio-file";
 import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
@@ -23,6 +20,7 @@ import {
     parseTranscriptionResponse,
 } from "@/lib/transcription/format";
 import { geminiTranscribe } from "@/lib/transcription/gemini-transcribe";
+import { maybeGenerateAndSyncTitle } from "@/lib/transcription/store-transcript";
 import { emitEvent } from "@/lib/webhooks/emit";
 
 /**
@@ -346,86 +344,14 @@ export async function transcribeRecording(
             throw txError;
         }
 
-        if (autoGenerateTitle && transcriptionText.trim()) {
-            try {
-                const generatedTitle = await generateTitleFromTranscription(
-                    userId,
-                    transcriptionText,
-                );
-
-                if (generatedTitle) {
-                    // Encrypt the generated title before storing it as the
-                    // recording's filename. The plaintext is still available
-                    // below for the optional sync-to-Plaud push.
-                    await db
-                        .update(recordings)
-                        .set({
-                            filename: encryptText(generatedTitle),
-                            updatedAt: new Date(),
-                        })
-                        .where(
-                            and(
-                                eq(recordings.id, recordingId),
-                                eq(recordings.userId, userId),
-                                isNull(recordings.deletedAt),
-                            ),
-                        );
-
-                    if (syncTitleToPlaud) {
-                        try {
-                            const [connection] = await db
-                                .select()
-                                .from(plaudConnections)
-                                .where(eq(plaudConnections.userId, userId))
-                                .limit(1);
-
-                            if (connection) {
-                                const plaudClient = await createPlaudClient(
-                                    connection.bearerToken,
-                                    connection.apiBase,
-                                    connection.workspaceId,
-                                );
-                                await plaudClient.updateFilename(
-                                    recording.plaudFileId,
-                                    generatedTitle,
-                                );
-                                // Backfill workspaceId if newly resolved.
-                                // Always scope user-owned UPDATEs by userId
-                                // even when filtering by id (per AGENTS.md).
-                                const resolved = plaudClient.workspaceId;
-                                if (
-                                    resolved &&
-                                    resolved !== connection.workspaceId
-                                ) {
-                                    await db
-                                        .update(plaudConnections)
-                                        .set({ workspaceId: resolved })
-                                        .where(
-                                            and(
-                                                eq(
-                                                    plaudConnections.id,
-                                                    connection.id,
-                                                ),
-                                                eq(
-                                                    plaudConnections.userId,
-                                                    userId,
-                                                ),
-                                            ),
-                                        );
-                                }
-                            }
-                        } catch (error) {
-                            console.error(
-                                "Failed to sync title to Plaud:",
-                                error,
-                            );
-                        }
-                    }
-                }
-            } catch (error) {
-                console.error("Failed to generate title:", error);
-            }
-        }
+        await maybeGenerateAndSyncTitle({
+            userId,
+            recordingId,
+            plaudFileId: recording.plaudFileId,
+            transcriptionText,
+            autoGenerateTitle,
+            syncTitleToPlaud,
+        });
 
         await emitEvent("transcription.completed", userId, recordingId);
 

--- a/src/lib/transcription/worker.ts
+++ b/src/lib/transcription/worker.ts
@@ -2,65 +2,89 @@
 
 import { type PipelineType, pipeline } from "@xenova/transformers";
 
-// @ts-expect-error -- disable local model cache in browser
-self.ONNX_CACHE = false;
+type Pipe = Awaited<ReturnType<typeof pipeline>>;
 
-let transcriber: Awaited<ReturnType<typeof pipeline>> | null = null;
+// Cache one pipeline per model id so switching recordings (same model)
+// doesn't re-download or re-instantiate. Whisper models are tens to a
+// few hundred MB; the browser HTTP cache persists the weights, but the
+// in-memory pipeline still needs rebuilding across worker reloads.
+const pipelines = new Map<string, Pipe>();
 
-async function initTranscriber(model: string) {
-    if (!transcriber) {
-        transcriber = await pipeline(
-            "automatic-speech-recognition" as PipelineType,
-            model,
-            { revision: "main" },
-        );
+async function getTranscriber(model: string): Promise<Pipe> {
+    const cached = pipelines.get(model);
+    if (cached) {
+        return cached;
     }
-    return transcriber;
+    const pipe = await pipeline(
+        "automatic-speech-recognition" as PipelineType,
+        model,
+        {
+            // Report model-download progress back to the main thread so
+            // the UI can show a percentage on first run.
+            progress_callback: (data: {
+                status?: string;
+                progress?: number;
+            }) => {
+                if (data?.status === "progress") {
+                    self.postMessage({
+                        type: "progress",
+                        stage: "loading-model",
+                        percent:
+                            typeof data.progress === "number"
+                                ? Math.round(data.progress)
+                                : undefined,
+                    });
+                }
+            },
+        },
+    );
+    pipelines.set(model, pipe);
+    return pipe;
 }
 
-self.addEventListener("message", async (event) => {
-    const { type, audioData, model } = event.data;
+self.addEventListener("message", async (event: MessageEvent) => {
+    const { type, samples, model } = event.data ?? {};
 
-    if (type === "transcribe") {
-        try {
-            const pipe = await initTranscriber(model);
+    if (type !== "transcribe") {
+        return;
+    }
 
-            self.postMessage({ type: "progress", status: "transcribing" });
+    try {
+        const pipe = await getTranscriber(model);
 
-            type TranscriberResult = {
-                text: string;
-                chunks?: { language?: string }[];
-            };
+        self.postMessage({ type: "progress", stage: "transcribing" });
 
-            type Transcriber = (
-                input: unknown,
-                options: {
-                    return_timestamps: boolean;
-                    chunk_length_s: number;
-                    stride_length_s: number;
-                },
-            ) => Promise<TranscriberResult>;
+        type TranscriberResult = {
+            text: string;
+            chunks?: { language?: string }[];
+        };
 
-            const result = await (pipe as Transcriber)(audioData, {
-                return_timestamps: false,
-                chunk_length_s: 30,
-                stride_length_s: 5,
-            });
+        type Transcriber = (
+            input: Float32Array,
+            options: {
+                return_timestamps: boolean;
+                chunk_length_s: number;
+                stride_length_s: number;
+            },
+        ) => Promise<TranscriberResult>;
 
-            self.postMessage({
-                type: "complete",
-                text: result.text,
-                detectedLanguage: result.chunks?.[0]?.language || "en",
-            });
-        } catch (error) {
-            self.postMessage({
-                type: "error",
-                error:
-                    error instanceof Error
-                        ? error.message
-                        : "Transcription failed",
-            });
-        }
+        const result = await (pipe as Transcriber)(samples as Float32Array, {
+            return_timestamps: false,
+            chunk_length_s: 30,
+            stride_length_s: 5,
+        });
+
+        self.postMessage({
+            type: "complete",
+            text: result.text,
+            detectedLanguage: result.chunks?.[0]?.language ?? null,
+        });
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            error:
+                error instanceof Error ? error.message : "Transcription failed",
+        });
     }
 });
 

--- a/src/tests/regressions/130-browser-transcription.test.ts
+++ b/src/tests/regressions/130-browser-transcription.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression: issue #130
+ *
+ * Background: the README and landing page advertised free in-browser
+ * transcription (Transformers.js / Whisper in WebAssembly), but the
+ * `BrowserTranscriber` class had zero callers and there was no route to
+ * persist a client-produced transcript. Shipping the feature added
+ * `storeBrowserTranscription`, which writes a browser transcript through
+ * the same encrypted-at-rest path as the server one.
+ *
+ * These tests pin the storage contract: user-scoped lookup, browser
+ * provider/type metadata, encrypted text, title generation, and webhook
+ * emission -- plus the not-found guard.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    decrypt: vi.fn().mockReturnValue("plaintext"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+}));
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/ai/generate-title", () => ({
+    generateTitleFromTranscription: vi
+        .fn()
+        .mockResolvedValue("Generated Title"),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+import { db } from "@/db";
+import { generateTitleFromTranscription } from "@/lib/ai/generate-title";
+import { storeBrowserTranscription } from "@/lib/transcription/store-transcript";
+import { emitEvent } from "@/lib/webhooks/emit";
+
+const USER_ID = "user-123";
+const RECORDING_ID = "rec-456";
+
+function selectOnce(rows: unknown[]) {
+    return {
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue(rows),
+            }),
+        }),
+    };
+}
+
+describe("storeBrowserTranscription (issue #130)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns RECORDING_NOT_FOUND when the recording is missing or not owned", async () => {
+        (db.select as Mock).mockReturnValueOnce(selectOnce([]));
+
+        const result = await storeBrowserTranscription(USER_ID, RECORDING_ID, {
+            text: "hello world",
+            detectedLanguage: "en",
+            model: "whisper-base",
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.errorCode).toBe("RECORDING_NOT_FOUND");
+        expect(emitEvent).not.toHaveBeenCalled();
+    });
+
+    it("inserts an encrypted browser transcript, generates a title, and emits completion", async () => {
+        // 1) recording lookup, 2) user settings lookup
+        (db.select as Mock)
+            .mockReturnValueOnce(
+                selectOnce([
+                    {
+                        id: RECORDING_ID,
+                        userId: USER_ID,
+                        plaudFileId: "plaud-1",
+                        deletedAt: null,
+                    },
+                ]),
+            )
+            .mockReturnValueOnce(
+                selectOnce([
+                    { autoGenerateTitle: true, syncTitleToPlaud: false },
+                ]),
+            );
+
+        const txInsertValues = vi.fn().mockResolvedValue(undefined);
+        const txInsert = vi.fn().mockReturnValue({ values: txInsertValues });
+        const txUpdate = vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(undefined),
+            }),
+        });
+        const tx = {
+            select: vi
+                .fn()
+                // tombstone FOR UPDATE check
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            for: vi.fn().mockReturnValue({
+                                limit: vi
+                                    .fn()
+                                    .mockResolvedValue([{ deletedAt: null }]),
+                            }),
+                        }),
+                    }),
+                })
+                // existing-transcription lookup (none)
+                .mockReturnValueOnce(selectOnce([])),
+            insert: txInsert,
+            update: txUpdate,
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+        );
+
+        // title update goes through the top-level db.update
+        (db.update as Mock).mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(undefined),
+            }),
+        });
+
+        const result = await storeBrowserTranscription(USER_ID, RECORDING_ID, {
+            text: "the quick brown fox",
+            detectedLanguage: "en",
+            model: "whisper-small",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.text).toBe("the quick brown fox");
+
+        expect(txInsert).toHaveBeenCalled();
+        const inserted = txInsertValues.mock.calls[0][0];
+        expect(inserted).toMatchObject({
+            recordingId: RECORDING_ID,
+            userId: USER_ID,
+            transcriptionType: "browser",
+            provider: "browser",
+            model: "whisper-small",
+            detectedLanguage: "en",
+        });
+        // Text is encrypted at rest (v1-prefixed ciphertext envelope).
+        expect(inserted.text).toBe("v1:encrypted:the quick brown fox");
+
+        expect(generateTitleFromTranscription).toHaveBeenCalledWith(
+            USER_ID,
+            "the quick brown fox",
+        );
+        expect(emitEvent).toHaveBeenCalledWith(
+            "transcription.completed",
+            USER_ID,
+            RECORDING_ID,
+        );
+    });
+});


### PR DESCRIPTION
## Description

In-browser transcription is now wired end to end. `BrowserTranscriber` (Whisper via Transformers.js / WebAssembly) previously had zero callers and there was no route to persist a client-produced transcript, so the advertised "free browser transcription" did nothing. The dead worker also passed a raw encoded `ArrayBuffer` to the pipeline, which only accepts decoded mono 16 kHz PCM — the real reason it never worked.

The actual transcription runs entirely on the user's device: model download and inference happen in a Web Worker. The server does zero transcription compute; only the resulting transcript text is sent back to be stored. This keeps it free for the user and cheap on the hosted instance (no shared GPU, no per-user transcription billing).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Related Issues

Fixes #130

## Changes Made

- Add an **In browser** option (Whisper Tiny / Base / Small) to the transcription panel, wired through the dashboard `Workstation` and the legacy `/recordings/[id]` view.
- New `src/lib/transcription/decode-audio.ts`: decodes audio to mono 16 kHz PCM via `OfflineAudioContext` (the missing step that made the old code dead).
- Rewire `browser-transcriber.ts` + `worker.ts` to take a `Float32Array`, cache one pipeline per model, report model-download progress, and transfer buffers across the worker boundary.
- New user-scoped route `POST /api/recordings/[id]/transcribe/browser` (Zod-validated) that stores the transcript encrypted at rest with `transcription_type: 'browser'`, `provider: 'browser'`.
- Extract shared `maybeGenerateAndSyncTitle` from the server path into `store-transcript.ts`; browser transcripts reuse it, so title/summary behavior stays governed by existing user config (no-ops cleanly when no AI provider is set).
- `next.config.ts`: Turbopack + webpack aliases so the Node-only optional deps of `@xenova/transformers` (`onnxruntime-node`, `sharp`) are stubbed out of the browser bundle.
- Restore the `guides/browser-transcription` doc; CHANGELOG entry under Added.
- Regression test `src/tests/regressions/130-browser-transcription.test.ts`.

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): not smoke-tested in a live browser yet (see For Reviewers)

### Test Steps
1. `pnpm type-check` — clean.
2. `pnpm test` (`vitest run`) — 399 passed, 5 skipped, including the new regression test and the untouched server-path tests.
3. `biome check` on all touched files — clean.
4. `next build` — compiles successfully; the worker bundles with `onnxruntime-web`, the new route is emitted, static generation passes.

## Database Changes

- [ ] No migration needed. `transcriptions.transcription_type` / `provider` already documented `'browser'` in the schema.

## Additional Notes

No new dependency: `@xenova/transformers` was already in `package.json`. No schema, env, or docker-compose changes — nothing on the self-host deploy surface. Model weights are fetched once from the Hugging Face CDN on first run; audio is never uploaded.

## For Reviewers

- The one thing a build can't exercise is the actual runtime model download + inference in a real browser. A manual smoke test on the dashboard (pick In browser → a Whisper model, watch download/progress, confirm the transcript persists) would fully close the loop.
- `next.config.ts` bundler aliasing: Next 16 builds through Turbopack, so the `turbopack.resolveAlias` stub (`empty-module.ts` with a `default` export) is what actually matters; the webpack alias is a fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end in-browser Whisper transcription that runs fully on the user’s device and saves only the transcript to the server. No API key needed; no audio upload.

- **New Features**
  - Adds an In browser option (Whisper Tiny/Base/Small) that runs via `@xenova/transformers` in a Web Worker and shows model download progress.
  - Decodes audio to mono 16 kHz PCM on the main thread and transfers a `Float32Array` to the worker; caches one pipeline per model for reuse.
  - New `POST /api/recordings/[id]/transcribe/browser` stores transcripts encrypted at rest with `transcription_type: 'browser'`/`provider: 'browser'`, reusing existing title generation and webhooks; only text is sent to the server.
  - Build: stubs `onnxruntime-node` and `sharp` with an empty module for Turbopack/webpack to keep the browser bundle clean (uses `onnxruntime-web`). Adds a browser transcription guide and a regression test.

<sup>Written for commit 8d0d59df9febb89785b29479c709e25894a2a99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

