### PR TITLE
fix(transcription): decode audio for browser Whisper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Newsletter signup form embedded in the landing footer (above the honesty rail) so visitors can subscribe without leaving the page. Same `/api/newsletter/subscribe` endpoint + double-opt-in flow as the dedicated `/updates` page.
 
 ### Fixed
+- Browser transcription now decodes and resamples audio to mono 16 kHz PCM before handing it to Transformers.js, and the production build stubs Transformers.js's Node-only optional dependencies so the Web Worker bundles under Next 16/Turbopack ([#130](https://github.com/riffado/riffado/issues/130)).
 - Long-meeting summaries no longer drop the end of the transcript. The summary endpoint hard-truncated transcripts to the first 8000 characters (~2000 tokens) before sending them to the model, silently discarding everything after — so end-of-call decisions and action items never reached the summary. The full transcript is now sent. If a transcript exceeds the configured model's context window, the provider error is surfaced as a clear 400 ("transcript too long, pick a larger-context model") instead of a generic 500 ([#213](https://github.com/riffado/riffado/issues/213)).
 
 ### Removed

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,25 @@ const nextConfig: NextConfig = {
         loaderFile: "./loader.ts",
         remotePatterns: [],
     },
+    // @xenova/transformers statically imports Node-only optional deps
+    // (`onnxruntime-node`, `sharp`). Browser transcription uses
+    // `onnxruntime-web` inside a Web Worker, so stub those native deps
+    // for both Next 16's Turbopack build path and the webpack fallback.
+    turbopack: {
+        resolveAlias: {
+            "onnxruntime-node": "./src/lib/transcription/empty-module.ts",
+            sharp: "./src/lib/transcription/empty-module.ts",
+        },
+    },
+    webpack: (config) => {
+        config.resolve = config.resolve ?? {};
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            "onnxruntime-node": false,
+            sharp: false,
+        };
+        return config;
+    },
 };
 
 const withMDX = createMDX({ outDir: "src/.source" });

--- a/src/components/dashboard/transcribe-in-browser-button.tsx
+++ b/src/components/dashboard/transcribe-in-browser-button.tsx
@@ -17,10 +17,16 @@ interface Props {
     model?: TranscriptionModel;
 }
 
-type Phase = "idle" | "downloading-audio" | "loading-model" | "transcribing";
+type Phase =
+    | "idle"
+    | "downloading-audio"
+    | "decoding-audio"
+    | "loading-model"
+    | "transcribing";
 
 const PHASE_LABEL: Record<Exclude<Phase, "idle">, string> = {
     "downloading-audio": "Downloading audio…",
+    "decoding-audio": "Decoding audio…",
     "loading-model": "Loading Whisper (one-time download)…",
     transcribing: "Transcribing locally…",
 };
@@ -58,8 +64,10 @@ export function TranscribeInBrowserButton({
                 type: blob.type || "audio/mpeg",
             });
 
-            setPhase("loading-model");
+            setPhase("decoding-audio");
             const result = await transcribeInBrowser(file, model, (status) => {
+                if (status === "decoding-audio") setPhase("decoding-audio");
+                if (status === "loading-model") setPhase("loading-model");
                 if (status === "transcribing") setPhase("transcribing");
             });
 

--- a/src/lib/transcription/browser-transcriber.ts
+++ b/src/lib/transcription/browser-transcriber.ts
@@ -1,8 +1,9 @@
 /**
- * Browser-based transcription using Transformers.js
- * Runs Whisper models in the browser via WebAssembly
+ * Browser-based transcription using Transformers.js.
+ * Runs Whisper models in the browser via WebAssembly.
  */
 
+import { decodeAudioToMono16k } from "@/lib/transcription/decode-audio";
 import type {
     TranscriptionModel,
     TranscriptionResult,
@@ -20,9 +21,7 @@ export class BrowserTranscriber {
     private worker: Worker | null = null;
     private isReady = false;
 
-    /**
-     * Initialize the transcription worker
-     */
+    /** Initialize the transcription worker. */
     async initialize(): Promise<void> {
         if (this.worker) {
             return;
@@ -30,25 +29,29 @@ export class BrowserTranscriber {
 
         return new Promise((resolve, reject) => {
             try {
-                this.worker = new Worker(
+                const worker = new Worker(
                     new URL("./worker.ts", import.meta.url),
                     { type: "module" },
                 );
 
-                this.worker.addEventListener("message", (event) => {
-                    if (event.data.type === "ready") {
+                const onReady = (event: MessageEvent) => {
+                    if (event.data?.type === "ready") {
+                        worker.removeEventListener("message", onReady);
                         this.isReady = true;
                         resolve();
                     }
-                });
+                };
 
-                this.worker.addEventListener("error", (error) => {
+                worker.addEventListener("message", onReady);
+                worker.addEventListener("error", (error) => {
                     reject(
                         new Error(
                             `Worker initialization failed: ${error.message}`,
                         ),
                     );
                 });
+
+                this.worker = worker;
             } catch (error) {
                 reject(error);
             }
@@ -56,77 +59,56 @@ export class BrowserTranscriber {
     }
 
     /**
-     * Transcribe audio file using the browser-based model
+     * Transcribe an audio file using the browser-based model.
+     *
+     * Transformers.js ASR expects raw mono PCM samples at the model's
+     * sampling rate, not encoded MP3/Opus bytes. Decode and resample the
+     * file before transferring the `Float32Array` to the worker.
      */
     async transcribe(
         audioFile: File,
         model: TranscriptionModel = "whisper-base",
         onProgress?: (status: string) => void,
     ): Promise<TranscriptionResult> {
-        if (!this.worker || !this.isReady) {
+        const worker = this.worker;
+        if (!worker || !this.isReady) {
             throw new Error(
                 "Transcriber not initialized. Call initialize() first.",
             );
         }
 
+        onProgress?.("decoding-audio");
+        const samples = await decodeAudioToMono16k(audioFile);
+
         return new Promise((resolve, reject) => {
-            if (!this.worker) {
-                reject(new Error("Worker not available"));
-                return;
-            }
+            const messageHandler = (event: MessageEvent) => {
+                const { type, text, detectedLanguage, error, status } =
+                    event.data ?? {};
 
-            const reader = new FileReader();
-
-            reader.onload = async () => {
-                if (!this.worker) {
-                    reject(new Error("Worker not available"));
-                    return;
+                if (type === "progress" && onProgress) {
+                    onProgress(status);
+                } else if (type === "complete") {
+                    worker.removeEventListener("message", messageHandler);
+                    resolve({ text, detectedLanguage });
+                } else if (type === "error") {
+                    worker.removeEventListener("message", messageHandler);
+                    reject(new Error(error));
                 }
+            };
 
-                const audioData = reader.result;
-                const modelPath = MODEL_MAP[model];
-
-                const messageHandler = (event: MessageEvent) => {
-                    const { type, text, detectedLanguage, error, status } =
-                        event.data;
-
-                    if (type === "progress" && onProgress) {
-                        onProgress(status);
-                    } else if (type === "complete") {
-                        this.worker?.removeEventListener(
-                            "message",
-                            messageHandler,
-                        );
-                        resolve({ text, detectedLanguage });
-                    } else if (type === "error") {
-                        this.worker?.removeEventListener(
-                            "message",
-                            messageHandler,
-                        );
-                        reject(new Error(error));
-                    }
-                };
-
-                this.worker.addEventListener("message", messageHandler);
-
-                this.worker.postMessage({
+            worker.addEventListener("message", messageHandler);
+            worker.postMessage(
+                {
                     type: "transcribe",
-                    audioData,
-                    model: modelPath,
-                });
-            };
-
-            reader.onerror = () => {
-                reject(new Error("Failed to read audio file"));
-            };
-
-            reader.readAsArrayBuffer(audioFile);
+                    samples,
+                    model: MODEL_MAP[model],
+                },
+                [samples.buffer],
+            );
         });
     }
 
-    /**
-     * Clean up the worker
-     */
+    /** Clean up the worker. */
     terminate(): void {
         if (this.worker) {
             this.worker.terminate();
@@ -136,9 +118,7 @@ export class BrowserTranscriber {
     }
 }
 
-/**
- * Convenience function to transcribe audio in the browser
- */
+/** Convenience function to transcribe audio in the browser. */
 export async function transcribeInBrowser(
     audioFile: File,
     model: TranscriptionModel = "whisper-base",

--- a/src/lib/transcription/browser-transcriber.ts
+++ b/src/lib/transcription/browser-transcriber.ts
@@ -17,6 +17,12 @@ const MODEL_MAP: Record<TranscriptionModel, string> = {
     "whisper-small": "Xenova/whisper-small",
 };
 
+const MAX_BROWSER_TRANSCRIPTION_BYTES = 150 * 1024 * 1024;
+
+function formatMiB(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(0)} MiB`;
+}
+
 export class BrowserTranscriber {
     private worker: Worker | null = null;
     private isReady = false;
@@ -77,8 +83,27 @@ export class BrowserTranscriber {
             );
         }
 
+        if (audioFile.size > MAX_BROWSER_TRANSCRIPTION_BYTES) {
+            throw new Error(
+                `This recording is too large for browser transcription (${formatMiB(audioFile.size)}). Use a server-side provider for recordings over ${formatMiB(MAX_BROWSER_TRANSCRIPTION_BYTES)}.`,
+            );
+        }
+
         onProgress?.("decoding-audio");
-        const samples = await decodeAudioToMono16k(audioFile);
+        let samples: Float32Array;
+        try {
+            samples = await decodeAudioToMono16k(audioFile);
+        } catch (error) {
+            throw new Error(
+                error instanceof Error
+                    ? `Failed to decode audio in the browser: ${error.message}`
+                    : "Failed to decode audio in the browser",
+            );
+        }
+
+        if (this.worker !== worker || !this.isReady) {
+            throw new Error("Transcription worker was terminated");
+        }
 
         return new Promise((resolve, reject) => {
             const messageHandler = (event: MessageEvent) => {

--- a/src/lib/transcription/decode-audio.ts
+++ b/src/lib/transcription/decode-audio.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser-only audio decoding for in-browser Whisper transcription.
+ *
+ * Transformers.js's automatic-speech-recognition pipeline expects raw
+ * mono PCM samples at 16 kHz (a `Float32Array`), not an encoded audio
+ * file. Whisper itself is trained at 16 kHz. Decoding and resampling
+ * happen on the main thread because `OfflineAudioContext` is not
+ * available inside a Web Worker.
+ */
+
+const WHISPER_SAMPLE_RATE = 16000;
+
+type AudioContextCtor = typeof AudioContext;
+
+function getAudioContextCtor(): AudioContextCtor {
+    const w = window as typeof window & {
+        webkitAudioContext?: AudioContextCtor;
+    };
+    const ctor = w.AudioContext ?? w.webkitAudioContext;
+    if (!ctor) {
+        throw new Error(
+            "Web Audio API is unavailable; browser transcription is not supported here.",
+        );
+    }
+    return ctor;
+}
+
+export async function decodeAudioToMono16k(blob: Blob): Promise<Float32Array> {
+    const arrayBuffer = await blob.arrayBuffer();
+
+    const AudioCtx = getAudioContextCtor();
+    const decodeCtx = new AudioCtx();
+    let decoded: AudioBuffer;
+    try {
+        decoded = await decodeCtx.decodeAudioData(arrayBuffer.slice(0));
+    } finally {
+        void decodeCtx.close();
+    }
+
+    if (
+        decoded.numberOfChannels === 1 &&
+        decoded.sampleRate === WHISPER_SAMPLE_RATE
+    ) {
+        return decoded.getChannelData(0).slice();
+    }
+
+    const frameCount = Math.ceil(decoded.duration * WHISPER_SAMPLE_RATE || 1);
+    const offline = new OfflineAudioContext(1, frameCount, WHISPER_SAMPLE_RATE);
+    const source = offline.createBufferSource();
+    source.buffer = decoded;
+    source.connect(offline.destination);
+    source.start();
+    const rendered = await offline.startRendering();
+
+    return rendered.getChannelData(0).slice();
+}

--- a/src/lib/transcription/empty-module.ts
+++ b/src/lib/transcription/empty-module.ts
@@ -1,0 +1,11 @@
+// Aliased in for `onnxruntime-node` and `sharp`, the Node-only optional
+// dependencies of `@xenova/transformers`. Browser transcription runs
+// Transformers.js exclusively in a browser Web Worker (onnxruntime-web),
+// so these native packages must never be resolved by the bundler.
+//
+// Transformers.js statically references both a default import
+// (`import sharp from 'sharp'`) and a namespace `.default` access
+// (`ONNX_NODE.default ?? ONNX_NODE`), so the stub must expose a default
+// export. Neither branch is invoked in the browser runtime.
+const stub = {};
+export default stub;

--- a/src/lib/transcription/worker.ts
+++ b/src/lib/transcription/worker.ts
@@ -2,65 +2,78 @@
 
 import { type PipelineType, pipeline } from "@xenova/transformers";
 
-// @ts-expect-error -- disable local model cache in browser
-self.ONNX_CACHE = false;
+type Pipe = Awaited<ReturnType<typeof pipeline>>;
 
-let transcriber: Awaited<ReturnType<typeof pipeline>> | null = null;
+const pipelines = new Map<string, Pipe>();
 
-async function initTranscriber(model: string) {
-    if (!transcriber) {
-        transcriber = await pipeline(
-            "automatic-speech-recognition" as PipelineType,
-            model,
-            { revision: "main" },
-        );
+async function getTranscriber(model: string): Promise<Pipe> {
+    const cached = pipelines.get(model);
+    if (cached) {
+        return cached;
     }
-    return transcriber;
+
+    const pipe = await pipeline(
+        "automatic-speech-recognition" as PipelineType,
+        model,
+        {
+            revision: "main",
+            progress_callback: (data: { status?: string }) => {
+                if (data?.status === "progress") {
+                    self.postMessage({
+                        type: "progress",
+                        status: "loading-model",
+                    });
+                }
+            },
+        },
+    );
+    pipelines.set(model, pipe);
+    return pipe;
 }
 
-self.addEventListener("message", async (event) => {
-    const { type, audioData, model } = event.data;
+self.addEventListener("message", async (event: MessageEvent) => {
+    const { type, samples, model } = event.data ?? {};
 
-    if (type === "transcribe") {
-        try {
-            const pipe = await initTranscriber(model);
+    if (type !== "transcribe") {
+        return;
+    }
 
-            self.postMessage({ type: "progress", status: "transcribing" });
+    try {
+        const pipe = await getTranscriber(model);
 
-            type TranscriberResult = {
-                text: string;
-                chunks?: { language?: string }[];
-            };
+        self.postMessage({ type: "progress", status: "transcribing" });
 
-            type Transcriber = (
-                input: unknown,
-                options: {
-                    return_timestamps: boolean;
-                    chunk_length_s: number;
-                    stride_length_s: number;
-                },
-            ) => Promise<TranscriberResult>;
+        type TranscriberResult = {
+            text: string;
+            chunks?: { language?: string }[];
+        };
 
-            const result = await (pipe as Transcriber)(audioData, {
-                return_timestamps: false,
-                chunk_length_s: 30,
-                stride_length_s: 5,
-            });
+        type Transcriber = (
+            input: Float32Array,
+            options: {
+                return_timestamps: boolean;
+                chunk_length_s: number;
+                stride_length_s: number;
+            },
+        ) => Promise<TranscriberResult>;
 
-            self.postMessage({
-                type: "complete",
-                text: result.text,
-                detectedLanguage: result.chunks?.[0]?.language || "en",
-            });
-        } catch (error) {
-            self.postMessage({
-                type: "error",
-                error:
-                    error instanceof Error
-                        ? error.message
-                        : "Transcription failed",
-            });
-        }
+        const result = await (pipe as Transcriber)(samples as Float32Array, {
+            return_timestamps: false,
+            chunk_length_s: 30,
+            stride_length_s: 5,
+        });
+
+        self.postMessage({
+            type: "complete",
+            text: result.text,
+            detectedLanguage: result.chunks?.[0]?.language ?? null,
+        });
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            error:
+                error instanceof Error ? error.message : "Transcription failed",
+        });
     }
 });
 


### PR DESCRIPTION
## Description

Fixes the browser transcription implementation that already exists on `main`. The UI and storage route were present, but the worker still passed raw encoded audio bytes (`ArrayBuffer`) into the Transformers.js ASR pipeline. Transformers.js accepts a URL or raw PCM sample array, not MP3/Opus bytes, so the browser path could fail at runtime.

This keeps the existing `main` UX/route shape and only fixes the missing runtime/build pieces: decode audio to mono 16 kHz PCM in the browser, transfer a `Float32Array` to the worker, and stub Transformers.js's Node-only optional dependencies for Next 16/Turbopack.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #130
Replaces #218

## Changes Made

- Add `decodeAudioToMono16k()` to decode browser audio with `AudioContext` and resample with `OfflineAudioContext` before inference.
- Update `BrowserTranscriber` to send decoded `Float32Array` samples to the worker instead of raw encoded file bytes.
- Update the transcription worker to consume PCM samples directly and cache one Transformers.js pipeline per model.
- Extend the existing browser transcription button with a "Decoding audio…" phase while preserving the existing route/UI shape.
- Add `empty-module.ts` and Next config aliases for `onnxruntime-node` / `sharp` so the Web Worker bundles under Next 16/Turbopack and webpack fallback.
- Add an Unreleased changelog note for the runtime/build fix.

## Screenshots (if applicable)

N/A

## Testing

### Test Environment
- OS: macOS
- Node version: v22.20.0
- Browser (if UI changes): not manually smoke-tested in browser

### Test Steps
1. `pnpm format-and-lint:fix` — no changes applied; reports only an existing unsafe suggestion in `src/tests/admin/elevated-cookie.test.ts`.
2. `pnpm type-check` — passes.
3. `pnpm test` — 684 passed, 5 skipped.
4. `next build` — passes; emits `/api/recordings/[id]/transcription/from-browser` and bundles the browser transcription worker successfully.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

No database changes.

## Breaking Changes

None.

## Additional Notes

This is intentionally smaller than #218 because `main` already gained a partial browser transcription implementation. This PR preserves that route/UI shape and only fixes the actual runtime incompatibility plus the production bundler issue.

## For Reviewers

- Please focus on the `Float32Array` decode/resample path and the Turbopack aliasing in `next.config.ts`.
- A real browser smoke test is still useful: click **Transcribe in browser**, confirm it reaches "Decoding audio…" / "Loading Whisper…" / "Transcribing locally…", then persists the transcript.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser transcription by decoding audio to mono 16 kHz PCM before Whisper runs in the worker, so Transformers.js gets raw samples instead of encoded bytes. Adds a 150 MiB size guard and stubs Node-only deps so the worker bundles under Next 16/Turbopack.

- **Bug Fixes**
  - Decode in the browser with `AudioContext`/`OfflineAudioContext`, send a `Float32Array` to the worker, and show a "Decoding audio…" phase.
  - Worker consumes PCM samples, caches one ASR pipeline per model, and posts "loading-model" and "transcribing" via the pipeline `progress_callback`.
  - Guard the decode/worker lifecycle and cap browser transcription at 150 MiB with a clear error message.

- **Dependencies**
  - Alias `onnxruntime-node` and `sharp` to a stub for Turbopack; set webpack aliases to `false`.
  - Use `@xenova/transformers` with `onnxruntime-web` in the worker.

<sup>Written for commit 8df1540061356e4566d88580e64586c9d32065e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

