### PR TITLE
fix(email): copy polish follow-ups from #233

### DIFF
--- a/src/lib/notifications/email-templates/export-ready.tsx
+++ b/src/lib/notifications/email-templates/export-ready.tsx
@@ -14,7 +14,7 @@ export function ExportReadyEmail({ downloadUrl }: Props) {
         >
             <Heading style={emailStyles.h1}>Your export is ready</Heading>
             <Text style={emailStyles.text}>
-                We finished building your full data archive — every
+                We finished building your full data archive: every
                 recording&apos;s audio, transcript, and AI summary, zipped up
                 and ready to download.
             </Text>

--- a/src/lib/notifications/email-templates/grace-started.tsx
+++ b/src/lib/notifications/email-templates/grace-started.tsx
@@ -60,7 +60,7 @@ export function GraceStartedEmail({
                 Questions, or something looks off? Reply to this email. I read
                 every one.
                 <br />
-                &mdash; Kacper, Riffado
+                Kacper, Riffado
             </Text>
         </EmailLayout>
     );

--- a/src/lib/notifications/email-templates/rebrand-announcement-email.tsx
+++ b/src/lib/notifications/email-templates/rebrand-announcement-email.tsx
@@ -74,7 +74,7 @@ export function RebrandAnnouncementEmail({
             <Text style={emailStyles.text}>
                 If anything broke for you, hit reply. I read this inbox.
                 <br />
-                &mdash; Kacper, from Riffado
+                Kacper, from Riffado
             </Text>
 
             <Text style={emailStyles.text}>

--- a/src/lib/notifications/email-templates/transition-start.tsx
+++ b/src/lib/notifications/email-templates/transition-start.tsx
@@ -99,7 +99,7 @@ export function TransitionStartEmail({
                 Questions, or something looks off? Reply to this email. It comes
                 straight to me.
                 <br />
-                &mdash; Kacper, building Riffado
+                Kacper, building Riffado
             </Text>
         </EmailLayout>
     );

--- a/src/lib/notifications/email-templates/welcome-hosted-pro.tsx
+++ b/src/lib/notifications/email-templates/welcome-hosted-pro.tsx
@@ -88,7 +88,7 @@ export function WelcomeHostedProEmail({
                 if anything's off or you have a question. It reaches me
                 directly.
                 <br />
-                &mdash; Kacper, building Riffado
+                Kacper, building Riffado
             </Text>
         </EmailLayout>
     );

--- a/src/lib/notifications/email-templates/welcome-hosted-pro.tsx
+++ b/src/lib/notifications/email-templates/welcome-hosted-pro.tsx
@@ -61,12 +61,14 @@ export function WelcomeHostedProEmail({
                     Pro entitlements are live:
                 </Text>
             )}
-            <Text style={emailStyles.text}>50 GB storage</Text>
-            <Text style={emailStyles.text}>
-                15 hours of Mynah transcription, refreshed every 30 days
+            <Text style={{ ...emailStyles.text, margin: "0 0 6px 0" }}>
+                &bull; 50 GB storage
             </Text>
-            <Text style={emailStyles.text}>
-                Unlimited devices, background sync
+            <Text style={{ ...emailStyles.text, margin: "0 0 6px 0" }}>
+                &bull; 15 hours of Mynah transcription, refreshed every 30 days
+            </Text>
+            <Text style={{ ...emailStyles.text, margin: "0 0 16px 0" }}>
+                &bull; Unlimited devices, background sync
             </Text>
             {isFoundingMonthly ? (
                 <Text style={emailStyles.text}>


### PR DESCRIPTION
Two small follow-ups caught after #233 merged, both regressions I introduced in that PR:

- **Em dashes in user-facing copy.** Per house style, replaced the 5 remaining `—`/`&mdash;` occurrences across email templates (a mid-sentence dash in `export-ready.tsx`, and 4 signature-line dashes) with standard punctuation.
- **Welcome email's feature list lost its bullets.** Splitting the crammed `<br>`-joined list into separate `<Text>` elements (to fix an email-client fragility issue) dropped the bullet markers entirely, so "50 GB storage / 15 hours of Mynah transcription / unlimited devices" rendered as three disconnected paragraphs instead of a list. Restored bullets with tighter spacing between them.

Verified: lint, type-check, full test suite (763 passed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes email copy and fixes a rendering regression in the Welcome Hosted Pro email. Replaces em dashes with standard punctuation across templates and restores bullet markers (with tighter spacing) in the feature list.

<sup>Written for commit d263391eefbb46b0391fa3990a33b97878dd0be8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

