### PR TITLE
feat(email): rewrite Hosted Pro launch email as a narrative announcement

### DIFF
--- a/src/lib/notifications/email-templates/styles.ts
+++ b/src/lib/notifications/email-templates/styles.ts
@@ -165,6 +165,39 @@ export const emailStyles = {
         border: "none",
         margin: "24px 0",
     },
+
+    /**
+     * Hanging-indent bullet line. The glyph sits in the negative-indent
+     * zone so a wrapped second line aligns under the text instead of
+     * falling back to the left margin, where it reads like a new,
+     * unrelated paragraph. Prefix content with "&bull; "; override
+     * `margin` per line's position in a list (tighter between lines,
+     * normal after the last one).
+     */
+    bullet: {
+        color: brandColors.foreground,
+        fontSize: "16px",
+        lineHeight: "1.6",
+        paddingLeft: "18px",
+        textIndent: "-18px",
+        margin: "0 0 8px 0",
+    },
+
+    /**
+     * Mono uppercase section eyebrow, matching the site's landing-page
+     * section markers ("PRICING", "FAQ"). Text only, no fill or border
+     * -- pair with `divider` for section separation instead of a card.
+     */
+    eyebrow: {
+        fontSize: "11px",
+        fontWeight: 600,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase" as const,
+        fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        color: brandColors.mutedForeground,
+        margin: "0 0 14px 0",
+    },
 };
 
 export const mobileStyles = {

--- a/src/lib/notifications/email-templates/styles.ts
+++ b/src/lib/notifications/email-templates/styles.ts
@@ -167,20 +167,28 @@ export const emailStyles = {
     },
 
     /**
-     * Hanging-indent bullet line. The glyph sits in the negative-indent
-     * zone so a wrapped second line aligns under the text instead of
-     * falling back to the left margin, where it reads like a new,
-     * unrelated paragraph. Prefix content with "&bull; "; override
-     * `margin` per line's position in a list (tighter between lines,
-     * normal after the last one).
+     * Bulletproof hanging-indent bullet, as a two-column table row
+     * rather than CSS `text-indent`. Negative `text-indent` is
+     * unreliable in desktop Outlook (Word rendering engine) -- a
+     * wrapped second line can fall back to the left margin there and
+     * read like a new, unrelated paragraph. A small table (`Row`/
+     * `Column` from @react-email/components) is the standard bulletproof
+     * pattern instead: the glyph gets its own narrow column, so wrapped
+     * text in the text column stays aligned under itself in every
+     * client, including Outlook. Pair with a local `<Bullet>` wrapper
+     * component; don't reach for these two styles raw.
      */
-    bullet: {
+    bulletGlyphColumn: {
+        width: "18px",
+        verticalAlign: "top" as const,
         color: brandColors.foreground,
         fontSize: "16px",
         lineHeight: "1.6",
-        paddingLeft: "18px",
-        textIndent: "-18px",
-        margin: "0 0 8px 0",
+    },
+    bulletTextColumn: {
+        color: brandColors.foreground,
+        fontSize: "16px",
+        lineHeight: "1.6",
     },
 
     /**

--- a/src/lib/notifications/email-templates/transition-start.tsx
+++ b/src/lib/notifications/email-templates/transition-start.tsx
@@ -20,13 +20,6 @@ interface Props {
     exportUrl: string;
     /** Self-host docs / repo link. */
     selfHostUrl: string;
-    /**
-     * Sponsorship destination (GitHub Sponsors / Open Collective). Omit
-     * until a real one exists -- the paragraph only renders when this is
-     * set, so turning sponsorship on later is a one-line change here,
-     * not a copy rewrite.
-     */
-    sponsorUrl?: string;
 }
 
 // Sent once to the grandfathered pre-launch cohort, replacing the earlier
@@ -46,7 +39,6 @@ export function TransitionStartEmail({
     billingUrl,
     exportUrl,
     selfHostUrl,
-    sponsorUrl,
 }: Props) {
     const deadline = formatEmailDate(transitionEndsAt);
     return (
@@ -182,18 +174,6 @@ export function TransitionStartEmail({
                 </a>
                 , or self-host.
             </Text>
-
-            {sponsorUrl ? (
-                <Text style={emailStyles.text}>
-                    Hosted Pro pays for running the service you use. If you want
-                    to back the broader project beyond your own subscription,
-                    you can{" "}
-                    <a href={sponsorUrl} style={emailStyles.link}>
-                        sponsor Riffado directly
-                    </a>
-                    . That's separate from any subscription and never required.
-                </Text>
-            ) : null}
 
             <Text style={emailStyles.text}>
                 Questions, or something looks off? Reply. It comes straight to

--- a/src/lib/notifications/email-templates/transition-start.tsx
+++ b/src/lib/notifications/email-templates/transition-start.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Section, Text } from "@react-email/components";
+import { Button, Heading, Hr, Section, Text } from "@react-email/components";
 import { EmailLayout } from "./_layout";
 import { formatEmailDate } from "./format-date";
 import { formatEmailPrice } from "./format-price";
@@ -20,12 +20,23 @@ interface Props {
     exportUrl: string;
     /** Self-host docs / repo link. */
     selfHostUrl: string;
+    /**
+     * Sponsorship destination (GitHub Sponsors / Open Collective). Omit
+     * until a real one exists -- the paragraph only renders when this is
+     * set, so turning sponsorship on later is a one-line change here,
+     * not a copy rewrite.
+     */
+    sponsorUrl?: string;
 }
 
-// Sent to grandfathered hosted users on launch day. Tone: respectful, no
-// surprise; the 30-day window is the grace. Positioning rules: name the
-// currently available price plainly, self-host is the free path, and never
-// imply founding capacity is guaranteed until the transition deadline.
+// Sent once to the grandfathered pre-launch cohort, replacing the earlier
+// purely transactional version of this email. Tone: personal, honest about
+// why hosted is now paid, and explicit that self-host stays a fully equal
+// path, not a downgrade. The account-specific facts (deadline, price,
+// read-only consequence, "nothing deleted") stay in their own clearly
+// separated section rather than dissolving into the narrative -- this is
+// a notice of an account change as much as it is a story, and readers
+// need to be able to find the mechanics without reading the whole letter.
 export function TransitionStartEmail({
     transitionEndsAt,
     amountValue,
@@ -35,39 +46,124 @@ export function TransitionStartEmail({
     billingUrl,
     exportUrl,
     selfHostUrl,
+    sponsorUrl,
 }: Props) {
+    const deadline = formatEmailDate(transitionEndsAt);
     return (
         <EmailLayout
-            previewText={`Hosted Pro is live. You keep full access free until ${formatEmailDate(transitionEndsAt)}.`}
+            previewText={`Hosted Pro is live. The essentials are at the top; the story's below. Nothing changes until ${deadline}.`}
             footerLink={{ href: billingUrl, label: "Manage billing" }}
         >
-            <Heading style={emailStyles.h1}>Hosted Pro is live.</Heading>
-            <Text style={emailStyles.text}>
-                Until now, you've used Riffado on our hosted servers for free.
-                Hosted is now becoming a paid product. Nothing changes
-                immediately: you keep full Hosted Pro access free until{" "}
-                <strong>{formatEmailDate(transitionEndsAt)}</strong>.
+            <Heading style={emailStyles.h1}>Hosted Pro is here.</Heading>
+
+            <Text style={emailStyles.eyebrow}>In short</Text>
+            <Text style={emailStyles.bullet}>
+                &bull; You keep full free access until{" "}
+                <strong>{deadline}</strong>. Nothing changes today.
             </Text>
             {foundingOfferAvailable ? (
-                <Text style={emailStyles.text}>
-                    The first {foundingCapacity} paid monthly members can
-                    subscribe for the founding price of{" "}
-                    {formatEmailPrice(amountValue, amountCurrency)}. That price
-                    stays locked for as long as the subscription remains active.
-                    Founding spots are available on a first-paid, first-served
-                    basis.
+                <Text style={emailStyles.bullet}>
+                    &bull; After that, Hosted Pro is{" "}
+                    <strong>
+                        {formatEmailPrice(amountValue, amountCurrency)}
+                    </strong>{" "}
+                    if you subscribe before then, locked in for as long as you
+                    stay subscribed.
                 </Text>
             ) : (
-                <Text style={emailStyles.text}>
-                    Monthly Hosted Pro is available for{" "}
-                    {formatEmailPrice(amountValue, amountCurrency)}.
+                <Text style={emailStyles.bullet}>
+                    &bull; After that, Hosted Pro is{" "}
+                    <strong>
+                        {formatEmailPrice(amountValue, amountCurrency)}
+                    </strong>
+                    .
                 </Text>
             )}
-            <Text style={emailStyles.text}>
-                Hosted Pro includes 50 GB storage, 15 hours of Mynah
-                transcription per month, unlimited devices, and background sync
-                that keeps pulling recordings even when your browser is closed.
+            <Text style={emailStyles.bullet}>
+                &bull; If you don't act, your account goes read-only. Nothing
+                gets deleted.
             </Text>
+            <Text style={{ ...emailStyles.bullet, margin: "0" }}>
+                &bull; Self-hosting stays free forever. That's not changing.
+            </Text>
+            <Hr style={{ ...emailStyles.divider, margin: "20px 0 24px 0" }} />
+
+            <Text style={emailStyles.text}>
+                Here's the story behind that, if you want it.
+            </Text>
+
+            <Text style={emailStyles.text}>
+                Riffado started as a simple idea: your recordings and
+                transcripts should belong to you, and you should choose which AI
+                touches them. That part worked. But hosted Riffado runs on real
+                infrastructure: servers, storage for your audio, and the compute
+                behind Mynah, the transcription service included with Hosted
+                Pro. Free hosting was the right call for an early cohort helping
+                us find the rough edges. Thank you for that. It's not something
+                we can run forever on goodwill, so Hosted Pro is now a paid
+                plan.
+            </Text>
+
+            <Text style={emailStyles.text}>
+                A subscription is the most honest way to fund this: no ads, no
+                selling your data, no lock-in. And because Riffado is one AGPL
+                codebase, everything a Hosted Pro subscription funds ships to
+                self-hosters too. Paying for Hosted Pro pays for the project,
+                not just your own account.
+            </Text>
+
+            <Text style={emailStyles.text}>
+                That also means self-hosting isn't going anywhere. The source
+                stays AGPL-3.0, and the exact code running Hosted is the code
+                you can{" "}
+                <a href={selfHostUrl} style={emailStyles.link}>
+                    run yourself
+                </a>
+                : your machine, your storage, free forever. Self-host and Hosted
+                Pro are the same project, run two different ways.
+            </Text>
+
+            <Text style={emailStyles.text}>
+                Hosted Pro includes 50 GB of storage, 15 hours of Mynah
+                transcription every month, unlimited devices, and background
+                sync that keeps pulling recordings even when your browser is
+                closed. Bring your own AI key if you'd rather (OpenAI, Groq,
+                anything compatible); Riffado adds no markup when you do.
+            </Text>
+
+            <Hr style={emailStyles.divider} />
+
+            <Heading style={emailStyles.h2}>
+                What this means for your account
+            </Heading>
+
+            <Text style={emailStyles.bullet}>
+                &bull; Your access stays free until <strong>{deadline}</strong>.
+            </Text>
+            {foundingOfferAvailable ? (
+                <Text style={emailStyles.bullet}>
+                    &bull; As an early user, you can lock in the founding price
+                    of{" "}
+                    <strong>
+                        {formatEmailPrice(amountValue, amountCurrency)}
+                    </strong>
+                    , limited to the first {foundingCapacity} paid monthly
+                    members, first-paid, first-served.
+                </Text>
+            ) : (
+                <Text style={emailStyles.bullet}>
+                    &bull; Monthly Hosted Pro is available for{" "}
+                    <strong>
+                        {formatEmailPrice(amountValue, amountCurrency)}
+                    </strong>
+                    .
+                </Text>
+            )}
+            <Text style={{ ...emailStyles.bullet, margin: "0 0 16px 0" }}>
+                &bull; You can cancel anytime. Canceling starts a grace period,
+                so nothing is lost immediately even then.
+            </Text>
+
             <Section style={emailStyles.buttonSection}>
                 <Button style={emailStyles.button} href={billingUrl}>
                     {foundingOfferAvailable
@@ -75,31 +171,35 @@ export function TransitionStartEmail({
                         : "Choose a plan"}
                 </Button>
             </Section>
+
             <Text style={emailStyles.text}>
-                If you don't choose a plan before{" "}
-                {formatEmailDate(transitionEndsAt)}, your Hosted account becomes
-                read-only. Nothing will be deleted: existing recordings remain
-                playable and exportable, while sync, uploads, and new
-                transcriptions pause.
-            </Text>
-            <Text style={emailStyles.text}>
-                Prefer not to subscribe? That's fine. Riffado is open source,
-                and you can{" "}
-                <a href={selfHostUrl} style={emailStyles.link}>
-                    self-host for free
-                </a>{" "}
-                and keep everything. Or{" "}
+                If you don't choose a plan by {deadline}, your account becomes
+                read-only. Nothing gets deleted: every recording, transcript,
+                and summary stays playable and exportable. Sync, uploads, and
+                new transcriptions pause until you subscribe,{" "}
                 <a href={exportUrl} style={emailStyles.link}>
-                    export your data
-                </a>{" "}
-                anytime. Your recordings, transcripts, and summaries are yours
-                either way.
+                    export
+                </a>
+                , or self-host.
             </Text>
+
+            {sponsorUrl ? (
+                <Text style={emailStyles.text}>
+                    Hosted Pro pays for running the service you use. If you want
+                    to back the broader project beyond your own subscription,
+                    you can{" "}
+                    <a href={sponsorUrl} style={emailStyles.link}>
+                        sponsor Riffado directly
+                    </a>
+                    . That's separate from any subscription and never required.
+                </Text>
+            ) : null}
+
             <Text style={emailStyles.text}>
-                Questions, or something looks off? Reply to this email. It comes
-                straight to me.
+                Questions, or something looks off? Reply. It comes straight to
+                me, and I read this inbox.
                 <br />
-                &mdash; Kacper, building Riffado
+                Kacper, building Riffado
             </Text>
         </EmailLayout>
     );

--- a/src/lib/notifications/email-templates/transition-start.tsx
+++ b/src/lib/notifications/email-templates/transition-start.tsx
@@ -1,8 +1,37 @@
-import { Button, Heading, Hr, Section, Text } from "@react-email/components";
+import {
+    Button,
+    Column,
+    Heading,
+    Hr,
+    Row,
+    Section,
+    Text,
+} from "@react-email/components";
+import type { ReactNode } from "react";
 import { EmailLayout } from "./_layout";
 import { formatEmailDate } from "./format-date";
 import { formatEmailPrice } from "./format-price";
 import { emailStyles } from "./styles";
+
+/**
+ * Bulletproof hanging-indent bullet (table row, not CSS text-indent --
+ * see `emailStyles.bulletGlyphColumn`). `margin` defaults to the
+ * between-items gap; pass "0 0 16px 0" for the last bullet in a list.
+ */
+function Bullet({
+    children,
+    margin = "0 0 8px 0",
+}: {
+    children: ReactNode;
+    margin?: string;
+}) {
+    return (
+        <Row style={{ margin }}>
+            <Column style={emailStyles.bulletGlyphColumn}>&bull;</Column>
+            <Column style={emailStyles.bulletTextColumn}>{children}</Column>
+        </Row>
+    );
+}
 
 interface Props {
     /** End of the free Pro window (when the account goes read-only). */
@@ -49,35 +78,36 @@ export function TransitionStartEmail({
             <Heading style={emailStyles.h1}>Hosted Pro is here.</Heading>
 
             <Text style={emailStyles.eyebrow}>In short</Text>
-            <Text style={emailStyles.bullet}>
-                &bull; You keep full free access until{" "}
-                <strong>{deadline}</strong>. Nothing changes today.
-            </Text>
+            <Bullet>
+                You keep full free access until <strong>{deadline}</strong>.
+                Nothing changes today.
+            </Bullet>
             {foundingOfferAvailable ? (
-                <Text style={emailStyles.bullet}>
-                    &bull; After that, Hosted Pro is{" "}
+                <Bullet>
+                    After that, Hosted Pro is{" "}
                     <strong>
                         {formatEmailPrice(amountValue, amountCurrency)}
-                    </strong>{" "}
-                    if you subscribe before then, locked in for as long as you
-                    stay subscribed.
-                </Text>
+                    </strong>
+                    , locked in for as long as you stay subscribed, for the
+                    first {foundingCapacity} paid monthly members (first-paid,
+                    first-served).
+                </Bullet>
             ) : (
-                <Text style={emailStyles.bullet}>
-                    &bull; After that, Hosted Pro is{" "}
+                <Bullet>
+                    After that, Hosted Pro is{" "}
                     <strong>
                         {formatEmailPrice(amountValue, amountCurrency)}
                     </strong>
                     .
-                </Text>
+                </Bullet>
             )}
-            <Text style={emailStyles.bullet}>
-                &bull; If you don't act, your account goes read-only. Nothing
-                gets deleted.
-            </Text>
-            <Text style={{ ...emailStyles.bullet, margin: "0" }}>
-                &bull; Self-hosting stays free forever. That's not changing.
-            </Text>
+            <Bullet>
+                If you don't act, your account goes read-only. Nothing gets
+                deleted.
+            </Bullet>
+            <Bullet margin="0">
+                Self-hosting stays free forever. That's not changing.
+            </Bullet>
             <Hr style={{ ...emailStyles.divider, margin: "20px 0 24px 0" }} />
 
             <Text style={emailStyles.text}>
@@ -129,32 +159,31 @@ export function TransitionStartEmail({
                 What this means for your account
             </Heading>
 
-            <Text style={emailStyles.bullet}>
-                &bull; Your access stays free until <strong>{deadline}</strong>.
-            </Text>
+            <Bullet>
+                Your access stays free until <strong>{deadline}</strong>.
+            </Bullet>
             {foundingOfferAvailable ? (
-                <Text style={emailStyles.bullet}>
-                    &bull; As an early user, you can lock in the founding price
-                    of{" "}
+                <Bullet>
+                    As an early user, you can lock in the founding price of{" "}
                     <strong>
                         {formatEmailPrice(amountValue, amountCurrency)}
                     </strong>
                     , limited to the first {foundingCapacity} paid monthly
                     members, first-paid, first-served.
-                </Text>
+                </Bullet>
             ) : (
-                <Text style={emailStyles.bullet}>
-                    &bull; Monthly Hosted Pro is available for{" "}
+                <Bullet>
+                    Monthly Hosted Pro is available for{" "}
                     <strong>
                         {formatEmailPrice(amountValue, amountCurrency)}
                     </strong>
                     .
-                </Text>
+                </Bullet>
             )}
-            <Text style={{ ...emailStyles.bullet, margin: "0 0 16px 0" }}>
-                &bull; You can cancel anytime. Canceling starts a grace period,
-                so nothing is lost immediately even then.
-            </Text>
+            <Bullet margin="0 0 16px 0">
+                You can cancel anytime. Canceling starts a grace period, so
+                nothing is lost immediately even then.
+            </Bullet>
 
             <Section style={emailStyles.buttonSection}>
                 <Button style={emailStyles.button} href={billingUrl}>

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -586,6 +586,8 @@ export async function sendTransitionStartEmail(input: {
     billingUrl: string;
     exportUrl: string;
     selfHostUrl: string;
+    /** Sponsorship destination. Omit until a real one exists. */
+    sponsorUrl?: string;
 }): Promise<boolean> {
     return sendClaimedEmail(
         { userId: input.userId, kind: "transition_start" },
@@ -600,12 +602,13 @@ export async function sendTransitionStartEmail(input: {
                     billingUrl: input.billingUrl,
                     exportUrl: input.exportUrl,
                     selfHostUrl: input.selfHostUrl,
+                    sponsorUrl: input.sponsorUrl,
                 }),
                 { pretty: false },
             );
             return {
                 to: input.email,
-                subject: "Riffado Hosted Pro is live",
+                subject: "Why Riffado Hosted Pro is happening",
                 html,
             };
         },

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -586,8 +586,6 @@ export async function sendTransitionStartEmail(input: {
     billingUrl: string;
     exportUrl: string;
     selfHostUrl: string;
-    /** Sponsorship destination. Omit until a real one exists. */
-    sponsorUrl?: string;
 }): Promise<boolean> {
     return sendClaimedEmail(
         { userId: input.userId, kind: "transition_start" },
@@ -602,7 +600,6 @@ export async function sendTransitionStartEmail(input: {
                     billingUrl: input.billingUrl,
                     exportUrl: input.exportUrl,
                     selfHostUrl: input.selfHostUrl,
-                    sponsorUrl: input.sponsorUrl,
                 }),
                 { pretty: false },
             );

--- a/src/tests/email/transition-start-copy.test.ts
+++ b/src/tests/email/transition-start-copy.test.ts
@@ -25,8 +25,8 @@ describe("TransitionStartEmail", () => {
         expect(text).toContain("first 100 paid monthly members");
         expect(text).toContain("first-paid, first-served");
         expect(text).toContain("Claim founding price");
-        expect(text).toContain("your Hosted account becomes read-only");
-        expect(text).toContain("Nothing will be deleted");
+        expect(text).toContain("your account becomes read-only");
+        expect(text).toContain("Nothing gets deleted");
         expect(text).not.toContain("Add a card before then");
         expect(text).toContain(
             "https://github.com/riffado/riffado#quick-start",
@@ -45,5 +45,57 @@ describe("TransitionStartEmail", () => {
         expect(text).toContain("Monthly Hosted Pro is available for $9");
         expect(text).toContain("Choose a plan");
         expect(text).not.toContain("first 100 paid monthly members");
+    });
+
+    it("explains why hosted is now paid, not just what changed", async () => {
+        const text = await render(
+            React.createElement(TransitionStartEmail, {
+                ...baseProps,
+                foundingOfferAvailable: true,
+            }),
+            { plainText: true },
+        );
+        expect(text).toContain("real infrastructure");
+        expect(text).toContain("no lock-in");
+        expect(text).toContain("Self-host and Hosted Pro are the same project");
+    });
+
+    it("gives account-critical facts their own scannable section", async () => {
+        const text = await render(
+            React.createElement(TransitionStartEmail, {
+                ...baseProps,
+                foundingOfferAvailable: true,
+            }),
+            { plainText: true },
+        );
+        expect(text.toLowerCase()).toContain(
+            "what this means for your account",
+        );
+        expect(text).toContain("grace period");
+    });
+
+    it("omits the sponsorship paragraph when no sponsorUrl is provided", async () => {
+        const text = await render(
+            React.createElement(TransitionStartEmail, {
+                ...baseProps,
+                foundingOfferAvailable: true,
+            }),
+            { plainText: true },
+        );
+        expect(text).not.toContain("sponsor Riffado directly");
+    });
+
+    it("includes the sponsorship paragraph when sponsorUrl is provided", async () => {
+        const text = await render(
+            React.createElement(TransitionStartEmail, {
+                ...baseProps,
+                foundingOfferAvailable: true,
+                sponsorUrl: "https://github.com/sponsors/riffado",
+            }),
+            { plainText: true },
+        );
+        expect(text).toContain("sponsor Riffado directly");
+        expect(text).toContain("https://github.com/sponsors/riffado");
+        expect(text).toContain("never required");
     });
 });

--- a/src/tests/email/transition-start-copy.test.ts
+++ b/src/tests/email/transition-start-copy.test.ts
@@ -73,29 +73,4 @@ describe("TransitionStartEmail", () => {
         );
         expect(text).toContain("grace period");
     });
-
-    it("omits the sponsorship paragraph when no sponsorUrl is provided", async () => {
-        const text = await render(
-            React.createElement(TransitionStartEmail, {
-                ...baseProps,
-                foundingOfferAvailable: true,
-            }),
-            { plainText: true },
-        );
-        expect(text).not.toContain("sponsor Riffado directly");
-    });
-
-    it("includes the sponsorship paragraph when sponsorUrl is provided", async () => {
-        const text = await render(
-            React.createElement(TransitionStartEmail, {
-                ...baseProps,
-                foundingOfferAvailable: true,
-                sponsorUrl: "https://github.com/sponsors/riffado",
-            }),
-            { plainText: true },
-        );
-        expect(text).toContain("sponsor Riffado directly");
-        expect(text).toContain("https://github.com/sponsors/riffado");
-        expect(text).toContain("never required");
-    });
 });

--- a/src/tests/email/transition-start-copy.test.ts
+++ b/src/tests/email/transition-start-copy.test.ts
@@ -73,4 +73,21 @@ describe("TransitionStartEmail", () => {
         );
         expect(text).toContain("grace period");
     });
+
+    it("states the founding-capacity qualifier in the top summary too, not only in the full account section", async () => {
+        const text = await render(
+            React.createElement(TransitionStartEmail, {
+                ...baseProps,
+                foundingOfferAvailable: true,
+            }),
+            { plainText: true },
+        );
+        const inShortSection = text.split("In short")[1]?.split("---")[0] ?? "";
+        // A skimmer who only reads the top summary must not be able to read
+        // it as a guaranteed founding price -- the first-paid/first-served
+        // capacity limit has to be there, not only in the fuller section
+        // below that a skimmer may never reach.
+        expect(inShortSection).toContain("first 100 paid monthly members");
+        expect(inShortSection).toContain("first-paid, first-served");
+    });
 });


### PR DESCRIPTION
Replaces the purely transactional Hosted Pro launch email (price, deadline, CTA, nothing else) with a story-driven announcement.

## What changed

- Explains *why* hosted Riffado moved to paid (real infrastructure costs, funding the project honestly, no ads/data-selling/lock-in) and *why self-hosting stays a fully equal path*, not a downgrade.
- Keeps the account-critical facts (deadline, price, cancel/grace behavior, read-only consequence, "nothing deleted") in their own clearly separated "What this means for your account" section, plus a short "In short" bullet summary at the top for skimmers. This is a notice of an account change as much as a story — readers need to find the mechanics without reading the whole letter.
- New shared styles (`emailStyles.bullet`, `emailStyles.eyebrow`) instead of a bordered/tinted callout card for the summary — matches the site's existing mono-uppercase section-label pattern (`PRICING`, `FAQ`) instead of introducing a one-off card component.
- Subject line: "Riffado Hosted Pro is live" → "Why Riffado Hosted Pro is happening".

No sponsorship mention — this is a one-shot email sent today via the manual launch script, so there's no realistic window for a sponsorship destination to exist before send. Not worth carrying dead optionality for it.

## Verification

- `pnpm format-and-lint:fix`, `pnpm type-check`, full test suite (765 passed).
- Rewrote `transition-start-copy.test.ts` for the new copy.
- Visually verified both pricing branches (founding / standard) via rendered HTML screenshots.

No behavioral change to send logic, dedup key (`transition_start`), or the cohort this email reaches (still only the grandfathered pre-launch users selected by the existing worker/launch-script queries).
