### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0] - 2026-07-20
 
 ### Breaking Changes
 - Upgrading runs migrations `0024` through `0034`. Back up PostgreSQL first. Migration `0024_sour_serpent_society.sql` drops the unused `storage_config` table with `CASCADE`; dump any historical rows before upgrading if they still matter ([#83](https://github.com/riffado/riffado/issues/83)). The remaining billing, export, email, and metering migrations are additive. No new environment variable is required for a normal self-hosted installation.
@@ -216,7 +216,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/riffado/riffado/compare/v0.5.6...HEAD
+[unreleased]: https://github.com/riffado/riffado/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/riffado/riffado/compare/v0.5.6...v0.6.0
 [0.5.6]: https://github.com/riffado/riffado/releases/tag/v0.5.6
 [0.5.5]: https://github.com/riffado/riffado/releases/tag/v0.5.5
 [0.5.4]: https://github.com/riffado/riffado/releases/tag/v0.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.6.0] - 2026-07-20
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "riffado",
-    "version": "0.5.6",
+    "version": "0.6.0",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "Riffado Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.6.0.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the v0.6.0 tag, which triggers
`docker.yml` and `release.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v0.6.0 release by bumping the version and updating the changelog. This release includes breaking database migrations (0024–0034), including dropping the unused storage_config table.

- **Migration**
  - Back up PostgreSQL before upgrading.
  - If you still need historical data in storage_config, export it first; migration 0024 drops the table with CASCADE.
  - Apply migrations 0024–0034 during upgrade as usual. No new env vars are needed for standard self-hosted setups.

<sup>Written for commit b781516fd3b9f0075842a0c5dad61431bd697f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

