### PR TITLE
fix(ci): correct broken Quick Start anchor in release notes template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
             printf '%s\n' "$BODY"
             printf '\n---\n\n'
             printf 'Full changelog: [CHANGELOG.md](https://github.com/%s/blob/%s/CHANGELOG.md)\n' "$REPO" "$TAG"
-            printf 'Install: see `docker-compose.yml` and `env.example` attached below, or follow [README \xe2\x86\x92 Quick Start](https://github.com/%s#-quick-start).\n' "$REPO"
+            printf 'Install: see `docker-compose.yml` and `env.example` attached below, or follow [README \xe2\x86\x92 Quick Start](https://github.com/%s#quick-start).\n' "$REPO"
           } > /tmp/release-body.md
           # Output name uses an underscore so `${{ steps.notes.outputs.body_path }}`
           # is parsed as a property access rather than `body - path`.


### PR DESCRIPTION
Found reviewing the v0.6.0 draft release notes: the "Install" footer line links to `https://github.com/riffado/riffado#-quick-start` (stray extra leading hyphen). README's actual heading is `## Quick start` (no emoji), so GitHub's real anchor is `#quick-start` — matching the convention already used everywhere else in the codebase (`SELF_HOST_URL` constants in `transition-emails.ts`, `send-hosted-pro-launch-email.ts`, and their tests).

This affected every release note this workflow has ever generated, not just v0.6.0's draft — fixing at the template source so future releases don't repeat it. The already-generated v0.6.0 draft gets a manual one-off edit, tracked separately (not code).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the "Install" link in the release notes template to the correct README anchor for Quick start. It now uses `#quick-start` (no stray hyphen), so future releases include a working link.

<sup>Written for commit fbfd8ef010f780fde9d33fb60a02baf092c86500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

