### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-20
+
 ### Fixed
-- The standalone Docker image built by this release crashed on startup for every deployment, self-host and hosted alike (`TypeError: ... is not a function` from `src/instrumentation.ts`). Next.js's output tracer externalized `@react-email/render`'s `prettier` dependency into a build directory this project's `Dockerfile` didn't copy into the image, breaking every worker that sends email. Replaced `@react-email/render` with a small helper built directly on `react-dom/server`, removing the dependency from the runtime image entirely.
+- The standalone Docker image built by v0.6.0 crashed on startup for every deployment, self-host and hosted alike (`TypeError: ... is not a function` from `src/instrumentation.ts`). Next.js's output tracer externalized `@react-email/render`'s `prettier` dependency into a build directory this project's `Dockerfile` didn't copy into the image, breaking every worker that sends email. Replaced `@react-email/render` with a small helper built directly on `react-dom/server`, removing the dependency from the runtime image entirely. v0.6.0's GitHub Release was never published; this is the first public release of that cycle.
 
 ## [0.6.0] - 2026-07-20
 
@@ -221,7 +223,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/riffado/riffado/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/riffado/riffado/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/riffado/riffado/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/riffado/riffado/compare/v0.5.6...v0.6.0
 [0.5.6]: https://github.com/riffado/riffado/releases/tag/v0.5.6
 [0.5.5]: https://github.com/riffado/riffado/releases/tag/v0.5.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "riffado",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "Riffado Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Patch release, cut immediately after merging #239.

v0.6.0's Docker image crashed on startup for every deployment (self-host and hosted). Its GitHub Release was intentionally left as a draft and will not be published. v0.6.1 is the first public release of this cycle.

After merge: `bun scripts/release.ts finalize` tags the release commit, which triggers `docker.yml` and `release.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish v0.6.1 (first public release of this cycle), replacing the unpublished v0.6.0. Includes the fix for the standalone Docker image crash at startup by replacing `@react-email/render` with a small `react-dom/server` helper.

<sup>Written for commit 8d14d3add79bcb9c8d31aafa253cee07083195a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

