### PR TITLE
fix: block dashboard access until onboarding completes

### DIFF
--- a/src/app/(app)/recordings/[id]/page.tsx
+++ b/src/app/(app)/recordings/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { RecordingWorkstation } from "@/components/recordings/recording-workstation";
 import { db } from "@/db";
 import { recordings, transcriptions, userSettings } from "@/db/schema";
-import { requireAuth } from "@/lib/auth-server";
+import { requireAuth, requireCompletedOnboarding } from "@/lib/auth-server";
 import { decryptText } from "@/lib/encryption/fields";
 
 interface RecordingDetailPageProps {
@@ -15,6 +15,7 @@ export default async function RecordingDetailPage({
 }: RecordingDetailPageProps) {
     // Check authentication server-side
     const session = await requireAuth();
+    await requireCompletedOnboarding(session);
     const { id } = await params;
 
     // Fetch recording from database

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,10 +1,11 @@
 import { SettingsPageContent } from "@/components/settings/settings-page-content";
 import { listUserProviders } from "@/lib/ai/list-providers";
-import { requireAuth } from "@/lib/auth-server";
+import { requireAuth, requireCompletedOnboarding } from "@/lib/auth-server";
 import { env } from "@/lib/env";
 
 export default async function SettingsPage() {
     const session = await requireAuth();
+    await requireCompletedOnboarding(session);
 
     const providers = await listUserProviders(session.user.id);
 

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -111,7 +111,13 @@ export function Workstation({
         recordings.length > 0 ? recordings[0] : null,
     );
     const [settingsOpen, setSettingsOpen] = useState(false);
-    const [onboardingOpen, setOnboardingOpen] = useState(false);
+    // Auto-opens on first paint when the account hasn't finished
+    // onboarding yet (server-supplied truth, re-evaluated on every fresh
+    // navigation to this page). Everyone must finish onboarding --
+    // `mandatory` below keeps it non-dismissible in that case.
+    const [onboardingOpen, setOnboardingOpen] = useState(
+        () => !initialSettings.onboardingCompleted,
+    );
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
     const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
@@ -469,6 +475,7 @@ export function Workstation({
                     setOnboardingOpen(false);
                     refresh();
                 }}
+                mandatory={!initialSettings.onboardingCompleted}
             />
         </>
     );

--- a/src/components/onboarding-dialog-base.tsx
+++ b/src/components/onboarding-dialog-base.tsx
@@ -32,9 +32,18 @@ function OnboardingDialogContent({
     className,
     children,
     ref,
+    hideCloseButton = false,
     ...props
 }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;
+    /**
+     * Hides the top-right close (X) button. Used for the mandatory,
+     * first-run onboarding flow -- combined with blocking Escape/
+     * outside-click in the caller, this makes the dialog non-dismissible
+     * until the user completes it. Defaults to `false` so every other
+     * (dismissible) usage is unaffected.
+     */
+    hideCloseButton?: boolean;
 }) {
     return (
         <OnboardingDialogPortal>
@@ -48,10 +57,12 @@ function OnboardingDialogContent({
                 {...props}
             >
                 {children}
-                <DialogPrimitive.Close className="group absolute right-3 top-3 flex size-7 items-center justify-center rounded-lg outline-offset-2 transition-colors focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none">
-                    <X className="size-4 opacity-60 transition-opacity group-hover:opacity-100" />
-                    <span className="sr-only">Close</span>
-                </DialogPrimitive.Close>
+                {!hideCloseButton && (
+                    <DialogPrimitive.Close className="group absolute right-3 top-3 flex size-7 items-center justify-center rounded-lg outline-offset-2 transition-colors focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none">
+                        <X className="size-4 opacity-60 transition-opacity group-hover:opacity-100" />
+                        <span className="sr-only">Close</span>
+                    </DialogPrimitive.Close>
+                )}
             </DialogPrimitive.Content>
         </OnboardingDialogPortal>
     );

--- a/src/components/onboarding-dialog.tsx
+++ b/src/components/onboarding-dialog.tsx
@@ -32,12 +32,21 @@ interface OnboardingDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onComplete: () => void;
+    /**
+     * True when the user has not finished onboarding yet -- makes the
+     * dialog non-dismissible (no close button, Escape and outside-click
+     * are suppressed) so the flow can't be abandoned partway. False for
+     * the voluntary "Re-run Onboarding" re-entry from Settings, which
+     * stays dismissible like before.
+     */
+    mandatory?: boolean;
 }
 
 export function OnboardingDialog({
     open,
     onOpenChange,
     onComplete,
+    mandatory = false,
 }: OnboardingDialogProps) {
     const { refresh } = useRouter();
     const [step, setStep] = useState<OnboardingStep>("welcome");
@@ -113,7 +122,19 @@ export function OnboardingDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+            <DialogContent
+                className="max-w-2xl max-h-[90vh] overflow-y-auto sm:max-w-[600px]"
+                hideCloseButton={mandatory}
+                onEscapeKeyDown={(e) => {
+                    if (mandatory) e.preventDefault();
+                }}
+                onPointerDownOutside={(e) => {
+                    if (mandatory) e.preventDefault();
+                }}
+                onInteractOutside={(e) => {
+                    if (mandatory) e.preventDefault();
+                }}
+            >
                 <DialogHeader>
                     <DialogTitle className="text-2xl" hidden>
                         Welcome to Riffado

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { db } from "@/db";
-import { users } from "@/db/schema";
+import { userSettings, users } from "@/db/schema";
 import { auth } from "./auth";
 import { AppError, ErrorCode } from "./errors";
 
@@ -32,6 +32,32 @@ export async function requireAuth() {
     }
 
     return session;
+}
+
+/**
+ * Redirects to `/dashboard` unless the session's account has finished
+ * onboarding (`userSettings.onboardingCompleted`). Call after
+ * `requireAuth()` from any authenticated content page other than
+ * `/dashboard` itself, which owns the mandatory onboarding dialog and
+ * must not redirect into itself.
+ *
+ * Deliberately separate from `requireAuth()` (rather than folded into
+ * it) so it doesn't blanket-apply to every `requireAuth()` caller --
+ * notably `/dev/demo-dashboard`, which renders fixtures, not a real
+ * account, and must never be gated on this.
+ */
+export async function requireCompletedOnboarding(
+    session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
+) {
+    const [row] = await db
+        .select({ onboardingCompleted: userSettings.onboardingCompleted })
+        .from(userSettings)
+        .where(eq(userSettings.userId, session.user.id))
+        .limit(1);
+
+    if (!row?.onboardingCompleted) {
+        redirect("/dashboard");
+    }
 }
 
 export async function redirectIfAuthenticated() {

--- a/src/lib/demo/fixtures.ts
+++ b/src/lib/demo/fixtures.ts
@@ -296,6 +296,9 @@ export function isDemoRecordingId(id: string): boolean {
  *     prompts pollute screenshots).
  *   - listDensity: comfortable, dateTimeFormat: relative (the
  *     visually-richer defaults).
+ *   - onboardingCompleted: true (this route renders fixtures, not a
+ *     real account -- the mandatory onboarding dialog must never cover
+ *     the screenshot).
  */
 export const DEMO_INITIAL_SETTINGS: InitialSettings = {
     ...INITIAL_SETTINGS_DEFAULTS,
@@ -306,4 +309,5 @@ export const DEMO_INITIAL_SETTINGS: InitialSettings = {
     browserNotifications: false,
     listDensity: "comfortable",
     dateTimeFormat: "relative",
+    onboardingCompleted: true,
 };

--- a/src/lib/settings/initial-settings.ts
+++ b/src/lib/settings/initial-settings.ts
@@ -16,6 +16,14 @@ export interface InitialSettings {
     syncOnVisibilityChange: boolean;
     syncNotifications: boolean;
     browserNotifications: boolean;
+    /**
+     * True once the user has clicked through the onboarding dialog's
+     * "Get Started" step. Drives the mandatory onboarding gate in
+     * `Workstation` -- when false, the dialog auto-opens and can't be
+     * dismissed. See `onboarding-dialog.tsx` and `requireCompletedOnboarding`
+     * in `auth-server.ts`.
+     */
+    onboardingCompleted: boolean;
 }
 
 export const INITIAL_SETTINGS_DEFAULTS: InitialSettings = {
@@ -34,6 +42,7 @@ export const INITIAL_SETTINGS_DEFAULTS: InitialSettings = {
     syncOnVisibilityChange: true,
     syncNotifications: true,
     browserNotifications: true,
+    onboardingCompleted: false,
 };
 
 type Row = typeof userSettings.$inferSelect | undefined | null;
@@ -70,5 +79,8 @@ export function initialSettingsFromRow(row: Row): InitialSettings {
         browserNotifications:
             r?.browserNotifications ??
             INITIAL_SETTINGS_DEFAULTS.browserNotifications,
+        onboardingCompleted:
+            r?.onboardingCompleted ??
+            INITIAL_SETTINGS_DEFAULTS.onboardingCompleted,
     };
 }


### PR DESCRIPTION
## Description

New signups were never actually forced through onboarding. The richer onboarding dialog (Connect Plaud -> AI Provider -> Complete) only set `userSettings.onboardingCompleted` when manually retriggered from Settings -> "Re-run Onboarding" -- `Workstation` never auto-opened it, so users landed on `/dashboard` with onboarding effectively skipped and no gate anywhere else in the app.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

- Thread `onboardingCompleted` through `InitialSettings` from the DB row (and force it `true` in the demo fixtures so the `/dev/demo-dashboard` screenshot route is unaffected).
- `Workstation` now auto-opens `OnboardingDialog` on first paint when onboarding is incomplete, and makes it non-dismissible (no close button, Escape/outside-click suppressed) only in that mandatory case -- the voluntary "Re-run Onboarding" flow from Settings stays dismissible as before.
- Add `requireCompletedOnboarding()` in `auth-server.ts`, kept separate from `requireAuth()` so it doesn't affect `/dev/demo-dashboard` (fixture-based, not a real account).
- Wire `requireCompletedOnboarding()` into `/settings` and `/recordings/[id]` so those routes can't be reached directly while onboarding is incomplete.
- Existing users are not backfilled/grandfathered -- everyone with `onboardingCompleted = false` sees the dialog once on next login. Each step auto-detects prior state (already-connected Plaud, already-configured AI provider), so it's a low-friction click-through for accounts that are already fully set up.

## Testing

- `pnpm format-and-lint:fix`
- `pnpm type-check`
- Not run: `pnpm test` (not requested)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] Type checking passes (`pnpm type-check`)
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`) -- not run
- [ ] I have added tests that prove my fix is effective -- not added

## Database Changes

No schema changes. `userSettings.onboardingCompleted` already existed; this PR only wires up code that reads/enforces it.

## Breaking Changes

Existing accounts with `onboardingCompleted = false` (essentially all of them today, since the flag was never being set) will see the onboarding dialog once on their next dashboard visit. It auto-detects already-connected Plaud / already-configured AI provider, so it's click-through rather than re-setup.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force users to complete onboarding before accessing the dashboard, settings, or recordings. Prevents new signups from skipping setup; the demo screenshot route stays unaffected.

- **Bug Fixes**
  - Threaded `onboardingCompleted` into `InitialSettings`; set to true in demo fixtures.
  - `Workstation` now auto-opens `OnboardingDialog` when onboarding isn’t done and makes it non-dismissible in that case only.
  - Added `requireCompletedOnboarding()` in `auth-server.ts` and enforced it on `/settings` and `/recordings/[id]` (redirects to `/dashboard` until complete).
  - No schema changes; existing users with `onboardingCompleted = false` will see the dialog once, with steps auto-detecting existing Plaud/AI setup.

<sup>Written for commit 809f50611957038dafdebcf4ab8927e1346d1bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

