### PR TITLE
fix(auth): show check-email notice after signup when verification is required

### DIFF
--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -4,6 +4,7 @@ import {
     SelfHostAuthChrome,
 } from "@/components/auth/auth-chrome";
 import { RegisterForm } from "@/components/auth/register-form";
+import { emailVerificationRequired } from "@/lib/auth";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
 import { env } from "@/lib/env";
 
@@ -24,7 +25,9 @@ export default async function RegisterPage() {
                 title="Create your account"
                 subtitle="Free to start. Upgrade only when you outgrow it."
             >
-                <RegisterForm />
+                <RegisterForm
+                    requireEmailVerification={emailVerificationRequired}
+                />
             </HostedAuthChrome>
         );
     }
@@ -34,7 +37,9 @@ export default async function RegisterPage() {
             title="Create your account"
             subtitle="The first account on a new Riffado instance becomes the admin."
         >
-            <RegisterForm />
+            <RegisterForm
+                requireEmailVerification={emailVerificationRequired}
+            />
         </SelfHostAuthChrome>
     );
 }

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -7,18 +7,34 @@ import { toast } from "sonner";
 import { MetalButton } from "@/components/metal-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { signUp } from "@/lib/auth-client";
+import { sendVerificationEmail, signUp } from "@/lib/auth-client";
+
+const RESEND_COOLDOWN_MS = 30_000;
+
+interface RegisterFormProps {
+    /**
+     * Whether the instance requires email verification before sign-in
+     * (`emailVerificationRequired` in `src/lib/auth.ts` -- hosted + SMTP
+     * configured only). When true, `signUp.email()` creates the user but
+     * does not create a session, so we can't redirect into the app; we
+     * show an in-place "check your email" panel instead.
+     */
+    requireEmailVerification: boolean;
+}
 
 /**
  * Renders only the form (fields + submit + sign-in footer).
  * Page chrome (logo, headings, panel, background) is owned by the route.
  */
-export function RegisterForm() {
+export function RegisterForm({ requireEmailVerification }: RegisterFormProps) {
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [isLoading, setIsLoading] = useState(false);
+    const [awaitingVerification, setAwaitingVerification] = useState(false);
+    const [lastResentAt, setLastResentAt] = useState(0);
+    const [isResending, setIsResending] = useState(false);
     const { push, refresh } = useRouter();
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -41,10 +57,21 @@ export function RegisterForm() {
                 email,
                 password,
                 name,
+                // Where the auto-sign-in-after-verification redirect lands the
+                // user once they click the emailed link -- matches the
+                // destination used when verification is off, so both paths
+                // funnel through onboarding (Plaud connection) the same way.
+                callbackURL: "/onboarding",
             });
 
             if (result.error) {
                 toast.error(result.error.message || "Failed to create account");
+                return;
+            }
+
+            if (requireEmailVerification) {
+                setLastResentAt(Date.now());
+                setAwaitingVerification(true);
                 return;
             }
 
@@ -62,75 +89,135 @@ export function RegisterForm() {
         }
     };
 
+    const handleResend = async () => {
+        const now = Date.now();
+        if (now - lastResentAt < RESEND_COOLDOWN_MS) {
+            const secs = Math.ceil(
+                (RESEND_COOLDOWN_MS - (now - lastResentAt)) / 1000,
+            );
+            toast.error(`Please wait ${secs}s before resending`);
+            return;
+        }
+
+        setIsResending(true);
+        try {
+            const result = await sendVerificationEmail({
+                email,
+                callbackURL: "/onboarding",
+            });
+
+            if (result.error) {
+                toast.error(
+                    result.error.message ||
+                        "Failed to resend verification email",
+                );
+                return;
+            }
+
+            setLastResentAt(Date.now());
+            toast.success("Verification email resent");
+        } catch (error) {
+            const message =
+                error instanceof Error
+                    ? error.message
+                    : "Failed to resend verification email";
+            toast.error(message);
+        } finally {
+            setIsResending(false);
+        }
+    };
+
     return (
         <div className="space-y-6">
-            <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-2">
-                    <Label htmlFor="name">Name</Label>
-                    <Input
-                        id="name"
-                        type="text"
-                        placeholder="John Doe"
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        required
-                        disabled={isLoading}
-                        autoComplete="name"
-                    />
+            {awaitingVerification ? (
+                <div className="space-y-3 rounded-md border border-border bg-muted/40 p-4 text-sm">
+                    <p className="font-medium">Check your email.</p>
+                    <p className="text-muted-foreground">
+                        We sent a verification link to{" "}
+                        <span className="font-mono text-xs">{email}</span>.
+                        Click the link to activate your account -- you won't be
+                        able to sign in until it's verified.
+                    </p>
+                    <button
+                        type="button"
+                        onClick={handleResend}
+                        disabled={isResending}
+                        className="text-accent-cyan hover:underline disabled:opacity-50"
+                    >
+                        {isResending ? "Resending..." : "Resend email"}
+                    </button>
                 </div>
+            ) : (
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Name</Label>
+                        <Input
+                            id="name"
+                            type="text"
+                            placeholder="John Doe"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            required
+                            disabled={isLoading}
+                            autoComplete="name"
+                        />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                        id="email"
-                        type="email"
-                        placeholder="you@example.com"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        required
+                    <div className="space-y-2">
+                        <Label htmlFor="email">Email</Label>
+                        <Input
+                            id="email"
+                            type="email"
+                            placeholder="you@example.com"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            required
+                            disabled={isLoading}
+                            autoComplete="email"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="password">Password</Label>
+                        <Input
+                            id="password"
+                            type="password"
+                            placeholder="••••••••"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            required
+                            disabled={isLoading}
+                            minLength={8}
+                            autoComplete="new-password"
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="confirmPassword">
+                            Confirm Password
+                        </Label>
+                        <Input
+                            id="confirmPassword"
+                            type="password"
+                            placeholder="••••••••"
+                            value={confirmPassword}
+                            onChange={(e) => setConfirmPassword(e.target.value)}
+                            required
+                            disabled={isLoading}
+                            autoComplete="new-password"
+                        />
+                    </div>
+
+                    <MetalButton
+                        type="submit"
+                        className="w-full"
+                        variant="cyan"
                         disabled={isLoading}
-                        autoComplete="email"
-                    />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="password">Password</Label>
-                    <Input
-                        id="password"
-                        type="password"
-                        placeholder="••••••••"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        required
-                        disabled={isLoading}
-                        minLength={8}
-                        autoComplete="new-password"
-                    />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="confirmPassword">Confirm Password</Label>
-                    <Input
-                        id="confirmPassword"
-                        type="password"
-                        placeholder="••••••••"
-                        value={confirmPassword}
-                        onChange={(e) => setConfirmPassword(e.target.value)}
-                        required
-                        disabled={isLoading}
-                        autoComplete="new-password"
-                    />
-                </div>
-
-                <MetalButton
-                    type="submit"
-                    className="w-full"
-                    variant="cyan"
-                    disabled={isLoading}
-                >
-                    {isLoading ? "Creating account..." : "Create Account"}
-                </MetalButton>
-            </form>
+                    >
+                        {isLoading ? "Creating account..." : "Create Account"}
+                    </MetalButton>
+                </form>
+            )}
 
             <div className="text-center text-sm">
                 <span className="text-muted-foreground">

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -16,4 +16,5 @@ export const {
     signUp,
     requestPasswordReset,
     resetPassword,
+    sendVerificationEmail,
 } = authClient;

--- a/src/lib/auth-rate-limit.ts
+++ b/src/lib/auth-rate-limit.ts
@@ -20,6 +20,11 @@ import {
  *   with one victim's address burns sender quota and bounce-spams the
  *   victim, hurting the instance's mail reputation. Needs a per-EMAIL cap,
  *   not just per-IP, because a distributed attacker rotates IPs.
+ * - `/send-verification-email` (the signup check-your-email resend action)
+ *   is the same SMTP-burn vector as password reset -- the client-side 30s
+ *   cooldown in `RegisterForm` is UX only and trivially bypassed by
+ *   reloading or calling the endpoint directly, so it needs the same
+ *   per-IP + per-EMAIL server-side cap.
  * - `/sign-in/email` is credential-stuffing surface (per-IP).
  * - `/sign-up/email` is spam-account surface (per-IP).
  * - `/reset-password` consumes a reset token (per-IP).
@@ -44,6 +49,7 @@ const RULES: Record<string, AuthRateRule> = {
     "/sign-up/email": { ipLimit: 5 },
     "/request-password-reset": { ipLimit: 5, emailLimit: 3 },
     "/reset-password": { ipLimit: 5 },
+    "/send-verification-email": { ipLimit: 5, emailLimit: 3 },
 };
 
 function authPath(request: Request): string {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,6 +28,15 @@ const EMAIL_VERIFICATION_TTL_SECONDS = 24 * 60 * 60;
  */
 const verificationActive = env.IS_HOSTED && isSmtpConfigured();
 
+/**
+ * Public alias for `verificationActive`, for callers outside this module
+ * (e.g. the register page/form) that need to know whether sign-up leaves
+ * the user unauthenticated pending email verification. Single source of
+ * truth -- don't re-derive the `IS_HOSTED && isSmtpConfigured()` condition
+ * elsewhere.
+ */
+export const emailVerificationRequired = verificationActive;
+
 export const auth = betterAuth({
     database: drizzleAdapter(db, {
         provider: "pg",

--- a/src/tests/regressions/85-auth-rate-limit.test.ts
+++ b/src/tests/regressions/85-auth-rate-limit.test.ts
@@ -12,6 +12,9 @@
  *   4. `/request-password-reset` applies a per-email bucket so a single victim
  *      can't be targeted from rotating IPs, and reading the email does NOT
  *      consume the request body (better-auth must still parse it).
+ *   5. `/send-verification-email` gets the same per-email cap as
+ *      `/request-password-reset` -- it's the same SMTP-burn vector, and the
+ *      client-side resend cooldown in `RegisterForm` is UX only.
  */
 
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -140,6 +143,25 @@ describe("enforceAuthRateLimit", () => {
         expect(consumeRateLimitBucket).toHaveBeenCalledTimes(1);
         expect(consumeRateLimitBucket).toHaveBeenCalledWith(
             "auth:email:/request-password-reset:a@b.com",
+            expect.objectContaining({ limit: 3 }),
+        );
+    });
+
+    it("applies a per-email bucket on send-verification-email", async () => {
+        (consumeRateLimitBucket as Mock)
+            .mockResolvedValueOnce(allowed()) // IP bucket
+            .mockResolvedValueOnce(blocked()); // email bucket
+
+        const result = await enforceAuthRateLimit(
+            authRequest("/send-verification-email", {
+                email: "a@b.com",
+                callbackURL: "/onboarding",
+            }),
+        );
+
+        expect(result?.status).toBe(429);
+        expect(consumeRateLimitBucket).toHaveBeenLastCalledWith(
+            "auth:email:/send-verification-email:a@b.com",
             expect.objectContaining({ limit: 3 }),
         );
     });


### PR DESCRIPTION
## Description

Fixes signup redirecting users to `/login` when email verification is required. When verification is enforced (hosted + SMTP configured), `signUp.email()` creates the user without a session, so the previous redirect to `/onboarding` bounced through `requireAuth()` back to `/login` with no explanation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

- Export `emailVerificationRequired` from `src/lib/auth.ts` as the single source of truth for whether signup leaves the user unauthenticated pending verification.
- Export `sendVerificationEmail` from the Better Auth client (`src/lib/auth-client.ts`).
- Pass `requireEmailVerification` into `RegisterForm` from the register page.
- `RegisterForm` now shows an in-place "check your email" panel with a rate-limited (30s) resend action instead of redirecting when verification is required.
- Set `callbackURL: "/onboarding"` on signup so verified users land in the same place as users who sign up when verification is off.

## Testing

- `pnpm format-and-lint:fix`
- `pnpm type-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes signup when email verification is required (hosted + SMTP). Users now see a “check your email” notice with a resend that is server-side rate-limited (per-IP and per-email), and verified users land on `/onboarding`.

- **Bug Fixes**
  - Show an in-place “check your email” panel with resend (30s client cooldown) and server-side limits when verification is enforced.
  - Use `emailVerificationRequired` as the single source of truth; pass it to `RegisterForm` and expose `sendVerificationEmail` for resends.
  - Set `callbackURL: "/onboarding"` on signup and resend so users return to the same place after verifying.

<sup>Written for commit a273b2788c6c263e48062d820af77c3dcc78393a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

