### PR TITLE
chore: add changelog entries for #243, #244

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- New signups landed on `/dashboard` with onboarding effectively skipped: `userSettings.onboardingCompleted` was only ever set when manually retriggered from Settings, never on first run. The onboarding dialog now auto-opens on first paint when onboarding is incomplete and is non-dismissible until it's done ([#243](https://github.com/riffado/riffado/pull/243)).
+- Signup with email verification enforced (hosted + SMTP configured) redirected straight to `/onboarding`, which bounced the unauthenticated user to `/login` since no session exists until the verification link is clicked. Signup now shows an in-place "check your email" panel with a rate-limited resend action ([#244](https://github.com/riffado/riffado/pull/244)).
+
 ## [0.6.1] - 2026-07-20
 
 ### Fixed


### PR DESCRIPTION
Backfills Unreleased entries for the onboarding-gate fix (#243) and check-email-notice fix (#244) ahead of the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Unreleased CHANGELOG entries for #243 (onboarding gate) and #244 (email verification notice) to prep the next release.

- **Bug Fixes**
  - New users now see the onboarding dialog on first load and can’t dismiss it until finished.
  - Signup with enforced email verification now shows an in-place “check your email” panel with a rate‑limited resend.

<sup>Written for commit a049e16f24789db1ec8be5e6c924d73eebc2c261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

