### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.6.2] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.2] - 2026-07-21
 
 ### Fixed
 - New signups landed on `/dashboard` with onboarding effectively skipped: `userSettings.onboardingCompleted` was only ever set when manually retriggered from Settings, never on first run. The onboarding dialog now auto-opens on first paint when onboarding is incomplete and is non-dismissible until it's done ([#243](https://github.com/riffado/riffado/pull/243)).
@@ -227,7 +227,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/riffado/riffado/compare/v0.6.1...HEAD
+[unreleased]: https://github.com/riffado/riffado/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/riffado/riffado/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/riffado/riffado/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/riffado/riffado/compare/v0.5.6...v0.6.0
 [0.5.6]: https://github.com/riffado/riffado/releases/tag/v0.5.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "riffado",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "Riffado Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.6.2.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.6.2` tag, which triggers
`docker.yml` and `release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.2 with fixes to onboarding and email verification signup flows to prevent skips and redirects to login.

- **Bug Fixes**
  - Onboarding now auto-opens on first load and can’t be dismissed until completed.
  - Email-verified signups show an in-place “check your email” screen with rate-limited resend instead of redirecting to `/onboarding` and then `/login`.

<sup>Written for commit ed298f660082ba9fe44cf1af83885815bf382db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

