### PR TITLE
fix(onboarding): tighten excessive spacing above onboarding step cards

### DIFF
--- a/src/components/onboarding-steps.tsx
+++ b/src/components/onboarding-steps.tsx
@@ -7,9 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export function OnboardingStepWelcome() {
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <div className="text-center space-y-2">
-                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-3">
                     <Mic className="size-8 text-primary" />
                 </div>
                 <h3 className="text-xl font-semibold">
@@ -81,9 +81,9 @@ export function OnboardingStepPlaud({
     onConnected: () => void;
 }) {
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <div className="text-center space-y-2">
-                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-3">
                     <Mic className="size-8 text-primary" />
                 </div>
                 <h3 className="text-xl font-semibold">
@@ -141,9 +141,9 @@ export function OnboardingStepAiProvider({
 }) {
     const includedOnly = hasIncludedProvider && !hasOwnProvider;
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <div className="text-center space-y-2">
-                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-3">
                     <Bot className="size-8 text-primary" />
                 </div>
                 <h3 className="text-xl font-semibold">
@@ -229,9 +229,9 @@ export function OnboardingStepComplete({
     hasIncludedProvider: boolean;
 }) {
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             <div className="text-center space-y-2">
-                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="size-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-3">
                     <CheckCircle2 className="size-8 text-primary" />
                 </div>
                 <h3 className="text-xl font-semibold">You're All Set!</h3>


### PR DESCRIPTION
## Description

Reduces excessive vertical whitespace above the content card in each onboarding dialog step (Welcome, Plaud, AI Provider, Complete). All four steps shared the same intro layout (icon + title + description) followed by a large gap before the card.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Reduced the outer spacing between the intro block and the content card from `space-y-6` to `space-y-4` across all four onboarding steps in `src/components/onboarding-steps.tsx`.
- Reduced the icon-to-title margin from `mb-4` to `mb-3` in the same steps for consistent tightened rhythm.

## Screenshots (if applicable)

N/A

## Testing

### Test Environment
- OS: macOS
- Node version: repo default
- Browser (if UI changes): N/A (not visually previewed in this session)

### Test Steps
1. `pnpm format-and-lint:fix`
2. `pnpm type-check`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

N/A

## Breaking Changes

N/A

## Additional Notes

Purely a spacing/CSS class change in `onboarding-steps.tsx`; no logic changes.

## For Reviewers

- Confirm the tightened spacing still reads well across all four onboarding steps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the vertical spacing above onboarding step cards so content sits closer to the intro block across Welcome, Plaud, AI Provider, and Complete. Updated `src/components/onboarding-steps.tsx` to reduce `space-y-6` → `space-y-4` and icon-to-title `mb-4` → `mb-3`.

<sup>Written for commit 4a9e9c20506fd14257cf046b19aa0a5accb5752e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

