### PR TITLE
fix(billing): reopen in-progress checkout instead of erroring

### DIFF
--- a/src/lib/hosted/billing/checkout.ts
+++ b/src/lib/hosted/billing/checkout.ts
@@ -42,6 +42,23 @@ export class CheckoutPreconditionError extends Error {
 }
 
 /**
+ * Resuming an existing, still-open Checkout Session rather than blocking
+ * the user with an error. Carries the prior session's own URL/id so the
+ * caller can just send the user back into the same Checkout flow instead
+ * of surfacing "a checkout is already in progress".
+ */
+export class CheckoutInProgressError extends CheckoutPreconditionError {
+    constructor(
+        message: string,
+        readonly existingCheckoutUrl: string | null,
+        readonly existingSessionId: string,
+    ) {
+        super(message, "checkout_in_progress");
+        this.name = "CheckoutInProgressError";
+    }
+}
+
+/**
  * Idempotent Stripe customer create + local mapping insert.
  *
  * The DB check-then-create above isn't atomic: two concurrent checkout
@@ -141,11 +158,28 @@ export async function startSubscriptionCheckout(
     }
 
     const interval = input.interval ?? "month";
-    const { price, reservation } = await resolveCheckoutPrice({
-        userId: input.userId,
-        country: input.country,
-        interval,
-    });
+    let price: ReturnType<typeof resolvePrice>;
+    let reservation: FoundingMemberReservationRow | null;
+    try {
+        ({ price, reservation } = await resolveCheckoutPrice({
+            userId: input.userId,
+            country: input.country,
+            interval,
+        }));
+    } catch (error) {
+        if (error instanceof CheckoutInProgressError) {
+            // Reuse the still-open prior session instead of erroring: resume
+            // the same Checkout the user already started.
+            if (!error.existingCheckoutUrl) {
+                throw error;
+            }
+            return {
+                checkoutUrl: error.existingCheckoutUrl,
+                sessionId: error.existingSessionId,
+            };
+        }
+        throw error;
+    }
 
     const stripe = getStripe();
 
@@ -436,7 +470,8 @@ async function reserveFoundingSlot(input: {
         if (!sessionId) {
             // Not yet attached to a Checkout Session -- a concurrent request
             // for this same user is mid-flight right now (or crashed between
-            // insert and attach). Either way, do not race it.
+            // insert and attach). Either way, do not race it. There is no
+            // prior session URL to hand back here, so this is a genuine error.
             throw new CheckoutPreconditionError(
                 "A checkout for this account is already in progress",
                 "checkout_in_progress",
@@ -458,11 +493,13 @@ async function reserveFoundingSlot(input: {
         }
 
         if (priorSession.status !== "expired") {
-            // `open`, or any other non-terminal Stripe session status --
-            // treat as still in progress rather than guessing.
-            throw new CheckoutPreconditionError(
+            // `open`, or any other non-terminal Stripe session status -- the
+            // user already has a live Checkout Session. Send them back into
+            // that same session instead of blocking with an error.
+            throw new CheckoutInProgressError(
                 "A checkout for this account is already in progress",
-                "checkout_in_progress",
+                priorSession.url,
+                priorSession.id,
             );
         }
 

--- a/src/tests/billing/checkout.test.ts
+++ b/src/tests/billing/checkout.test.ts
@@ -534,7 +534,7 @@ describe("startSubscriptionCheckout", () => {
             );
         });
 
-        it("refuses to touch a reservation whose Checkout Session is still open", async () => {
+        it("reopens the still-open prior Checkout Session instead of erroring", async () => {
             queriesMock.createFoundingMemberReservation.mockResolvedValue({
                 kind: "already_reserved",
                 existing: {
@@ -545,6 +545,36 @@ describe("startSubscriptionCheckout", () => {
             stripeMock.checkout.sessions.retrieve.mockResolvedValue({
                 id: "cs_open",
                 status: "open",
+                url: "https://checkout.stripe.com/cs_open",
+            });
+
+            const result = await startSubscriptionCheckout({
+                ...baseInput,
+                country: "US",
+            });
+
+            expect(result).toEqual({
+                checkoutUrl: "https://checkout.stripe.com/cs_open",
+                sessionId: "cs_open",
+            });
+            expect(
+                queriesMock.releaseFoundingMemberReservation,
+            ).not.toHaveBeenCalled();
+            expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+        });
+
+        it("still errors when the still-open prior session has no URL to reopen", async () => {
+            queriesMock.createFoundingMemberReservation.mockResolvedValue({
+                kind: "already_reserved",
+                existing: {
+                    id: "fmr_stale",
+                    stripeCheckoutSessionId: "cs_open",
+                },
+            });
+            stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+                id: "cs_open",
+                status: "open",
+                url: null,
             });
 
             await expect(


### PR DESCRIPTION
## Description

When a founding-price checkout reservation's Stripe Checkout Session is still `open` (a real, in-progress checkout), the backend used to throw `checkout_in_progress` and surface "A checkout for this account is already in progress" as an error to the user. Instead, it now returns the existing session's URL/id so the caller can send the user straight back into that same, still-valid Checkout Session.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Added `CheckoutInProgressError` (extends `CheckoutPreconditionError`) carrying the prior session's `checkoutUrl`/`sessionId`.
- `reserveFoundingSlot` throws `CheckoutInProgressError` when the existing reservation's Checkout Session is still `open`, instead of a plain precondition error.
- `startSubscriptionCheckout` catches `CheckoutInProgressError` and, when a URL is present, returns it directly (reopening the existing session) instead of erroring or creating a duplicate session.
- Falls back to the original error if Stripe's session object has no `url` (edge case) or if no session was ever attached yet (genuine concurrent-request race).
- Updated/added unit tests in `checkout.test.ts` covering both the reopen path and the no-URL fallback.

## Screenshots (if applicable)

N/A

## Testing

### Test Environment
- OS: n/a (unit tests only)
- Node version: n/a
- Browser (if UI changes): n/a

### Test Steps
1. `pnpm test src/tests/billing/checkout.test.ts`
2. `pnpm type-check`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

None.

## Additional Notes

Scope is limited to the founding-price reservation collision path in `src/lib/hosted/billing/checkout.ts`; no route or client changes were needed since the API route already forwards `{ checkoutUrl }` on success.

## For Reviewers

- Confirm reusing the existing Stripe Checkout Session URL (rather than creating a new one) is the desired UX for this race.
- Check the fallback behavior when `priorSession.url` is null.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reopens an in-progress founding-price Stripe Checkout instead of erroring, returning the existing session URL/id so users resume the same checkout. Prevents duplicate sessions and improves the checkout race UX.

- **Bug Fixes**
  - Added `CheckoutInProgressError` that includes `existingCheckoutUrl` and `existingSessionId`.
  - `reserveFoundingSlot` throws `CheckoutInProgressError` when the prior session is non-terminal (e.g., `open`).
  - `startSubscriptionCheckout` catches it and returns the existing session URL/id instead of creating a new session.
  - Falls back to the original error if no URL is available or no session is attached.
  - Updated tests to cover the reopen path and the no-URL fallback.

<sup>Written for commit 4ef87d348f74d560d93df61c012e29adb4e55354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

