### PR TITLE
fix(admin): split billing lockout tile into transition vs actually locked out

### DIFF
--- a/src/app/(hosted)/admin/(gated)/billing/page.tsx
+++ b/src/app/(hosted)/admin/(gated)/billing/page.tsx
@@ -40,7 +40,14 @@ export default async function AdminBillingPage({
             {/* Overview tiles */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                 <Tile label="Pro" value={counts.proPlan} />
-                <Tile label="Free/lockout" value={counts.freePlan} />
+                <Tile
+                    label="Free, in grace/transition"
+                    value={counts.freePlanInTransition}
+                />
+                <Tile
+                    label="Free, actually locked out"
+                    value={counts.freePlanLockedOut}
+                />
                 <Tile label="In trial" value={counts.inTrial} />
                 <Tile label="In grace" value={counts.inGrace} />
                 <Tile label="Active subs" value={counts.activeSubscriptions} />

--- a/src/db/queries/admin-billing.ts
+++ b/src/db/queries/admin-billing.ts
@@ -58,12 +58,12 @@ export async function billingOverview(): Promise<BillingOverview> {
             (select count(*)::int from users where plan = 'hosted_pro') as "proPlan",
             (select count(*)::int from users where plan = 'hosted_free') as "freePlan",
             (select count(*)::int from users
-             where plan = 'hosted_free'
+             where coalesce(plan, 'hosted_free') = 'hosted_free'
                and plan_transition_until is not null
                and plan_transition_until > now()
             ) as "freePlanInTransition",
             (select count(*)::int from users
-             where plan = 'hosted_free'
+             where coalesce(plan, 'hosted_free') = 'hosted_free'
                and (plan_transition_until is null or plan_transition_until <= now())
             ) as "freePlanLockedOut",
             (select count(*)::int from users

--- a/src/db/queries/admin-billing.ts
+++ b/src/db/queries/admin-billing.ts
@@ -7,6 +7,8 @@ export interface BillingOverviewRow {
     totalUsers: number;
     proPlan: number;
     freePlan: number;
+    freePlanInTransition: number;
+    freePlanLockedOut: number;
     inTrial: number;
     inGrace: number;
     foundingMembers: number;
@@ -55,6 +57,15 @@ export async function billingOverview(): Promise<BillingOverview> {
             (select count(*)::int from users) as "totalUsers",
             (select count(*)::int from users where plan = 'hosted_pro') as "proPlan",
             (select count(*)::int from users where plan = 'hosted_free') as "freePlan",
+            (select count(*)::int from users
+             where plan = 'hosted_free'
+               and plan_transition_until is not null
+               and plan_transition_until > now()
+            ) as "freePlanInTransition",
+            (select count(*)::int from users
+             where plan = 'hosted_free'
+               and (plan_transition_until is null or plan_transition_until <= now())
+            ) as "freePlanLockedOut",
             (select count(*)::int from users
              where plan = 'hosted_pro'
                and plan_transition_until is not null

--- a/src/tests/billing/admin-billing.test.ts
+++ b/src/tests/billing/admin-billing.test.ts
@@ -31,6 +31,8 @@ describe("admin billing overview", () => {
                     totalUsers: 20,
                     proPlan: 12,
                     freePlan: 8,
+                    freePlanInTransition: 5,
+                    freePlanLockedOut: 3,
                     inTrial: 3,
                     inGrace: 2,
                     foundingMembers: 4,
@@ -69,6 +71,8 @@ describe("admin billing overview", () => {
 
         const overview = await billingOverview();
 
+        expect(overview.counts.freePlanInTransition).toBe(5);
+        expect(overview.counts.freePlanLockedOut).toBe(3);
         expect(overview.counts.activeSubscriptions).toBe(9);
         expect(overview.counts.pastDueSubscriptions).toBe(1);
         expect(overview.counts.cancelPendingSubscriptions).toBe(2);


### PR DESCRIPTION
## Description

The admin billing "Free/lockout" tile counted every `plan = 'hosted_free'` user, including accounts still inside their `plan_transition_until` grace/transition window. Those accounts resolve to `hosted_pro` entitlements per `src/lib/entitlements.ts`, so the raw count made it look like a mass lockout even when almost all of them were unaffected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

- Added `freePlanInTransition` and `freePlanLockedOut` counts to `billingOverview()` in `src/db/queries/admin-billing.ts`, split by whether `plan_transition_until` is still in the future.
- Replaced the single "Free/lockout" tile in `src/app/(hosted)/admin/(gated)/billing/page.tsx` with "Free, in grace/transition" and "Free, actually locked out".
- Extended `src/tests/billing/admin-billing.test.ts` to cover both new fields.

## Testing

- `pnpm format-and-lint:fix`
- `pnpm type-check`
- `pnpm test src/tests/billing`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] Type checking passes (`pnpm type-check`)
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the admin billing “Free/lockout” tile into “Free, in grace/transition” and “Free, actually locked out,” and align counts with entitlement rules, including null-plan users.

- **Bug Fixes**
  - Added `freePlanInTransition` and `freePlanLockedOut` in `billingOverview()` using `plan_transition_until`.
  - Count null-plan users as `hosted_free` with `coalesce(plan, 'hosted_free')` to match entitlement logic.
  - Replaced the single tile with two tiles on the admin billing page and updated tests.

<sup>Written for commit 1e534ad3e28199c8d8e49b12b0978bae63b97fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

