### PR TITLE
fix(auth): stop reset-password page crashing with server error

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -2,10 +2,8 @@ import {
     HostedAuthChrome,
     SelfHostAuthChrome,
 } from "@/components/auth/auth-chrome";
-import {
-    ResetPasswordForm,
-    resetPasswordMode,
-} from "@/components/auth/reset-password-form";
+import { ResetPasswordForm } from "@/components/auth/reset-password-form";
+import { resetPasswordMode } from "@/lib/auth/reset-password-mode";
 import { redirectIfAuthenticated } from "@/lib/auth-server";
 import { env } from "@/lib/env";
 

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { MetalButton } from "@/components/metal-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { resetPasswordMode } from "@/lib/auth/reset-password-mode";
 import { resetPassword } from "@/lib/auth-client";
 
 interface ResetPasswordFormProps {
@@ -22,22 +23,10 @@ interface ResetPasswordFormProps {
 }
 
 /**
- * `resetPasswordMode` lets the route compute the right chrome title /
- * subtitle from the same `(token, error)` pair we hand to the form.
- * Keeping the inference in one place avoids drift between route and form.
- */
-export function resetPasswordMode(
-    token: string | undefined,
-    error: string | undefined,
-): "set" | "invalid" {
-    if (!token || error) return "invalid";
-    return "set";
-}
-
-/**
  * Renders only the form body. Page chrome (logo, headings, panel,
- * background) is owned by the route, which uses `resetPasswordMode()` to
- * decide the appropriate title/subtitle.
+ * background) is owned by the route, which uses `resetPasswordMode()`
+ * (from `@/lib/auth/reset-password-mode`) to decide the appropriate
+ * title/subtitle.
  */
 export function ResetPasswordForm({ token, error }: ResetPasswordFormProps) {
     const [password, setPassword] = useState("");

--- a/src/lib/auth/reset-password-mode.ts
+++ b/src/lib/auth/reset-password-mode.ts
@@ -1,0 +1,22 @@
+/**
+ * `resetPasswordMode` lets both the `/reset-password` server route and the
+ * client `ResetPasswordForm` compute the same "set" | "invalid" state from
+ * the same `(token, error)` pair, so title/subtitle/UI never drift.
+ *
+ * This has no `"use client"` directive and no React/DOM dependency --
+ * deliberately so it can be imported directly from a Server Component.
+ * Exports from a `"use client"` module become client references when
+ * consumed by server code; calling one directly (rather than rendering it
+ * as JSX) throws at request time ("Attempted to call ... from the server
+ * but ... is on the client"). This function used to live in
+ * `reset-password-form.tsx` (a `"use client"` file) and was called
+ * directly from `reset-password/page.tsx` (a Server Component), which hit
+ * exactly that failure in production (issue #241, bug 3).
+ */
+export function resetPasswordMode(
+    token: string | undefined,
+    error: string | undefined,
+): "set" | "invalid" {
+    if (!token || error) return "invalid";
+    return "set";
+}

--- a/src/tests/regressions/241-reset-password-page-crash.test.ts
+++ b/src/tests/regressions/241-reset-password-page-crash.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test for issue #241 (bug 3): visiting `/reset-password?token=...`
+ * crashed with "Application error" in production. Server logs showed:
+ *   "Attempted to call resetPasswordMode() from the server but
+ *    resetPasswordMode is on the client"
+ *
+ * Root cause: `resetPasswordMode` was defined and exported from
+ * `reset-password-form.tsx`, a `"use client"` module, and called directly
+ * (not rendered as JSX) from the Server Component
+ * `src/app/(auth)/reset-password/page.tsx`. React Server Components turns
+ * every export of a `"use client"` file into a client reference when
+ * consumed by server code -- calling one directly throws at request time.
+ *
+ * Fix: `resetPasswordMode` now lives in `src/lib/auth/reset-password-mode.ts`,
+ * a plain module with no `"use client"` directive, importable from both the
+ * server route and the client form.
+ *
+ * This test guards both the function's behavior and the module boundary
+ * that caused the crash, so a future refactor can't silently reintroduce
+ * the client-file export + server-side call pattern.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resetPasswordMode } from "@/lib/auth/reset-password-mode";
+
+describe("resetPasswordMode", () => {
+    it("is 'set' when a token is present and there is no error", () => {
+        expect(resetPasswordMode("valid-token", undefined)).toBe("set");
+    });
+
+    it("is 'invalid' when there is no token", () => {
+        expect(resetPasswordMode(undefined, undefined)).toBe("invalid");
+    });
+
+    it("is 'invalid' when better-auth signaled an error, even with a token", () => {
+        expect(resetPasswordMode("some-token", "INVALID_TOKEN")).toBe(
+            "invalid",
+        );
+    });
+});
+
+describe("resetPasswordMode module boundary", () => {
+    const repoRoot = join(__dirname, "..", "..", "..");
+
+    it('is not defined inside a "use client" module', () => {
+        const source = readFileSync(
+            join(repoRoot, "src/lib/auth/reset-password-mode.ts"),
+            "utf-8",
+        );
+        expect(source.trimStart().startsWith('"use client"')).toBe(false);
+    });
+
+    it("the reset-password Server Component imports it from the shared module, not the client form", () => {
+        const pageSource = readFileSync(
+            join(repoRoot, "src/app/(auth)/reset-password/page.tsx"),
+            "utf-8",
+        );
+        expect(pageSource).toContain('from "@/lib/auth/reset-password-mode"');
+        // Guard against reintroducing the import from the "use client" form
+        // file, which is what caused the production crash.
+        const clientFormImportBlock = pageSource.match(
+            /import\s*{[^}]*}\s*from\s*"@\/components\/auth\/reset-password-form";/,
+        );
+        expect(clientFormImportBlock).not.toBeNull();
+        expect(clientFormImportBlock?.[0]).not.toContain("resetPasswordMode");
+    });
+});


### PR DESCRIPTION
## Description

`/reset-password?token=...` crashed with a generic "A server error occurred" page for every user clicking the password-reset link from their email. Root cause: `resetPasswordMode` was defined and exported from `reset-password-form.tsx` (a `"use client"` module) and called directly from the Server Component `src/app/(auth)/reset-password/page.tsx`. Exports of a `"use client"` file become client references when consumed by server code; calling one directly (instead of only rendering it as JSX) throws at request time.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Relates to #241 (bug 3 of 5 in that report; the other bugs there are unrelated and not addressed by this PR)

## Changes Made

- Extracted `resetPasswordMode` into a new plain module `src/lib/auth/reset-password-mode.ts` with no `"use client"` directive, safe to import from both server and client code.
- Updated `src/app/(auth)/reset-password/page.tsx` (Server Component) to import `resetPasswordMode` from the new shared module instead of from the client form file.
- Updated `src/components/auth/reset-password-form.tsx` to import `resetPasswordMode` from the shared module instead of defining/exporting it locally.
- Added `src/tests/regressions/241-reset-password-page-crash.test.ts` covering the function's behavior and guarding the module boundary that caused the crash (asserts the shared module has no `"use client"` directive and that the page no longer imports `resetPasswordMode` from the client form file).

## Testing

- `pnpm format-and-lint:fix`
- `pnpm type-check`
- `pnpm test` (816 passed, 0 failed)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- Not applicable (no schema changes)

## Breaking Changes

None.

## For Reviewers

- Confirm no other `"use client"` module exports a non-component function that's called (rather than rendered) from a Server Component elsewhere in the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the reset-password page crash by moving `resetPasswordMode` out of a `"use client"` file into a shared module. Users can now open `/reset-password?token=...` without the generic server error (relates to #241).

- **Bug Fixes**
  - Moved `resetPasswordMode` to `src/lib/auth/reset-password-mode.ts` (no `"use client"`) and updated imports in `src/app/(auth)/reset-password/page.tsx` and `src/components/auth/reset-password-form.tsx`.
  - Added regression test `src/tests/regressions/241-reset-password-page-crash.test.ts` to verify behavior and prevent reintroducing the server/client boundary issue.

<sup>Written for commit 29eeac389ceab5009da7daed6033132f3cdcc60f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

