### PR TITLE
chore(release): v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.6.3] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.3] - 2026-07-22
 
 ### Added
 - Optional `.env.example` vars `POSTHOG_KEY`/`POSTHOG_HOST` for hosted-only product analytics. Inert unless `IS_HOSTED=true` and `POSTHOG_KEY` is set.
@@ -233,7 +233,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/riffado/riffado/compare/v0.6.2...HEAD
+[unreleased]: https://github.com/riffado/riffado/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/riffado/riffado/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/riffado/riffado/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/riffado/riffado/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/riffado/riffado/compare/v0.5.6...v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "riffado",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "Riffado Contributors",
     "license": "AGPL-3.0",


### PR DESCRIPTION
Release v0.6.3.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message
is used by `bun scripts/release.ts finalize` to locate the commit to tag.
Squash-merge still works (GitHub uses the PR title as the squash subject),
but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.6.3` tag, which triggers
`docker.yml` and `release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.3 adds optional hosted analytics env vars and enables server-side background sync for all self-hosted deployments. Also bumps `package.json` to `0.6.3` and updates changelog links.

- **Migration**
  - Hosted: set `POSTHOG_KEY` (and optional `POSTHOG_HOST`) when `IS_HOSTED=true` to enable analytics.
  - Self-hosted: background sync is enabled by default; set `BACKGROUND_SYNC_ENABLED=false` to opt out.
  - Adjust sync interval with `BACKGROUND_SYNC_INTERVAL_MS` (default ~5 minutes).

<sup>Written for commit ce8b2b6c10042d2c67a2647c7febcee6941537c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

