### PR TITLE
fix(plaud): validate device-list response shape before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `PlaudClient.listDevices()` now validates the Plaud API response shape (`status === 0` and `data_devices` an array) before returning it, instead of trusting a malformed `200` response. A workspace-token mint failure followed by a business-error device-list response crashed the whole Plaud connect flow with an unhandled `TypeError` on `undefined.data_devices`, surfacing as a generic "unexpected error" instead of an actionable message ([#231](https://github.com/riffado/riffado/issues/231)).
+- The companion [riffado/connector](https://github.com/riffado/connector) browser extension had several bugs preventing most "Continue with Plaud" attempts from completing: the plaud.ai tab could close before login finished (v0.2.1), a coincidental non-token localStorage value could be captured as if it were the access token (v0.2.2), and — the actual root cause underneath both — the entire `localStorage`-scanning capture strategy could never reliably find a real token, because Plaud authenticates with an `HttpOnly` session cookie no page JavaScript can read. v0.2.3 replaces it with `chrome.cookies`-based capture, the correct API for reading an `HttpOnly` cookie. See the [connector changelog](https://github.com/riffado/connector/blob/main/CHANGELOG.md) for the full trail.
+
 ## [0.6.3] - 2026-07-22
 
 ### Added

--- a/src/lib/plaud/client.ts
+++ b/src/lib/plaud/client.ts
@@ -185,8 +185,27 @@ export class PlaudClient {
         }
     }
 
+    /**
+     * Fetch the device list. Validates the response shape before returning:
+     * a 200 with a non-zero `status` (or missing/malformed `data_devices`) is
+     * a business-level Plaud error, not a schema `PlaudDeviceListResponse`
+     * guarantees -- callers that iterate `data_devices` without this check
+     * crash on an undefined array (issue #231). Surfaces as a typed,
+     * actionable `PLAUD_API_ERROR` instead.
+     */
     async listDevices(): Promise<PlaudDeviceListResponse> {
-        return this.request<PlaudDeviceListResponse>("/device/list");
+        const body =
+            await this.request<PlaudDeviceListResponse>("/device/list");
+        if (body?.status !== 0 || !Array.isArray(body.data_devices)) {
+            throw new AppError(
+                ErrorCode.PLAUD_API_ERROR,
+                body?.msg ||
+                    "Plaud returned an invalid device list response. Reconnect your Plaud account and try again.",
+                400,
+                { plaudStatus: body?.status },
+            );
+        }
+        return body;
     }
 
     async getRecordings(

--- a/src/lib/public-changelog.ts
+++ b/src/lib/public-changelog.ts
@@ -82,6 +82,22 @@ export type PublicChangelogRelease = {
  */
 export const PUBLIC_CHANGELOG: PublicChangelogRelease[] = [
     {
+        // Not tied to a cut app version yet -- the connector-side fixes
+        // (riffado/connector v0.2.1-v0.2.3) already shipped independently;
+        // this entry surfaces them to hosted users ahead of the next
+        // riffado/riffado release. Replace `version` with the real one once
+        // 0.6.3's successor actually ships.
+        version: "unreleased",
+        date: "2026-07-23",
+        items: [
+            {
+                tag: "fixed",
+                title: "Signing in to Plaud through the browser extension actually works now",
+                body: "The Connect-with-Plaud button could get stuck or fail to detect a completed sign-in. Fixed — Google, Apple, and email sign-in through the extension now reliably connects your account.",
+            },
+        ],
+    },
+    {
         version: "0.6.2",
         date: "2026-07-21",
         items: [

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -236,7 +236,11 @@ describe("PlaudClient", () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 json: () =>
-                    Promise.resolve({ code: 0, msg: "success", data: {} }),
+                    Promise.resolve({
+                        status: 0,
+                        msg: "success",
+                        data_devices: [],
+                    }),
             });
 
             const result = await client.testConnection();

--- a/src/tests/regressions/231-device-list-malformed-response.test.ts
+++ b/src/tests/regressions/231-device-list-malformed-response.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for issue #231:
+ *   "Plaud connect via connector crashes on undefined `c.data_devices` after
+ *    'workspace discovery failed' (self-hosted v0.5.6)"
+ *
+ * Root cause: `PlaudClient.request()` only checked `response.ok` (HTTP
+ * status), never Plaud's business-level `status` field on a 200 body. When
+ * workspace-token mint fell back to the user token and `/device/list`
+ * returned a 200 with an error-shaped body (no `data_devices`), the response
+ * sailed through as "success" and `persist-connection.ts`'s
+ * `for (const device of deviceList.data_devices)` threw an unhandled
+ * `TypeError` on the undefined array, surfacing as a generic
+ * "unexpected error" (err_<hash>) instead of an actionable message.
+ *
+ * The fix validates `status === 0` and `Array.isArray(data_devices)` inside
+ * `PlaudClient.listDevices()` and throws a typed `PLAUD_API_ERROR` on a
+ * malformed body instead of returning it as if it were valid.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type Mock,
+    vi,
+} from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+    WEBSHARE_API_KEY: undefined as string | undefined,
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: mockEnv,
+}));
+
+import { AppError, ErrorCode } from "@/lib/errors";
+import { PlaudClient } from "@/lib/plaud/client";
+
+const originalFetch = global.fetch;
+let mockFetch: Mock;
+
+beforeAll(() => {
+    mockFetch = vi.fn() as Mock;
+    global.fetch = mockFetch as typeof global.fetch;
+});
+
+afterAll(() => {
+    global.fetch = originalFetch;
+});
+
+describe("PlaudClient.listDevices — malformed response guard (#231)", () => {
+    let client: PlaudClient;
+
+    beforeEach(() => {
+        client = new PlaudClient("test-user-token");
+        mockFetch.mockReset();
+        // Workspace-token mint fails first (matches the reported log:
+        // "workspace discovery failed" -> falls back to the user token).
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            json: () => Promise.resolve({ status: 500, msg: "server error" }),
+        });
+    });
+
+    it("throws a typed PLAUD_API_ERROR on a 200 body with no data_devices", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () =>
+                Promise.resolve({ status: -1, msg: "session not authorized" }),
+        });
+
+        await expect(client.listDevices()).rejects.toMatchObject({
+            code: ErrorCode.PLAUD_API_ERROR,
+            statusCode: 400,
+        });
+    });
+
+    it("throws a typed PLAUD_API_ERROR when data_devices is not an array", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () =>
+                Promise.resolve({ status: 0, msg: "ok", data_devices: null }),
+        });
+
+        await expect(client.listDevices()).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("still returns devices on a well-formed response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () =>
+                Promise.resolve({
+                    status: 0,
+                    msg: "success",
+                    data_devices: [
+                        {
+                            sn: "123",
+                            name: "Device",
+                            model: "888",
+                            version_number: 1,
+                        },
+                    ],
+                }),
+        });
+
+        const result = await client.listDevices();
+        expect(result.data_devices).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Description

Fixes the Plaud connect flow crashing on a malformed device-list response after a workspace-token mint failure, and surfaces the related companion browser extension fixes (riffado/connector v0.2.1-v0.2.3) in both changelogs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #231

## Changes Made

- `PlaudClient.listDevices()` now validates the Plaud API response shape (`status === 0` and `data_devices` an array) before returning it, instead of trusting a malformed `200` response.
- Fixed a pre-existing test in `plaud.test.ts` that used an incorrect mock response shape (`code`/`data` instead of `status`/`data_devices`), which only passed before because there was no validation to catch it.
- Added a regression test (`src/tests/regressions/231-device-list-malformed-response.test.ts`) pinning the new behavior against both a malformed and a well-formed device-list response.
- Added a `CHANGELOG.md` entry documenting this fix and pointing to the companion `riffado/connector` extension's own fix trail (v0.2.1-v0.2.3), which addressed the underlying connector-side bugs (premature tab close, a stray non-token value getting captured, and ultimately replacing its `localStorage`-scanning capture strategy with `chrome.cookies`, since Plaud authenticates via an `HttpOnly` cookie no page script can read).
- Added a corresponding entry to the hosted-user-facing `/changelog` (`src/lib/public-changelog.ts`).

## Testing

### Test Steps
1. `pnpm test`
2. `pnpm type-check`
3. `pnpm format-and-lint:fix`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

None.

## Additional Notes

The companion extension fixes (riffado/connector v0.2.1-v0.2.3) already shipped independently in that repo; this PR only carries the server-side guard in this repo plus the changelog entries. The public changelog entry uses a placeholder `version: "unreleased"` until the next app release actually cuts.

## For Reviewers

- `src/lib/plaud/client.ts`: the response-shape validation in `listDevices()`.
- `src/tests/regressions/231-device-list-malformed-response.test.ts`: regression coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in the Plaud connect flow by validating the device-list response before use. Also updates changelogs to surface companion `riffado/connector` fixes.

- **Bug Fixes**
  - `PlaudClient.listDevices()` now validates the Plaud API shape (`status === 0` and `data_devices` is an array) and throws `PLAUD_API_ERROR` on malformed bodies.
  - Fixed a test using the wrong response fields and added a regression test to cover malformed vs. well-formed device-list responses (issue #231).
  - Added entries to `CHANGELOG.md` and the public `/changelog` noting `riffado/connector` v0.2.1–v0.2.3 fixes (tab close, false token capture, and switch to `chrome.cookies` for `HttpOnly` auth).

<sup>Written for commit 2dc96846157c407bc9e02949b0a8e11b725952b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

