### PR TITLE
fix(admin): quote reserved interval keyword in billing overview SQL

### DIFF
--- a/src/db/queries/admin-billing.ts
+++ b/src/db/queries/admin-billing.ts
@@ -109,8 +109,8 @@ export async function billingOverview(): Promise<BillingOverview> {
             (select count(*)::int from subscriptions where status = 'active') as "activeSubscriptions",
             (select count(*)::int from subscriptions where status = 'past_due') as "pastDueSubscriptions",
             (select count(*)::int from subscriptions where status in ${LIVE_STATUS_SQL} and canceled_at is not null) as "cancelPendingSubscriptions",
-            (select count(*)::int from subscriptions where status in ${LIVE_STATUS_SQL} and lower(interval) like '%month%') as "monthlySubscriptions",
-            (select count(*)::int from subscriptions where status in ${LIVE_STATUS_SQL} and lower(interval) like '%year%') as "annualSubscriptions",
+            (select count(*)::int from subscriptions where status in ${LIVE_STATUS_SQL} and lower("interval") like '%month%') as "monthlySubscriptions",
+            (select count(*)::int from subscriptions where status in ${LIVE_STATUS_SQL} and lower("interval") like '%year%') as "annualSubscriptions",
             (select count(*)::int from users where ever_paid_at >= now() - interval '30 days') as "firstPaymentsLast30Days"
     `);
 

--- a/src/tests/admin-billing-interval-keyword.test.ts
+++ b/src/tests/admin-billing-interval-keyword.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression guard for a production crash on /admin/billing (PostHog issue
+ * 019f905d-4454-7612-8681-02f489bbf1ed): every render threw a masked
+ * "An error occurred in the Server Components render" digest error.
+ *
+ * Root cause: `billingOverview()`'s raw SQL referenced the `subscriptions`
+ * table's `interval` column bare/unqualified inside `lower(interval)`.
+ * `interval` is a fully reserved PostgreSQL keyword (it introduces
+ * `INTERVAL '...'` literals), so Postgres's grammar only accepts it as an
+ * identifier when double-quoted or dot-qualified (e.g. `s.interval`, used
+ * correctly everywhere else in this file). The bare reference caused a
+ * hard SQL syntax error on every single execution.
+ *
+ * This test statically guards the source so a future edit can't
+ * reintroduce a bare, unquoted `interval` column reference in this file.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("admin-billing.ts interval column references", () => {
+    const source = readFileSync(
+        join(__dirname, "..", "db", "queries", "admin-billing.ts"),
+        "utf-8",
+    );
+
+    it("never references the `interval` column bare/unqualified", () => {
+        // Every reference to the subscriptions.interval column must be
+        // either dot-qualified (s.interval) or double-quoted ("interval").
+        // A bare `interval` (no leading `.` or `"`) is a Postgres reserved
+        // keyword and causes a SQL syntax error. Exclude `interval:` (a
+        // TS field name) and `interval '...'` (the valid INTERVAL literal
+        // syntax, e.g. `now() - interval '30 days'`).
+        const bareIntervalRefs =
+            source.match(/[^."]\binterval\b(?!:)(?!\s*')/g) ?? [];
+        expect(bareIntervalRefs).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Description

`/admin/billing` threw a masked "An error occurred in the Server Components render" error on every single visit (confirmed via PostHog error tracking + session replay: the user browsed every other admin tab with no errors, and every visit to billing errored instantly).

Root cause: `billingOverview()`'s raw SQL referenced the `subscriptions.interval` column bare/unqualified inside `lower(interval)` in two subqueries. `interval` is a reserved PostgreSQL keyword (it introduces `INTERVAL '...'` literals), so Postgres only accepts it as an identifier when dot-qualified (`s.interval`, used correctly everywhere else in this file) or double-quoted. The bare reference caused a hard SQL syntax error on every execution.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Double-quote the `interval` column reference in `billingOverview()`'s `monthlySubscriptions`/`annualSubscriptions` subqueries (`lower("interval")` instead of `lower(interval)`)
- Add a static regression test (`src/tests/admin-billing-interval-keyword.test.ts`) that fails if a bare/unqualified `interval` reference is reintroduced in this file

## Screenshots (if applicable)

N/A (server-side SQL fix, no UI changes)

## Testing

### Test Environment
- OS: n/a (server-side fix)
- Node version: n/a
- Browser (if UI changes): n/a

### Test Steps
1. `pnpm type-check`
2. `npx vitest run src/tests/admin-billing-interval-keyword.test.ts` (verified it fails against the pre-fix code and passes against the fix)
3. `pnpm format-and-lint:fix`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

No schema changes; SQL query fix only.

## Breaking Changes

None.

## Additional Notes

Confirmed via PostHog error tracking issue `019f905d-4454-7612-8681-02f489bbf1ed`.

## For Reviewers

- The other `interval` references in this file (`s.interval`) already work correctly because dot-qualification lets Postgres's grammar treat the keyword as a column label; only the two bare references were broken.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the server error on `/admin/billing` by quoting the reserved PostgreSQL `interval` column in the billing overview SQL. Adds a regression test to block bare `interval` references from being reintroduced.

<sup>Written for commit 633101025e28fb8f03c2a2276868cf073fda99e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

