### PR TITLE
fix(billing): self-heal out-of-order subscription webhook conflicts

### DIFF
--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -75,6 +75,37 @@ export interface SubscriptionUpsertInput {
     metadata: unknown;
 }
 
+/**
+ * Thrown by `upsertSubscription` when the row being written would violate
+ * `subscriptions_user_id_active_unique` -- i.e. the user already has a
+ * *different* subscription id in a live status. This happens when Stripe
+ * webhooks for two subscriptions on the same customer arrive out of order
+ * (the old one hasn't been mirrored as canceled/superseded yet). Callers
+ * should re-mirror `conflictingSubscriptionId` from Stripe (the source of
+ * truth) and retry.
+ */
+export class SubscriptionUserConflictError extends Error {
+    constructor(
+        readonly userId: string,
+        readonly conflictingSubscriptionId: string,
+    ) {
+        super(
+            `User ${userId} already has a live subscription (${conflictingSubscriptionId}) distinct from the one being mirrored`,
+        );
+        this.name = "SubscriptionUserConflictError";
+    }
+}
+
+function isUniqueViolationOn(error: unknown, constraintName: string): boolean {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        (error as { code?: string }).code === "23505" &&
+        (error as { constraint_name?: string }).constraint_name ===
+            constraintName
+    );
+}
+
 export async function upsertSubscription(
     input: SubscriptionUpsertInput,
 ): Promise<void> {
@@ -108,10 +139,20 @@ export async function upsertSubscription(
           }
         : { ...baseValues, updatedAt: new Date() };
 
-    await db.insert(subscriptions).values(insertValues).onConflictDoUpdate({
-        target: subscriptions.id,
-        set: updateValues,
-    });
+    try {
+        await db.insert(subscriptions).values(insertValues).onConflictDoUpdate({
+            target: subscriptions.id,
+            set: updateValues,
+        });
+    } catch (error) {
+        if (isUniqueViolationOn(error, "subscriptions_user_id_active_unique")) {
+            const other = await getSubscriptionByUserId(input.userId);
+            if (other && other.id !== input.id) {
+                throw new SubscriptionUserConflictError(input.userId, other.id);
+            }
+        }
+        throw error;
+    }
 }
 
 export interface SubscriptionRow {

--- a/src/lib/hosted/billing/mirror.ts
+++ b/src/lib/hosted/billing/mirror.ts
@@ -167,7 +167,7 @@ export async function mirrorStripeSubscription(
         console.warn(
             `[billing-mirror] subscription ${n.id} conflicts with locally-active ${error.conflictingSubscriptionId} for user ${userId}; re-mirroring the stale one before retrying`,
         );
-        await mirrorSubscriptionById(error.conflictingSubscriptionId);
+        await resyncSubscriptionRow(error.conflictingSubscriptionId);
         await upsertSubscription(subscriptionRow);
     }
 
@@ -257,6 +257,59 @@ function isTerminalSubscriptionStatus(status: string): boolean {
         status === "unpaid" ||
         status === "incomplete_expired"
     );
+}
+
+/**
+ * Refresh only the `subscriptions` row for `subscriptionId` from Stripe --
+ * no plan mutation, no lapse/founding/email side effects. Used solely to
+ * resolve `SubscriptionUserConflictError`: the conflicting row just needs
+ * its stale status corrected so the one-live-subscription-per-user index
+ * frees up before the real write is retried.
+ *
+ * Deliberately does not call `mirrorStripeSubscription`/`mirrorSubscriptionById`
+ * here: if the conflicting subscription has genuinely gone terminal, running
+ * the full mirror would fire lapse side effects (release the founding
+ * reservation, forfeit founding status, schedule account deletion, send the
+ * grace-started email) for a subscription that's about to be immediately
+ * superseded by the new active one this function is unblocking. Those side
+ * effects are not undone by mirroring the new subscription afterward --
+ * `clearAccountDeletion` only clears the deletion timer, it doesn't unsend
+ * the email or restore founding status. The conflicting subscription's own
+ * webhook (or the next reconcile pass) still runs the full mirror -- with
+ * side effects -- at the time that transition is actually confirmed.
+ */
+async function resyncSubscriptionRow(subscriptionId: string): Promise<void> {
+    const stripe = getStripe();
+    const sub = await stripe.subscriptions.retrieve(subscriptionId);
+    const n = normalize(sub);
+    const userId =
+        n.userId ??
+        (await getBillingCustomerByStripeId(n.stripeCustomerId))?.userId ??
+        null;
+    if (!userId) {
+        console.warn(
+            `[billing-mirror] conflicting subscription ${n.id} has no resolvable user (customer ${n.stripeCustomerId}); skipping resync`,
+        );
+        return;
+    }
+    const billingCountry = await resolveBillingCountry(n.stripeCustomerId);
+    await upsertSubscription({
+        id: n.id,
+        userId,
+        stripeCustomerId: n.stripeCustomerId,
+        stripePriceId: n.stripePriceId,
+        status: n.status,
+        amountValue: n.amountValue,
+        amountCurrency: n.amountCurrency,
+        interval: n.interval,
+        description: n.description,
+        billingCountry,
+        startDate: n.startDate,
+        nextPaymentAt: n.nextPaymentAt,
+        canceledAt: n.canceledAt,
+        withdrawalWaiverAcceptedAt: n.withdrawalWaiverAcceptedAt,
+        metadata: sub,
+    });
 }
 
 /** Webhook/reconcile entry: fetch the subscription by id, then mirror. */

--- a/src/lib/hosted/billing/mirror.ts
+++ b/src/lib/hosted/billing/mirror.ts
@@ -10,6 +10,7 @@ import {
     getUserActivitySummary,
     markEverPaid,
     releaseFoundingMemberReservation,
+    SubscriptionUserConflictError,
     scheduleAccountDeletion,
     setUserPlan,
     upsertSubscription,
@@ -133,7 +134,7 @@ export async function mirrorStripeSubscription(
 
     const billingCountry = await resolveBillingCountry(n.stripeCustomerId);
 
-    await upsertSubscription({
+    const subscriptionRow = {
         id: n.id,
         userId,
         stripeCustomerId: n.stripeCustomerId,
@@ -149,7 +150,26 @@ export async function mirrorStripeSubscription(
         canceledAt: n.canceledAt,
         withdrawalWaiverAcceptedAt: n.withdrawalWaiverAcceptedAt,
         metadata: sub,
-    });
+    };
+
+    try {
+        await upsertSubscription(subscriptionRow);
+    } catch (error) {
+        if (!(error instanceof SubscriptionUserConflictError)) throw error;
+        // Webhooks for two subscriptions on the same customer can arrive out
+        // of order: the user's previously-active subscription hasn't been
+        // mirrored as canceled/superseded yet, so it's still occupying the
+        // one-live-subscription-per-user slot. Re-fetch it from Stripe (the
+        // source of truth) and re-mirror it, then retry once. If Stripe
+        // genuinely reports two live subscriptions for this customer, the
+        // retry fails again and this throws for real -- that needs manual
+        // investigation, not a silent workaround.
+        console.warn(
+            `[billing-mirror] subscription ${n.id} conflicts with locally-active ${error.conflictingSubscriptionId} for user ${userId}; re-mirroring the stale one before retrying`,
+        );
+        await mirrorSubscriptionById(error.conflictingSubscriptionId);
+        await upsertSubscription(subscriptionRow);
+    }
 
     const planEntry = entitlementsForSubscription({
         status: n.status,


### PR DESCRIPTION
## Description

Fixes a crash in Stripe subscription mirroring: `insert into "subscriptions" ... on conflict ("id") do update` was failing with `duplicate key value violates unique constraint "subscriptions_user_id_active_unique"`.

`upsertSubscription` only handled `ON CONFLICT (id)`. The partial unique index `subscriptions_user_id_active_unique` enforces one live subscription (`active`/`trialing`/`past_due`) per user, and it isn't covered by that arbiter. When a webhook for a new subscription arrives before the old subscription's cancellation has been mirrored, the plain `INSERT` fails on that second unique index and the whole mirror throws.

Because the webhook route always returns 200 (by design, to stop Stripe retry storms) and the event id is claimed before processing runs, that failure was silently swallowed — and the reconcile job never picks it up either, since it only walks rows that were actually inserted. Net effect: a user could be charged and have an active Stripe subscription while never being mirrored as Pro locally, with no automatic recovery path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

- `upsertSubscription` now detects the `subscriptions_user_id_active_unique` violation specifically and throws a typed `SubscriptionUserConflictError` carrying the conflicting subscription id.
- `mirrorStripeSubscription` catches that error, re-fetches and re-mirrors the stale conflicting subscription from Stripe (source of truth), then retries the write once, so the mirror self-heals the out-of-order-webhook race instead of failing outright.
- A genuine double-live-subscription case (real Stripe-side anomaly) still throws after the retry, surfacing for manual investigation rather than being papered over.

## Testing

- `pnpm format-and-lint:fix`
- `pnpm type-check`

### Test Steps
1. `pnpm format-and-lint:fix` — no new issues in changed files
2. `pnpm type-check` — passes clean

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [ ] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

No schema changes; this is a code-only fix.

## Breaking Changes

None.

## Additional Notes

Root-caused from a PostHog error report: https://eu.posthog.com/error_tracking/019f8b3a-fb8f-7a72-9444-0b288f6a8e07

## For Reviewers

- The retry-once behavior in `mirrorStripeSubscription`: intentional to avoid infinite recursion if Stripe genuinely reports two live subscriptions for one customer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add self-healing to Stripe subscription mirroring so out-of-order webhooks don’t crash on `subscriptions_user_id_active_unique` and users stay in sync as Pro. Prevents silent failures when a new subscription arrives before the old one is mirrored as canceled, and avoids firing lapse side effects during repair.

- **Bug Fixes**
  - Detects `subscriptions_user_id_active_unique` violations in `upsertSubscription` and throws `SubscriptionUserConflictError` with the conflicting subscription id.
  - `mirrorStripeSubscription` catches the error, resyncs only the conflicting subscription row from Stripe (no plan changes or side effects), then retries the write once.
  - Still surfaces real double-live-subscription cases by throwing after the retry.

<sup>Written for commit 4d66e78e63170032345a59c8de5a23f269944da1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

