### PR TITLE
chore(release): v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.4] - 2026-07-24
 
 ### Fixed
 - `PlaudClient.listDevices()` now validates the Plaud API response shape (`status === 0` and `data_devices` an array) before returning it, instead of trusting a malformed `200` response. A workspace-token mint failure followed by a business-error device-list response crashed the whole Plaud connect flow with an unhandled `TypeError` on `undefined.data_devices`, surfacing as a generic "unexpected error" instead of an actionable message ([#231](https://github.com/riffado/riffado/issues/231)).
@@ -239,7 +239,8 @@
 - Environment variable validation
 - Path traversal protection
 
-[unreleased]: https://github.com/riffado/riffado/compare/v0.6.3...HEAD
+[unreleased]: https://github.com/riffado/riffado/compare/v0.6.4...HEAD
+[0.6.4]: https://github.com/riffado/riffado/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/riffado/riffado/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/riffado/riffado/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/riffado/riffado/compare/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [0.6.4] - 2026-07-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "riffado",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "description": "Self-hosted AI transcription interface for Plaud Note devices",
     "author": "Riffado Contributors",
     "license": "AGPL-3.0",

--- a/src/lib/public-changelog.ts
+++ b/src/lib/public-changelog.ts
@@ -95,6 +95,11 @@ export const PUBLIC_CHANGELOG: PublicChangelogRelease[] = [
                 title: "Signing in to Plaud through the browser extension actually works now",
                 body: "The Connect-with-Plaud button could get stuck or fail to detect a completed sign-in. Fixed — Google, Apple, and email sign-in through the extension now reliably connects your account.",
             },
+            {
+                tag: "fixed",
+                title: "Subscription status could get out of sync after a billing change",
+                body: "A timing issue with how we process billing updates could occasionally leave your account showing the wrong plan status after subscribing or changing plans. Fixed.",
+            },
         ],
     },
     {


### PR DESCRIPTION
Release v0.6.4.

Includes the hosted public-changelog entry for the subscription-sync fix (`b59ebfc`) alongside the standard release commit, since branch protection blocks pushing that changelog commit to `main` directly.

**Merge instructions:**

Use **"Create a merge commit"** (not squash). The release commit's message (`chore(release): v0.6.4`) is used by `bun scripts/release.ts finalize` to locate the commit to tag. Squash-merge still works (GitHub uses the PR title as the squash subject), but a merge commit preserves history more cleanly.

After this PR is merged, run:

```bash
bun scripts/release.ts finalize
```

That will create and push the `v0.6.4` tag, which triggers `docker.yml` and `release.yml`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.6.4 with reliability fixes to Plaud integration and an updated hosted public changelog. Includes the public-changelog entry for the subscription status sync fix.

- **Bug Fixes**
  - Plaud API: validate `listDevices` response to avoid crashes on bad 200s.
  - Connector: use `chrome.cookies` for reliable Plaud sign-in.

- **Migration**
  - Merge using “Create a merge commit”.
  - After merge, run `bun scripts/release.ts finalize` to create/push `v0.6.4` and trigger `docker.yml` and `release.yml`.

<sup>Written for commit 3f5d9e6307b7f6788224f18b1e0ed234e0f7def1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

