### PR TITLE
fix: three PostHog-surfaced production bugs (admin billing crash, subscription mirror leak, mynah retry)

### DIFF
--- a/src/app/(hosted)/admin/(gated)/_components/metrics.tsx
+++ b/src/app/(hosted)/admin/(gated)/_components/metrics.tsx
@@ -138,9 +138,29 @@ export function formatHours(ms: number): string {
     return `${Math.round(hours).toLocaleString("en-US")}h`;
 }
 
+/**
+ * Coerce a `Date | null | undefined` prop to a real `Date` instance,
+ * returning `null` if it isn't one (or isn't a valid one).
+ *
+ * These admin pages source their timestamps from raw `db.execute(sql\`...\`)`
+ * queries (see `src/db/queries/admin-billing.ts`), where the `Date` return
+ * type is a compile-time annotation only -- it isn't enforced at runtime.
+ * A value that reaches here as an ISO string (or otherwise non-Date) used
+ * to crash `formatDate`/`formatRelative` with "x.getTime is not a
+ * function", taking down the whole page (e.g. /admin/billing). Same guard
+ * `compactAgo` in `src/components/sync-button.tsx` already uses for this
+ * exact failure mode.
+ */
+function toValidDate(d: Date | null | undefined): Date | null {
+    if (!d) return null;
+    const date = d instanceof Date ? d : new Date(d);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
 export function formatDate(d: Date | null | undefined): string {
-    if (!d) return "—";
-    return d.toLocaleString("en-US", {
+    const date = toValidDate(d);
+    if (!date) return "—";
+    return date.toLocaleString("en-US", {
         year: "numeric",
         month: "short",
         day: "numeric",
@@ -150,8 +170,9 @@ export function formatDate(d: Date | null | undefined): string {
 }
 
 export function formatRelative(d: Date | null | undefined): string {
-    if (!d) return "never";
-    const diffMs = Date.now() - d.getTime();
+    const date = toValidDate(d);
+    if (!date) return "never";
+    const diffMs = Date.now() - date.getTime();
     const sec = Math.floor(diffMs / 1000);
     if (sec < 60) return `${sec}s ago`;
     const min = Math.floor(sec / 60);

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -145,27 +145,42 @@ export async function upsertSubscription(
             set: updateValues,
         });
 
-    try {
-        await doUpsert();
-    } catch (error) {
-        if (
-            !isUniqueViolationOn(error, "subscriptions_user_id_active_unique")
-        ) {
-            throw error;
+    // Bounded retry loop, not a single retry: a *genuine* conflict (a
+    // different subscription is still live) throws immediately below --
+    // no amount of looping fixes that, it needs `SubscriptionUserConflictError`
+    // recovery from the caller. The loop exists only for the self-resolving
+    // race (the blocking row clears between our failed insert and the
+    // lookup): under concurrent webhook delivery that race can in
+    // principle repeat, and a *second* unresolved unique violation must
+    // not escape as the raw driver error -- which embeds the full
+    // parameterized SQL statement (Stripe customer id, price id, amount)
+    // and would leak into error tracking as an unhandled failure.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            await doUpsert();
+            return;
+        } catch (error) {
+            if (
+                !isUniqueViolationOn(
+                    error,
+                    "subscriptions_user_id_active_unique",
+                )
+            ) {
+                throw error;
+            }
+            const other = await getSubscriptionByUserId(input.userId);
+            if (other && other.id !== input.id) {
+                throw new SubscriptionUserConflictError(input.userId, other.id);
+            }
+            if (attempt === MAX_ATTEMPTS) {
+                throw new Error(
+                    `Failed to upsert subscription ${input.id} for user ${input.userId}: unique-constraint race did not resolve after ${MAX_ATTEMPTS} attempts`,
+                );
+            }
+            // Conflicting row is gone -- the index isn't violated anymore.
+            // Loop and retry rather than re-throwing.
         }
-        const other = await getSubscriptionByUserId(input.userId);
-        if (other && other.id !== input.id) {
-            throw new SubscriptionUserConflictError(input.userId, other.id);
-        }
-        // The conflicting row is gone (a concurrent webhook resolved it
-        // between our failed insert and this lookup) -- the unique index
-        // is no longer violated, so retry once instead of re-throwing the
-        // raw driver error. That raw error carries the full parameterized
-        // SQL statement (Stripe customer id, price id, amount) and would
-        // otherwise leak into error tracking as an unhandled failure, and
-        // callers here only know how to recover from
-        // `SubscriptionUserConflictError`, not a raw driver error.
-        await doUpsert();
     }
 }
 

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -139,19 +139,33 @@ export async function upsertSubscription(
           }
         : { ...baseValues, updatedAt: new Date() };
 
-    try {
-        await db.insert(subscriptions).values(insertValues).onConflictDoUpdate({
+    const doUpsert = () =>
+        db.insert(subscriptions).values(insertValues).onConflictDoUpdate({
             target: subscriptions.id,
             set: updateValues,
         });
+
+    try {
+        await doUpsert();
     } catch (error) {
-        if (isUniqueViolationOn(error, "subscriptions_user_id_active_unique")) {
-            const other = await getSubscriptionByUserId(input.userId);
-            if (other && other.id !== input.id) {
-                throw new SubscriptionUserConflictError(input.userId, other.id);
-            }
+        if (
+            !isUniqueViolationOn(error, "subscriptions_user_id_active_unique")
+        ) {
+            throw error;
         }
-        throw error;
+        const other = await getSubscriptionByUserId(input.userId);
+        if (other && other.id !== input.id) {
+            throw new SubscriptionUserConflictError(input.userId, other.id);
+        }
+        // The conflicting row is gone (a concurrent webhook resolved it
+        // between our failed insert and this lookup) -- the unique index
+        // is no longer violated, so retry once instead of re-throwing the
+        // raw driver error. That raw error carries the full parameterized
+        // SQL statement (Stripe customer id, price id, amount) and would
+        // otherwise leak into error tracking as an unhandled failure, and
+        // callers here only know how to recover from
+        // `SubscriptionUserConflictError`, not a raw driver error.
+        await doUpsert();
     }
 }
 

--- a/src/lib/hosted/transcription/mynah.ts
+++ b/src/lib/hosted/transcription/mynah.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { env } from "@/lib/env";
 import {
     commitMynahReservation,
@@ -77,11 +78,21 @@ interface PostTranscriptionRequestInput {
  * a status-only `Error` -- the upstream body can contain internal Mynah
  * diagnostics, so the detail is logged server-side only, not propagated
  * to the client.
+ *
+ * A 502/503/504/524 is ambiguous: the gateway timing out doesn't tell us
+ * whether Mynah ever started (or finished) the work, so a naive retry can
+ * duplicate billed transcription work server-side while we only keep one
+ * local result/reservation. Every attempt for one logical request
+ * (initial + retries) carries the same `idempotency-key` header so Mynah
+ * can de-duplicate on its side; this is a client-side mitigation only --
+ * it's a no-op unless Mynah's API honors the header, which this repo
+ * can't verify (Mynah runs as a separate service, see AGENTS.md).
  */
 async function postTranscriptionRequest(
     input: PostTranscriptionRequestInput,
 ): Promise<{ text?: string; language?: string | null }> {
     const { mynahBaseUrl, mynahServiceToken, userId, url, language } = input;
+    const idempotencyKey = randomUUID();
     let attempt = 0;
     for (;;) {
         const res = await fetch(`${mynahBaseUrl}/v1/audio/transcriptions`, {
@@ -90,6 +101,7 @@ async function postTranscriptionRequest(
                 authorization: `Bearer ${mynahServiceToken}`,
                 "content-type": "application/json",
                 "x-riffado-user-id": userId,
+                "idempotency-key": idempotencyKey,
             },
             body: JSON.stringify({
                 url,

--- a/src/lib/hosted/transcription/mynah.ts
+++ b/src/lib/hosted/transcription/mynah.ts
@@ -32,6 +32,21 @@ export interface MynahTranscribeInput {
     language?: string;
 }
 
+// Mirrors `PlaudClient`'s retry pattern (src/lib/plaud/client.ts) -- a
+// transient gateway failure (Cloudflare 524 timeout, 502/503 during a
+// deploy) shouldn't fail the whole transcription and burn the user's turn
+// when a short retry would likely succeed.
+const MAX_RETRIES = 2;
+const INITIAL_RETRY_DELAY_MS = 1000;
+
+function isTransientStatus(status: number): boolean {
+    return status === 502 || status === 503 || status === 504 || status === 524;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * True when `value` is an absolute http(s) URL Mynah can fetch on its own.
  * S3-style storage yields absolute presigned URLs; local storage yields a
@@ -44,6 +59,81 @@ function isFetchableUrl(value: string): boolean {
         return protocol === "http:" || protocol === "https:";
     } catch {
         return false;
+    }
+}
+
+interface PostTranscriptionRequestInput {
+    mynahBaseUrl: string;
+    mynahServiceToken: string;
+    userId: string;
+    url: string;
+    language?: string;
+}
+
+/**
+ * POST the transcription request to Mynah, retrying transient gateway
+ * failures (502/503/504/524) with exponential backoff before giving up.
+ * Non-transient failures (4xx, or 5xx after retries are exhausted) throw
+ * a status-only `Error` -- the upstream body can contain internal Mynah
+ * diagnostics, so the detail is logged server-side only, not propagated
+ * to the client.
+ */
+async function postTranscriptionRequest(
+    input: PostTranscriptionRequestInput,
+): Promise<{ text?: string; language?: string | null }> {
+    const { mynahBaseUrl, mynahServiceToken, userId, url, language } = input;
+    let attempt = 0;
+    for (;;) {
+        const res = await fetch(`${mynahBaseUrl}/v1/audio/transcriptions`, {
+            method: "POST",
+            headers: {
+                authorization: `Bearer ${mynahServiceToken}`,
+                "content-type": "application/json",
+                "x-riffado-user-id": userId,
+            },
+            body: JSON.stringify({
+                url,
+                response_format: "verbose_json",
+                ...(language ? { language } : {}),
+            }),
+        });
+
+        if (res.ok) {
+            return (await res.json()) as {
+                text?: string;
+                language?: string | null;
+            };
+        }
+
+        if (isTransientStatus(res.status) && attempt < MAX_RETRIES) {
+            await res.text().catch(() => "");
+            const delay = INITIAL_RETRY_DELAY_MS * 2 ** attempt;
+            attempt += 1;
+            console.warn(
+                `[mynah] transcription request failed (${res.status}) for user ${userId}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`,
+            );
+            await sleep(delay);
+            continue;
+        }
+
+        // The upstream body can contain internal Mynah diagnostics; this
+        // error's message propagates all the way to the client via
+        // transcribeRecording's catch block (result.error -> AppError
+        // message -> JSON response), so log the detail server-side only
+        // and throw a status-only message.
+        const detail = await res.text().catch(() => "");
+        console.error(
+            `[mynah] transcription request failed (${res.status}) for user ${userId}: ${detail.slice(0, 2000)}`,
+        );
+        const upstreamError = new Error(
+            `Mynah transcription failed (${res.status})`,
+        );
+        captureServerException(upstreamError, {
+            source: "mynah",
+            distinctId: userId,
+            status: res.status,
+        });
+        throw upstreamError;
     }
 }
 
@@ -99,45 +189,13 @@ export async function transcribeViaMynah(
             throw configError;
         }
 
-        const res = await fetch(`${mynahBaseUrl}/v1/audio/transcriptions`, {
-            method: "POST",
-            headers: {
-                authorization: `Bearer ${mynahServiceToken}`,
-                "content-type": "application/json",
-                "x-riffado-user-id": input.userId,
-            },
-            body: JSON.stringify({
-                url,
-                response_format: "verbose_json",
-                ...(input.language ? { language: input.language } : {}),
-            }),
+        const body = await postTranscriptionRequest({
+            mynahBaseUrl,
+            mynahServiceToken,
+            userId: input.userId,
+            url,
+            language: input.language,
         });
-
-        if (!res.ok) {
-            // The upstream body can contain internal Mynah diagnostics; this
-            // error's message propagates all the way to the client via
-            // transcribeRecording's catch block (result.error -> AppError
-            // message -> JSON response), so log the detail server-side only
-            // and throw a status-only message.
-            const detail = await res.text().catch(() => "");
-            console.error(
-                `[mynah] transcription request failed (${res.status}) for user ${input.userId}: ${detail.slice(0, 2000)}`,
-            );
-            const upstreamError = new Error(
-                `Mynah transcription failed (${res.status})`,
-            );
-            captureServerException(upstreamError, {
-                source: "mynah",
-                distinctId: input.userId,
-                status: res.status,
-            });
-            throw upstreamError;
-        }
-
-        const body = (await res.json()) as {
-            text?: string;
-            language?: string | null;
-        };
 
         commitMynahReservation(reservation);
         return {

--- a/src/tests/admin/metrics-format.test.ts
+++ b/src/tests/admin/metrics-format.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression coverage for `formatDate`/`formatRelative` receiving a
+ * non-`Date` value at runtime.
+ *
+ * `src/db/queries/admin-billing.ts` (and the other raw `db.execute(sql\`...\`)`
+ * admin queries) type their timestamp columns as `Date`, but that's a
+ * compile-time annotation only -- nothing enforces it at runtime. When a
+ * value reached these formatters as something other than a real `Date`
+ * instance (e.g. an ISO string), `d.getTime()` / `d.toLocaleString()`
+ * threw `TypeError: x.getTime is not a function` and crashed the whole
+ * page (observed repeatedly on /admin/billing in production). These
+ * formatters must coerce a parseable non-Date value instead of throwing,
+ * and degrade to their "no value" fallback only for genuinely invalid
+ * input.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+    formatDate,
+    formatRelative,
+} from "@/app/(hosted)/admin/(gated)/_components/metrics";
+
+describe("formatRelative", () => {
+    it("formats a real Date", () => {
+        const d = new Date(Date.now() - 5 * 60_000);
+        expect(formatRelative(d)).toBe("5m ago");
+    });
+
+    it("returns 'never' for null/undefined", () => {
+        expect(formatRelative(null)).toBe("never");
+        expect(formatRelative(undefined)).toBe("never");
+    });
+
+    it("coerces a parseable non-Date value (e.g. an ISO string) instead of throwing", () => {
+        const isoString = new Date(Date.now() - 5 * 60_000).toISOString();
+        // biome-ignore lint/suspicious/noExplicitAny: exercising a runtime type mismatch the `Date` prop type can't express
+        expect(() => formatRelative(isoString as any)).not.toThrow();
+        // biome-ignore lint/suspicious/noExplicitAny: exercising a runtime type mismatch the `Date` prop type can't express
+        expect(formatRelative(isoString as any)).toBe("5m ago");
+    });
+
+    it("falls back to 'never' for an unparseable value instead of throwing", () => {
+        const invalid = new Date("not-a-date");
+        expect(() => formatRelative(invalid)).not.toThrow();
+        expect(formatRelative(invalid)).toBe("never");
+    });
+});
+
+describe("formatDate", () => {
+    it("formats a real Date", () => {
+        expect(formatDate(new Date("2026-07-22T12:00:00Z"))).toContain("2026");
+    });
+
+    it("returns an em dash for null/undefined", () => {
+        expect(formatDate(null)).toBe("—");
+        expect(formatDate(undefined)).toBe("—");
+    });
+
+    it("coerces a parseable non-Date value (e.g. an ISO string) instead of throwing", () => {
+        const isoString = "2026-07-22T12:00:00Z";
+        // biome-ignore lint/suspicious/noExplicitAny: exercising a runtime type mismatch the `Date` prop type can't express
+        expect(() => formatDate(isoString as any)).not.toThrow();
+        // biome-ignore lint/suspicious/noExplicitAny: exercising a runtime type mismatch the `Date` prop type can't express
+        expect(formatDate(isoString as any)).toContain("2026");
+    });
+
+    it("falls back to an em dash for an unparseable value instead of throwing", () => {
+        const invalid = new Date("not-a-date");
+        expect(() => formatDate(invalid)).not.toThrow();
+        expect(formatDate(invalid)).toBe("—");
+    });
+});

--- a/src/tests/billing/upsert-subscription.test.ts
+++ b/src/tests/billing/upsert-subscription.test.ts
@@ -14,12 +14,18 @@
  *     and retry.
  *   - If no conflicting row is found, the race already resolved itself
  *     between the failed insert and this lookup (a concurrent webhook
- *     cleared/replaced the blocking row) -- retry the upsert once instead
- *     of re-throwing the raw postgres driver error, which embeds the full
- *     parameterized SQL statement (Stripe customer id, price id, amount)
- *     and would otherwise leak into error tracking as an unhandled
- *     failure (see PostHog issue with fingerprint
+ *     cleared/replaced the blocking row) -- retry the upsert in a bounded
+ *     loop instead of re-throwing the raw postgres driver error, which
+ *     embeds the full parameterized SQL statement (Stripe customer id,
+ *     price id, amount) and would otherwise leak into error tracking as an
+ *     unhandled failure (see PostHog issue with fingerprint
  *     fd4b8e92...0cd8c38026b41ef8975754971710a3c3918b05c66578ebb82a6a2623ab77c8e0cc73d428).
+ *   - The loop, not a single retry, matters under repeated contention: if
+ *     a *second* live subscription lands on the retry attempt, that must
+ *     still surface as `SubscriptionUserConflictError` (not escape as a
+ *     raw error), and if the self-resolving race repeats past the retry
+ *     budget, the final failure must still be a sanitized error rather
+ *     than the raw driver error.
  */
 
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -61,9 +67,9 @@ function stubInsert(...results: Array<"ok" | Error>) {
     return onConflictDoUpdate;
 }
 
-/** Stubs `db.select().from().where().orderBy().limit()` used by `getSubscriptionByUserId`. */
-function stubSelect(rows: Array<Record<string, unknown>>) {
-    (db.select as unknown as Mock).mockReturnValue({
+/** Builds one `db.select()` chain result resolving to `rows`. */
+function selectResult(rows: Array<Record<string, unknown>>) {
+    return {
         from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
                 orderBy: vi.fn().mockReturnValue({
@@ -71,7 +77,12 @@ function stubSelect(rows: Array<Record<string, unknown>>) {
                 }),
             }),
         }),
-    });
+    };
+}
+
+/** Stubs `db.select().from().where().orderBy().limit()` used by `getSubscriptionByUserId`. */
+function stubSelect(rows: Array<Record<string, unknown>>) {
+    (db.select as unknown as Mock).mockReturnValue(selectResult(rows));
 }
 
 const baseInput = {
@@ -132,15 +143,53 @@ describe("upsertSubscription", () => {
         expect(onConflictDoUpdate).toHaveBeenCalledTimes(2);
     });
 
-    it("does not swallow the raw driver error if the retry itself fails", async () => {
-        const conflictError = uniqueViolation();
-        const onConflictDoUpdate = stubInsert(conflictError, uniqueViolation());
+    it("throws SubscriptionUserConflictError, not a raw driver error, when a second live subscription lands on the retry", async () => {
+        // Attempt 1 fails; the lookup right after finds nothing (the race
+        // looked self-resolved), so it retries. But before attempt 2 lands,
+        // a *different* webhook inserts another live subscription for this
+        // user, so attempt 2 also violates the index -- this time there IS
+        // a genuine conflicting row on the next lookup.
+        const onConflictDoUpdate = stubInsert(
+            uniqueViolation(),
+            uniqueViolation(),
+        );
+        const select = db.select as unknown as Mock;
+        select
+            .mockImplementationOnce(() => selectResult([]))
+            .mockImplementationOnce(() =>
+                selectResult([
+                    { id: "sub_other", userId: "u1", status: "active" },
+                ]),
+            );
+
+        const error = await upsertSubscription(baseInput).catch((e) => e);
+
+        expect(error).toBeInstanceOf(SubscriptionUserConflictError);
+        expect(error).toMatchObject({
+            userId: "u1",
+            conflictingSubscriptionId: "sub_other",
+        });
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(2);
+        expect(select).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up with a sanitized error (not the raw driver error) after exhausting retries on a persistently self-resolving race", async () => {
+        const onConflictDoUpdate = stubInsert(
+            uniqueViolation(),
+            uniqueViolation(),
+            uniqueViolation(),
+        );
+        // Every lookup finds no conflicting row -- the race never actually
+        // resolves within the retry budget.
         stubSelect([]);
 
-        await expect(upsertSubscription(baseInput)).rejects.toThrow(
-            /duplicate key value violates unique constraint/,
-        );
-        expect(onConflictDoUpdate).toHaveBeenCalledTimes(2);
+        const error = await upsertSubscription(baseInput).catch((e) => e);
+
+        expect(error).not.toBeInstanceOf(SubscriptionUserConflictError);
+        expect(error.message).not.toMatch(/insert into "subscriptions"/);
+        expect(error.message).toMatch(/did not resolve after 3 attempts/);
+        // 3 attempts total: the initial call + 2 retries.
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(3);
     });
 
     it("rethrows unrelated errors immediately without looking up a conflict", async () => {

--- a/src/tests/billing/upsert-subscription.test.ts
+++ b/src/tests/billing/upsert-subscription.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression coverage for `upsertSubscription`'s handling of the
+ * `subscriptions_user_id_active_unique` partial unique index (at most one
+ * live subscription per user).
+ *
+ * Two Stripe webhooks racing on the same user can both hit this index: the
+ * first insert/update wins, the second collides. `upsertSubscription`
+ * resolves the collision by looking up the currently-live subscription for
+ * that user:
+ *
+ *   - If a *different* subscription is still live, that's a genuine
+ *     out-of-order-webhook conflict -- throw `SubscriptionUserConflictError`
+ *     so the caller (`mirror.ts`) can re-mirror the stale row from Stripe
+ *     and retry.
+ *   - If no conflicting row is found, the race already resolved itself
+ *     between the failed insert and this lookup (a concurrent webhook
+ *     cleared/replaced the blocking row) -- retry the upsert once instead
+ *     of re-throwing the raw postgres driver error, which embeds the full
+ *     parameterized SQL statement (Stripe customer id, price id, amount)
+ *     and would otherwise leak into error tracking as an unhandled
+ *     failure (see PostHog issue with fingerprint
+ *     fd4b8e92...0cd8c38026b41ef8975754971710a3c3918b05c66578ebb82a6a2623ab77c8e0cc73d428).
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        insert: vi.fn(),
+        select: vi.fn(),
+    },
+}));
+
+import { db } from "@/db";
+import {
+    SubscriptionUserConflictError,
+    upsertSubscription,
+} from "@/db/queries/billing";
+
+const uniqueViolation = () =>
+    Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "23505",
+        constraint_name: "subscriptions_user_id_active_unique",
+    });
+
+/** Queues successive resolutions/rejections for `db.insert(...).values(...).onConflictDoUpdate(...)`. */
+function stubInsert(...results: Array<"ok" | Error>) {
+    const onConflictDoUpdate = vi.fn();
+    for (const result of results) {
+        if (result === "ok") {
+            onConflictDoUpdate.mockImplementationOnce(async () => undefined);
+        } else {
+            onConflictDoUpdate.mockImplementationOnce(async () => {
+                throw result;
+            });
+        }
+    }
+    (db.insert as unknown as Mock).mockReturnValue({
+        values: vi.fn().mockReturnValue({ onConflictDoUpdate }),
+    });
+    return onConflictDoUpdate;
+}
+
+/** Stubs `db.select().from().where().orderBy().limit()` used by `getSubscriptionByUserId`. */
+function stubSelect(rows: Array<Record<string, unknown>>) {
+    (db.select as unknown as Mock).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue(rows),
+                }),
+            }),
+        }),
+    });
+}
+
+const baseInput = {
+    id: "sub_new",
+    userId: "u1",
+    stripeCustomerId: "cus_1",
+    stripePriceId: "price_1",
+    status: "active",
+    amountValue: "5.00",
+    amountCurrency: "USD",
+    interval: "1 month",
+    description: null,
+    billingCountry: "US",
+    startDate: new Date("2026-07-22T00:00:00Z"),
+    nextPaymentAt: null,
+    canceledAt: null,
+    metadata: {},
+};
+
+describe("upsertSubscription", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("succeeds on the first attempt when there is no conflict", async () => {
+        const onConflictDoUpdate = stubInsert("ok");
+
+        await expect(upsertSubscription(baseInput)).resolves.toBeUndefined();
+
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
+        expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("throws SubscriptionUserConflictError when a different subscription is still live", async () => {
+        const onConflictDoUpdate = stubInsert(uniqueViolation());
+        stubSelect([{ id: "sub_other", userId: "u1", status: "active" }]);
+
+        const error = await upsertSubscription(baseInput).catch((e) => e);
+
+        expect(error).toBeInstanceOf(SubscriptionUserConflictError);
+        expect(error).toMatchObject({
+            userId: "u1",
+            conflictingSubscriptionId: "sub_other",
+        });
+        // Never retries the raw insert once a genuine conflict is found --
+        // the caller must re-mirror the conflicting row first.
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries once and succeeds when the conflict already resolved itself", async () => {
+        const onConflictDoUpdate = stubInsert(uniqueViolation(), "ok");
+        // No live row for this user by the time we look -- the blocking
+        // row was cleared/replaced by a concurrent webhook.
+        stubSelect([]);
+
+        await expect(upsertSubscription(baseInput)).resolves.toBeUndefined();
+
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not swallow the raw driver error if the retry itself fails", async () => {
+        const conflictError = uniqueViolation();
+        const onConflictDoUpdate = stubInsert(conflictError, uniqueViolation());
+        stubSelect([]);
+
+        await expect(upsertSubscription(baseInput)).rejects.toThrow(
+            /duplicate key value violates unique constraint/,
+        );
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it("rethrows unrelated errors immediately without looking up a conflict", async () => {
+        const connectionError = new Error("connection terminated");
+        const onConflictDoUpdate = stubInsert(connectionError);
+
+        await expect(upsertSubscription(baseInput)).rejects.toThrow(
+            "connection terminated",
+        );
+
+        expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
+        expect(db.select).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/hosted/mynah-transcribe.test.ts
+++ b/src/tests/hosted/mynah-transcribe.test.ts
@@ -138,23 +138,84 @@ describe("transcribeViaMynah", () => {
         expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("refunds the reservation when Mynah returns an error", async () => {
+    it("refunds the reservation and gives up after exhausting retries on a persistent transient error", async () => {
+        vi.useFakeTimers();
+        try {
+            reserveMock.mockResolvedValue({
+                userId: "u1",
+                seconds: 65,
+                reserved: true,
+            });
+            const fetchSpy = vi
+                .fn()
+                .mockResolvedValue(
+                    new Response("upstream down", { status: 502 }),
+                );
+            vi.stubGlobal("fetch", fetchSpy);
+
+            const result = transcribeViaMynah(input);
+            const assertion = expect(result).rejects.toThrow(/502/);
+            await vi.runAllTimersAsync();
+            await assertion;
+
+            // Initial attempt + 2 retries (MAX_RETRIES).
+            expect(fetchSpy).toHaveBeenCalledTimes(3);
+            expect(releaseMock).toHaveBeenCalledOnce();
+            expect(commitMock).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("does not retry a non-transient (4xx) error", async () => {
         reserveMock.mockResolvedValue({
             userId: "u1",
             seconds: 65,
             reserved: true,
         });
-        vi.stubGlobal(
-            "fetch",
-            vi
-                .fn()
-                .mockResolvedValue(
-                    new Response("upstream down", { status: 502 }),
-                ),
-        );
+        const fetchSpy = vi
+            .fn()
+            .mockResolvedValue(new Response("bad request", { status: 400 }));
+        vi.stubGlobal("fetch", fetchSpy);
 
-        await expect(transcribeViaMynah(input)).rejects.toThrow(/502/);
+        await expect(transcribeViaMynah(input)).rejects.toThrow(/400/);
+        expect(fetchSpy).toHaveBeenCalledOnce();
         expect(releaseMock).toHaveBeenCalledOnce();
-        expect(commitMock).not.toHaveBeenCalled();
+    });
+
+    it("retries a transient (524) gateway timeout and succeeds", async () => {
+        vi.useFakeTimers();
+        try {
+            reserveMock.mockResolvedValue({
+                userId: "u1",
+                seconds: 65,
+                reserved: true,
+            });
+            const fetchSpy = vi
+                .fn()
+                .mockResolvedValueOnce(
+                    new Response("gateway timeout", { status: 524 }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ text: "hi", language: "en" }),
+                        { status: 200 },
+                    ),
+                );
+            vi.stubGlobal("fetch", fetchSpy);
+
+            const result = transcribeViaMynah(input);
+            await vi.runAllTimersAsync();
+            await expect(result).resolves.toEqual({
+                text: "hi",
+                detectedLanguage: "en",
+            });
+
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+            expect(commitMock).toHaveBeenCalledOnce();
+            expect(releaseMock).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/src/tests/hosted/mynah-transcribe.test.ts
+++ b/src/tests/hosted/mynah-transcribe.test.ts
@@ -218,4 +218,68 @@ describe("transcribeViaMynah", () => {
             vi.useRealTimers();
         }
     });
+
+    it("reuses the same idempotency key across every retry attempt of one logical request", async () => {
+        vi.useFakeTimers();
+        try {
+            reserveMock.mockResolvedValue({
+                userId: "u1",
+                seconds: 65,
+                reserved: true,
+            });
+            const fetchSpy = vi
+                .fn()
+                .mockResolvedValueOnce(
+                    new Response("bad gateway", { status: 502 }),
+                )
+                .mockResolvedValueOnce(
+                    new Response(
+                        JSON.stringify({ text: "hi", language: "en" }),
+                        { status: 200 },
+                    ),
+                );
+            vi.stubGlobal("fetch", fetchSpy);
+
+            const result = transcribeViaMynah(input);
+            await vi.runAllTimersAsync();
+            await expect(result).resolves.toEqual({
+                text: "hi",
+                detectedLanguage: "en",
+            });
+
+            expect(fetchSpy).toHaveBeenCalledTimes(2);
+            const [, firstInit] = fetchSpy.mock.calls[0];
+            const [, secondInit] = fetchSpy.mock.calls[1];
+            const firstKey = firstInit.headers["idempotency-key"];
+            const secondKey = secondInit.headers["idempotency-key"];
+            expect(firstKey).toBeTruthy();
+            expect(secondKey).toBe(firstKey);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("uses a fresh idempotency key for a separate transcription call", async () => {
+        reserveMock.mockResolvedValue({
+            userId: "u1",
+            seconds: 65,
+            reserved: true,
+        });
+        const fetchSpy = vi.fn().mockImplementation(
+            async () =>
+                new Response(JSON.stringify({ text: "hi", language: "en" }), {
+                    status: 200,
+                }),
+        );
+        vi.stubGlobal("fetch", fetchSpy);
+
+        await transcribeViaMynah(input);
+        await transcribeViaMynah(input);
+
+        const [, firstInit] = fetchSpy.mock.calls[0];
+        const [, secondInit] = fetchSpy.mock.calls[1];
+        expect(secondInit.headers["idempotency-key"]).not.toBe(
+            firstInit.headers["idempotency-key"],
+        );
+    });
 });


### PR DESCRIPTION
## Description

Fixes three real bugs surfaced by triaging PostHog's active error-tracking issues in production: an admin page crash, a subscription-mirroring error-tracking leak, and a Mynah transcription failure with no retry.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #
Relates to #

## Changes Made

- `formatDate`/`formatRelative` in the admin metrics helpers now coerce their input through a shared `toValidDate()` guard instead of calling `.getTime()`/`.toLocaleString()` on an unverified value -- this was crashing `/admin/billing` repeatedly in production with `TypeError: x.getTime is not a function`.
- `upsertSubscription` now retries once when a `subscriptions_user_id_active_unique` violation has already resolved itself (no conflicting row found), instead of re-throwing the raw driver error, which was leaking full parameterized SQL (Stripe customer id, price id, amount) into error tracking and skipping `mirror.ts`'s existing conflict-retry path.
- `transcribeViaMynah` now retries transient upstream gateway failures (502/503/504/524) with exponential backoff before giving up, mirroring `PlaudClient`'s existing retry pattern, instead of failing the whole transcription on a single Cloudflare timeout.

## Screenshots (if applicable)

N/A

## Testing

### Test Environment
- OS: macOS
- Node version: n/a (bun/vitest via pnpm scripts)
- Browser (if UI changes): N/A

### Test Steps
1. `pnpm format-and-lint:fix`
2. `pnpm type-check`
3. `pnpm test`

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

None.

## Additional Notes

Root-caused via the PostHog MCP: pulled the last 30 days of active error-tracking issues, matched stack traces/session correlation to source, and confirmed two other issues in that list (`data_devices` TypeError, `Failed to list Plaud workspaces`) were already fixed by a prior commit predating this branch, and two more (`Sync completed with N error(s)`, the Gemini 20MB size error) are intentional by design -- no changes needed for those.

## For Reviewers

- `src/db/queries/billing.ts`: the retry-once behavior on a self-resolved conflict is the one worth double-checking for correctness under concurrent webhook delivery.
- `src/lib/hosted/transcription/mynah.ts`: retry/backoff constants (`MAX_RETRIES = 2`, `INITIAL_RETRY_DELAY_MS = 1000`) mirror `PlaudClient`'s existing values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three production issues: stop `/admin/billing` crashes on bad dates, bound and sanitize subscription upsert conflict retries to avoid raw SQL leaks, and add idempotent retries for transient Mynah gateway errors.

- **Bug Fixes**
  - Admin: `formatDate`/`formatRelative` now coerce inputs via a shared `toValidDate()` to handle non-Date values and avoid crashes.
  - Billing: `upsertSubscription` handles `subscriptions_user_id_active_unique` with a bounded retry loop (3 attempts) when the conflict self-resolves; still throws `SubscriptionUserConflictError` for genuine conflicts and returns a sanitized error if retries are exhausted (no raw SQL leak).
  - Transcription: `transcribeViaMynah` retries transient 502/503/504/524 with exponential backoff and sends a stable `idempotency-key` across attempts; non-transient errors fail fast.

<sup>Written for commit c2575001546b741d1c4131303de89860a3d3006f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

