### PR TITLE
fix(billing): durably process Stripe webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Migration `0036_wide_raider` upgrades `stripe_webhook_events` to a durable Stripe event inbox. Inert on self-host unless hosted billing is configured.
+
 ## [0.6.4] - 2026-07-24
 
 ### Fixed

--- a/src/app/(hosted)/api/admin/actions/replay-stripe-webhook/route.ts
+++ b/src/app/(hosted)/api/admin/actions/replay-stripe-webhook/route.ts
@@ -1,0 +1,40 @@
+import { headers as nextHeaders } from "next/headers";
+import { NextResponse } from "next/server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import { replayStripeWebhookEvent } from "@/lib/hosted/admin/actions";
+import { requireAdminMutation } from "@/lib/hosted/admin/guard";
+import { clientIpFromHeaders } from "@/lib/hosted/admin/ip-allowlist";
+
+/** Safely requeues a terminal Stripe inbox event without deleting its audit row. */
+export const POST = apiHandler(async (request: Request) => {
+    const admin = await requireAdminMutation({
+        route: "/api/admin/actions/replay-stripe-webhook",
+        method: "POST",
+    });
+    const parsed = await request.json().catch(() => null);
+    const body =
+        parsed && typeof parsed === "object"
+            ? (parsed as Record<string, unknown>)
+            : {};
+    const eventId = typeof body.eventId === "string" ? body.eventId : null;
+    const reason = typeof body.reason === "string" ? body.reason : "";
+    if (!eventId) {
+        throw new AppError(
+            ErrorCode.MISSING_REQUIRED_FIELD,
+            "eventId required",
+            400,
+            { field: "eventId" },
+        );
+    }
+
+    const result = await replayStripeWebhookEvent(
+        {
+            adminUserId: admin.user.id,
+            adminUserEmail: admin.user.email,
+            ip: clientIpFromHeaders(await nextHeaders()),
+            reason,
+        },
+        eventId,
+    );
+    return NextResponse.json(result);
+});

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,19 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server";
 import type Stripe from "stripe";
+import { enqueueStripeWebhookEvent } from "@/db/queries/billing";
 import { env } from "@/lib/env";
 import {
     getStripe,
     isStripeConfigured,
 } from "@/lib/hosted/billing/stripe-client";
-import { handleStripeWebhook } from "@/lib/hosted/billing/webhook";
-import { captureServerException } from "@/lib/posthog-server";
 
 /**
  * Stripe webhook receiver. Verifies the signature against
- * `STRIPE_WEBHOOK_SECRET`, then dispatches the verified event. Always
- * 200s after a successful signature check so Stripe stops retrying;
- * handler errors are logged, not surfaced (Stripe would otherwise hammer
- * the endpoint). 404 on self-host, 503 if unconfigured.
+ * `STRIPE_WEBHOOK_SECRET`, then durably queues the verified event. It only
+ * acknowledges after persistence; the billing worker processes the inbox.
+ * 404 on self-host, 503 if unconfigured.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
     if (!env.IS_HOSTED) {
@@ -57,19 +55,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         );
     }
 
-    try {
-        await handleStripeWebhook(event);
-    } catch (error) {
-        console.error(
-            `[stripe-webhook] handler threw for ${event.type} id=${event.id}`,
-            error,
-        );
-        captureServerException(error, {
-            source: "stripe-webhook",
-            eventType: event.type,
-            eventId: event.id,
-        });
-    }
+    const queued = await enqueueStripeWebhookEvent({
+        eventId: event.id,
+        type: event.type,
+        eventCreatedAt: new Date(event.created * 1000),
+        payload: event.data.object as unknown as Record<string, unknown>,
+    });
 
-    return NextResponse.json({ received: true });
+    return NextResponse.json({ received: true, queued });
 }

--- a/src/db/migrations/0036_wide_raider.sql
+++ b/src/db/migrations/0036_wide_raider.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."stripe_webhook_event_status" AS ENUM('pending', 'processing', 'completed', 'failed');--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" RENAME COLUMN "processed_at" TO "event_created_at";--> statement-breakpoint
+DROP INDEX "stripe_webhook_events_processed_at_idx";--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "payload" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "status" "stripe_webhook_event_status" DEFAULT 'completed' NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "claim_token" text;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "started_at" timestamp;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "next_attempt_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "last_error" text;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "completed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "failed_at" timestamp;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "created_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "stripe_webhook_events" ADD COLUMN "updated_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+CREATE INDEX "stripe_webhook_events_due_idx" ON "stripe_webhook_events" USING btree ("status","next_attempt_at");--> statement-breakpoint
+CREATE INDEX "stripe_webhook_events_created_at_idx" ON "stripe_webhook_events" USING btree ("created_at");

--- a/src/db/migrations/meta/0036_snapshot.json
+++ b/src/db/migrations/meta/0036_snapshot.json
@@ -1,0 +1,3530 @@
+{
+  "id": "fefc5511-d9ed-47a3-b6ba-ea18202650da",
+  "prevId": "caf9f869-84c0-4517-8d5a-68e5748776d6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_action_log": {
+      "name": "admin_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_action_log_created_idx": {
+          "name": "admin_action_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_action_log_target_user_idx": {
+          "name": "admin_action_log_target_user_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_action_log_admin_user_id_users_id_fk": {
+          "name": "admin_action_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_action_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_created_idx": {
+          "name": "admin_audit_log_admin_created_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'riffado'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "api_key_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"read\"]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limit_buckets": {
+      "name": "api_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_buckets_reset_at_idx": {
+          "name": "api_rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_campaigns": {
+      "name": "email_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_campaigns_slug_unique": {
+          "name": "email_campaigns_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_deliveries": {
+      "name": "email_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_deliveries_campaign_status_idx": {
+          "name": "email_deliveries_campaign_status_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_deliveries_user_id_idx": {
+          "name": "email_deliveries_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_deliveries_campaign_id_email_campaigns_id_fk": {
+          "name": "email_deliveries_campaign_id_email_campaigns_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "email_campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_deliveries_user_id_users_id_fk": {
+          "name": "email_deliveries_user_id_users_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_deliveries_subscriber_id_newsletter_subscriptions_id_fk": {
+          "name": "email_deliveries_subscriber_id_newsletter_subscriptions_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "newsletter_subscriptions",
+          "columnsFrom": [
+            "subscriber_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_deliveries_campaign_email_unique": {
+          "name": "email_deliveries_campaign_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "campaign_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_log": {
+      "name": "email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_log_user_id_users_id_fk": {
+          "name": "email_log_user_id_users_id_fk",
+          "tableFrom": "email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_log_user_kind_unique": {
+          "name": "email_log_user_kind_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_created_at_idx": {
+          "name": "email_suppressions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_validations": {
+      "name": "email_validations",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disposable": {
+          "name": "is_disposable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_role_account": {
+          "name": "is_role_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_full_inbox": {
+          "name": "has_full_inbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_catch_all": {
+          "name": "is_catch_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mx_accepts": {
+          "name": "mx_accepts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reacher-stacked'"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_validations_checked_at_idx": {
+          "name": "email_validations_checked_at_idx",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_count": {
+          "name": "recording_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_storage_keys": {
+          "name": "stale_storage_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "export_jobs_user_id_idx": {
+          "name": "export_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_status_created_at_idx": {
+          "name": "export_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_expires_at_idx": {
+          "name": "export_jobs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_user_active_unique": {
+          "name": "export_jobs_user_active_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"export_jobs\".\"status\" in ('pending', 'processing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "export_jobs_user_id_users_id_fk": {
+          "name": "export_jobs_user_id_users_id_fk",
+          "tableFrom": "export_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.founding_member_reservations": {
+      "name": "founding_member_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "founding_member_reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "founding_member_reservations_status_expires_at_idx": {
+          "name": "founding_member_reservations_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founding_member_reservations_user_status_idx": {
+          "name": "founding_member_reservations_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founding_member_reservations_user_reserved_unique": {
+          "name": "founding_member_reservations_user_reserved_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"founding_member_reservations\".\"status\" = 'reserved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "founding_member_reservations_user_id_users_id_fk": {
+          "name": "founding_member_reservations_user_id_users_id_fk",
+          "tableFrom": "founding_member_reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "founding_member_reservations_stripe_checkout_session_id_unique": {
+          "name": "founding_member_reservations_stripe_checkout_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_checkout_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.install_script_hits": {
+      "name": "install_script_hits",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_script_hits_day_version_pk": {
+          "name": "install_script_hits_day_version_pk",
+          "columns": [
+            "day",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscriptions": {
+      "name": "newsletter_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscriptions_confirmed_at_idx": {
+          "name": "newsletter_subscriptions_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscriptions_email_unique": {
+          "name": "newsletter_subscriptions_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "waveform_peaks": {
+          "name": "waveform_peaks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_user_id_plaud_file_id_unique": {
+          "name": "recordings_user_id_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_webhook_events_due_idx": {
+          "name": "stripe_webhook_events_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_webhook_events_created_at_idx": {
+          "name": "stripe_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_value": {
+          "name": "amount_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_currency": {
+          "name": "amount_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_country": {
+          "name": "billing_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_payment_at": {
+          "name": "next_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_waiver_accepted_at": {
+          "name": "withdrawal_waiver_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_active_unique": {
+          "name": "subscriptions_user_id_active_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'trialing', 'past_due')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_user_status_idx": {
+          "name": "subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'riffado'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transcriptions_recording_user_source_unique": {
+          "name": "transcriptions_recording_user_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "player_scrubber": {
+          "name": "player_scrubber",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waveform'"
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "import_plaud_content": {
+          "name": "import_plaud_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transcript_mode": {
+          "name": "transcript_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plaud_only'"
+        },
+        "preferred_transcript_source": {
+          "name": "preferred_transcript_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plaud'"
+        },
+        "default_transcription_provider_id": {
+          "name": "default_transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "list_density": {
+          "name": "list_density",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comfortable'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing_email_consent": {
+          "name": "marketing_email_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_transition_until": {
+          "name": "plan_transition_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_mynah_seconds_remaining": {
+          "name": "monthly_mynah_seconds_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_mynah_grant_reset_at": {
+          "name": "monthly_mynah_grant_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_member": {
+          "name": "founding_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "founding_member_claimed_at": {
+          "name": "founding_member_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ever_paid_at": {
+          "name": "ever_paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_deletion_scheduled_at": {
+          "name": "account_deletion_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_id_idx": {
+          "name": "webhook_deliveries_endpoint_id_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recording_id_idx": {
+          "name": "webhook_deliveries_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_user_id_users_id_fk": {
+          "name": "webhook_deliveries_user_id_users_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_recording_id_recordings_id_fk": {
+          "name": "webhook_deliveries_recording_id_recordings_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_status": {
+          "name": "last_delivery_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_user_id_idx": {
+          "name": "webhook_endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_user_id_users_id_fk": {
+          "name": "webhook_endpoints_user_id_users_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_source": {
+      "name": "api_key_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "device-flow"
+      ]
+    },
+    "public.export_job_status": {
+      "name": "export_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.founding_member_reservation_status": {
+      "name": "founding_member_reservation_status",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "consumed",
+        "released",
+        "expired"
+      ]
+    },
+    "public.stripe_webhook_event_status": {
+      "name": "stripe_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "self_host",
+        "hosted_free",
+        "hosted_pro"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1784656848456,
       "tag": "0035_peaceful_hairball",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1785145753255,
+      "tag": "0036_wide_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -1087,6 +1087,30 @@ export async function claimDueStripeWebhookEvents(input: {
     }));
 }
 
+/** Extends a live claim so long-running handlers are not reclaimed mid-flight. */
+export async function renewStripeWebhookEventClaim(input: {
+    eventId: string;
+    claimToken: string;
+    processingLeaseMs: number;
+}): Promise<boolean> {
+    const now = new Date();
+    const rows = await db
+        .update(stripeWebhookEvents)
+        .set({
+            nextAttemptAt: new Date(now.getTime() + input.processingLeaseMs),
+            updatedAt: now,
+        })
+        .where(
+            and(
+                eq(stripeWebhookEvents.eventId, input.eventId),
+                eq(stripeWebhookEvents.status, "processing"),
+                eq(stripeWebhookEvents.claimToken, input.claimToken),
+            ),
+        )
+        .returning({ eventId: stripeWebhookEvents.eventId });
+    return rows.length > 0;
+}
+
 export async function completeStripeWebhookEvent(input: {
     eventId: string;
     claimToken: string;

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -1087,6 +1087,19 @@ export async function claimDueStripeWebhookEvents(input: {
     }));
 }
 
+/** Serializes event side effects across workers for one Stripe event id. */
+export async function withStripeWebhookEventLock<T>(
+    eventId: string,
+    run: () => Promise<T>,
+): Promise<T> {
+    return db.transaction(async (tx) => {
+        await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${eventId}, 0))`,
+        );
+        return run();
+    });
+}
+
 /** Extends a live claim so long-running handlers are not reclaimed mid-flight. */
 export async function renewStripeWebhookEventClaim(input: {
     eventId: string;

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -1153,6 +1153,30 @@ export async function renewStripeWebhookEventClaim(input: {
     return rows.length > 0;
 }
 
+/** Completes an event while its event-scoped advisory lock is held. */
+export async function completeStripeWebhookEventUnderLock(
+    eventId: string,
+): Promise<boolean> {
+    const rows = await db
+        .update(stripeWebhookEvents)
+        .set({
+            status: "completed",
+            completedAt: new Date(),
+            claimToken: null,
+            startedAt: null,
+            lastError: null,
+            updatedAt: new Date(),
+        })
+        .where(
+            and(
+                eq(stripeWebhookEvents.eventId, eventId),
+                eq(stripeWebhookEvents.status, "processing"),
+            ),
+        )
+        .returning({ eventId: stripeWebhookEvents.eventId });
+    return rows.length > 0;
+}
+
 export async function completeStripeWebhookEvent(input: {
     eventId: string;
     claimToken: string;

--- a/src/db/queries/billing.ts
+++ b/src/db/queries/billing.ts
@@ -995,20 +995,171 @@ export async function listSubscriptionsForReconcile(input: {
     }));
 }
 
-/** First-write-wins claim on a Stripe webhook event. Null = duplicate. */
-export async function claimWebhookDelivery(input: {
+export type StripeWebhookEventStatus =
+    | "pending"
+    | "processing"
+    | "completed"
+    | "failed";
+
+export interface ClaimedStripeWebhookEvent {
     eventId: string;
     type: string;
-}): Promise<{ eventId: string } | null> {
+    eventCreatedAt: Date;
+    payload: Record<string, unknown>;
+    attempts: number;
+    claimToken: string;
+}
+
+/**
+ * Durably records a verified Stripe event. The unique event id makes Stripe
+ * redelivery safe without conflating receipt with successful processing.
+ */
+export async function enqueueStripeWebhookEvent(input: {
+    eventId: string;
+    type: string;
+    eventCreatedAt: Date;
+    payload: Record<string, unknown>;
+}): Promise<boolean> {
     const inserted = await db
         .insert(stripeWebhookEvents)
         .values({
             eventId: input.eventId,
             type: input.type,
+            eventCreatedAt: input.eventCreatedAt,
+            payload: input.payload,
+            status: "pending",
         })
         .onConflictDoNothing({ target: stripeWebhookEvents.eventId })
         .returning({ eventId: stripeWebhookEvents.eventId });
-    return inserted[0] ?? null;
+    return inserted.length > 0;
+}
+
+/**
+ * Atomically claims due inbox rows. Processing claims expire so a process
+ * crash cannot strand an event forever; claim-token-scoped completion writes
+ * prevent a stale worker from overwriting the newer claimant's result.
+ */
+export async function claimDueStripeWebhookEvents(input: {
+    limit: number;
+    processingLeaseMs: number;
+}): Promise<ClaimedStripeWebhookEvent[]> {
+    const now = new Date();
+    const leaseExpiresAt = new Date(now.getTime() + input.processingLeaseMs);
+    const nowIso = now.toISOString();
+    const claimed = await db.execute<{
+        event_id: string;
+        type: string;
+        event_created_at: Date;
+        payload: Record<string, unknown>;
+        attempts: number;
+        claim_token: string;
+    }>(sql`
+        update ${stripeWebhookEvents}
+        set
+            status = 'processing',
+            claim_token = gen_random_uuid()::text,
+            started_at = ${nowIso}::timestamp,
+            next_attempt_at = ${leaseExpiresAt.toISOString()}::timestamp,
+            updated_at = ${nowIso}::timestamp
+        where event_id in (
+            select event_id
+            from ${stripeWebhookEvents}
+            where (
+                (status = 'pending' and next_attempt_at <= ${nowIso}::timestamp)
+                or (status = 'processing' and next_attempt_at <= ${nowIso}::timestamp)
+            )
+            order by next_attempt_at asc, created_at asc
+            limit ${input.limit}
+            for update skip locked
+        )
+        returning event_id, type, event_created_at, payload, attempts, claim_token
+    `);
+    const rows = Array.isArray(claimed)
+        ? claimed
+        : ((claimed as { rows: typeof claimed }).rows ?? []);
+    return rows.map((row) => ({
+        eventId: row.event_id,
+        type: row.type,
+        eventCreatedAt: row.event_created_at,
+        payload: row.payload,
+        attempts: row.attempts,
+        claimToken: row.claim_token,
+    }));
+}
+
+export async function completeStripeWebhookEvent(input: {
+    eventId: string;
+    claimToken: string;
+}): Promise<boolean> {
+    const rows = await db
+        .update(stripeWebhookEvents)
+        .set({
+            status: "completed",
+            completedAt: new Date(),
+            claimToken: null,
+            startedAt: null,
+            lastError: null,
+            updatedAt: new Date(),
+        })
+        .where(
+            and(
+                eq(stripeWebhookEvents.eventId, input.eventId),
+                eq(stripeWebhookEvents.status, "processing"),
+                eq(stripeWebhookEvents.claimToken, input.claimToken),
+            ),
+        )
+        .returning({ eventId: stripeWebhookEvents.eventId });
+    return rows.length > 0;
+}
+
+/** Records a failed attempt and schedules exponential retry or terminal failure. */
+export async function failStripeWebhookEvent(input: {
+    eventId: string;
+    claimToken: string;
+    errorMessage: string;
+    maxAttempts: number;
+    retryAt: Date;
+}): Promise<{ status: StripeWebhookEventStatus; attempts: number } | null> {
+    const retryAtIso = input.retryAt.toISOString();
+    const rows = await db.execute<{
+        status: StripeWebhookEventStatus;
+        attempts: number;
+    }>(sql`
+        update ${stripeWebhookEvents}
+        set
+            attempts = attempts + 1,
+            status = case
+                when attempts + 1 >= ${input.maxAttempts} then 'failed'
+                else 'pending'
+            end,
+            claim_token = null,
+            started_at = null,
+            next_attempt_at = case
+                when attempts + 1 >= ${input.maxAttempts} then next_attempt_at
+                else ${retryAtIso}::timestamp
+            end,
+            last_error = ${input.errorMessage},
+            failed_at = case
+                when attempts + 1 >= ${input.maxAttempts} then now()
+                else null
+            end,
+            updated_at = now()
+        where event_id = ${input.eventId}
+          and status = 'processing'
+          and claim_token = ${input.claimToken}
+        returning status, attempts
+    `);
+    const row = Array.isArray(rows)
+        ? rows[0]
+        : ((
+              rows as {
+                  rows: {
+                      status: StripeWebhookEventStatus;
+                      attempts: number;
+                  }[];
+              }
+          ).rows ?? [])[0];
+    return row ?? null;
 }
 
 export interface UserBillingState {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -29,6 +29,11 @@ export const foundingMemberReservationStatusEnum = pgEnum(
     ["reserved", "consumed", "released", "expired"],
 );
 
+export const stripeWebhookEventStatusEnum = pgEnum(
+    "stripe_webhook_event_status",
+    ["pending", "processing", "completed", "failed"],
+);
+
 // Better Auth tables (handled by Better Auth)
 export const users = pgTable("users", {
     id: text("id")
@@ -959,11 +964,33 @@ export const stripeWebhookEvents = pgTable(
     {
         eventId: text("event_id").primaryKey(),
         type: varchar("type", { length: 60 }).notNull(),
-        processedAt: timestamp("processed_at").notNull().defaultNow(),
+        eventCreatedAt: timestamp("event_created_at").notNull(),
+        payload: jsonb("payload")
+            .$type<Record<string, unknown>>()
+            .notNull()
+            .default({}),
+        // Existing claim-only rows predate the durable inbox and must remain
+        // completed on migration; new inbox inserts explicitly set pending.
+        status: stripeWebhookEventStatusEnum("status")
+            .notNull()
+            .default("completed"),
+        attempts: integer("attempts").notNull().default(0),
+        claimToken: text("claim_token"),
+        startedAt: timestamp("started_at"),
+        nextAttemptAt: timestamp("next_attempt_at").notNull().defaultNow(),
+        lastError: text("last_error"),
+        completedAt: timestamp("completed_at"),
+        failedAt: timestamp("failed_at"),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
     },
     (table) => ({
-        processedAtIdx: index("stripe_webhook_events_processed_at_idx").on(
-            table.processedAt,
+        dueScanIdx: index("stripe_webhook_events_due_idx").on(
+            table.status,
+            table.nextAttemptAt,
+        ),
+        createdAtIdx: index("stripe_webhook_events_created_at_idx").on(
+            table.createdAt,
         ),
     }),
 );

--- a/src/lib/hosted/admin/actions.ts
+++ b/src/lib/hosted/admin/actions.ts
@@ -4,6 +4,7 @@ import {
     adminActionLog,
     plaudConnections,
     recordings,
+    stripeWebhookEvents,
     users,
 } from "@/db/schema";
 import { AppError, ErrorCode } from "@/lib/errors";
@@ -365,6 +366,70 @@ export async function extendTransitionWindow(
             planTransitionUntil: newUntil,
             extendedFrom: u.planTransitionUntil,
         };
+    });
+}
+
+/** Requeue a terminal Stripe event without deleting the durable inbox row. */
+export async function replayStripeWebhookEvent(
+    ctx: ActionContext,
+    eventId: string,
+): Promise<{ ok: true; requeued: boolean }> {
+    assertReason(ctx.reason);
+    return db.transaction(async (tx) => {
+        const [event] = await tx
+            .select({
+                eventId: stripeWebhookEvents.eventId,
+                status: stripeWebhookEvents.status,
+                attempts: stripeWebhookEvents.attempts,
+                lastError: stripeWebhookEvents.lastError,
+            })
+            .from(stripeWebhookEvents)
+            .where(eq(stripeWebhookEvents.eventId, eventId))
+            .for("update")
+            .limit(1);
+        if (!event) {
+            throw new AppError(
+                ErrorCode.NOT_FOUND,
+                "Stripe webhook event not found",
+                404,
+            );
+        }
+        if (event.status !== "failed") {
+            await writeActionLog(tx, {
+                ctx,
+                action: "replay_stripe_webhook_noop",
+                targetUserId: null,
+                targetResourceId: eventId,
+                before: { status: event.status, attempts: event.attempts },
+                after: { status: event.status, attempts: event.attempts },
+            });
+            return { ok: true, requeued: false };
+        }
+        await tx
+            .update(stripeWebhookEvents)
+            .set({
+                status: "pending",
+                attempts: 0,
+                claimToken: null,
+                startedAt: null,
+                nextAttemptAt: new Date(),
+                failedAt: null,
+                updatedAt: new Date(),
+            })
+            .where(eq(stripeWebhookEvents.eventId, eventId));
+        await writeActionLog(tx, {
+            ctx,
+            action: "replay_stripe_webhook",
+            targetUserId: null,
+            targetResourceId: eventId,
+            before: {
+                status: event.status,
+                attempts: event.attempts,
+                lastError: event.lastError,
+            },
+            after: { status: "pending", attempts: 0 },
+        });
+        return { ok: true, requeued: true };
     });
 }
 

--- a/src/lib/hosted/billing/README.md
+++ b/src/lib/hosted/billing/README.md
@@ -32,11 +32,10 @@ Pro-granting status defensively, but in practice a live subscription means paid.
    creates two Sessions. That's harmless: only the Session the browser
    navigates to can be completed, and the other expires unused (no double
    charge).
-2. **Webhook delivery claim** — `stripe_webhook_events(event_id)`,
-   `claimWebhookDelivery()`. First-write-wins on `event.id`; duplicate Stripe
-   deliveries are acked without re-running side effects. The claim row is
-   written BEFORE processing, so a transient handler failure is not retried on
-   redelivery (see below).
+2. **Webhook inbox** — `stripe_webhook_events(event_id)` stores every verified
+   Stripe event as `pending` before the route acknowledges it. A worker claims
+   rows as `processing`, then marks them `completed` or retries failures with
+   exponential backoff. The unique event id makes Stripe redelivery safe.
 3. `mirror.ts` is idempotent by construction — re-mirroring the same
    subscription (webhook redelivery, reconcile tick) converges to the same
    local state, and the welcome/grace emails dedup once-only at `email_log`.
@@ -89,25 +88,26 @@ Successful payment consumes the reservation from subscription metadata and stamp
 clears only `users.founding_member`, so the active price is forfeited without
 reopening capacity.
 
-## Webhook claim blocks transient-failure retries
+## Durable webhook inbox
 
-`claimWebhookDelivery` writes the `stripe_webhook_events` row BEFORE downstream
-processing runs — that is how duplicate deliveries are suppressed. Trade-off: if
-`mirror*` throws transiently, Stripe's redelivery of the same `event.id` hits
-the claim row and is acked without re-running the work.
+After signature verification, the route inserts the event payload as `pending`
+and returns 200 only after that insert succeeds. The billing worker claims due
+rows with `FOR UPDATE SKIP LOCKED`, marks them `processing`, and guards every
+completion/failure write with a per-claim token. A crashed process loses its
+15-minute lease; another process can claim it without accepting a late write
+from the original worker.
 
-Posture: **fail loud, operator replays manually.**
+Failures retry with exponential backoff (one minute through one hour) for five
+attempts. A terminal failure remains as `failed`, with its error and attempts
+preserved. An elevated admin can POST `{ eventId, reason }` to
+`/api/admin/actions/replay-stripe-webhook` to requeue only a failed event; this
+resets its attempts without deleting its durable or audit row. Replaying an
+already-pending, processing, or completed event is a logged no-op.
 
-1. Sentry / log alert fires on `[stripe-webhook] handler threw for ...`.
-2. Operator opens the Stripe dashboard → Developers → Events, finds the event,
-   and resends it.
-3. The duplicate-claim short-circuit fires. To force re-processing, delete the
-   row first: `DELETE FROM stripe_webhook_events WHERE event_id = '<id>';` then
-   resend the event.
-
-Because `mirror.ts` is idempotent, the safest recovery is usually the
-`reconcile` tick (below) rather than a manual replay — it re-fetches live state
-from Stripe and re-mirrors.
+Reconciliation remains the drift safety net, and is still the preferred repair
+for subscription state that can be reconstructed from Stripe. The inbox also
+preserves event-specific work such as payment-failure and analytics side effects
+that reconciliation cannot reproduce.
 
 ## Reconcile
 
@@ -120,9 +120,9 @@ state to Stripe's without depending on webhook delivery.
 
 `src/app/api/stripe/webhook/route.ts` verifies the signature with
 `constructEventAsync(rawBody, sig, STRIPE_WEBHOOK_SECRET)` (SubtleCrypto; works
-in both Node and Edge), then dispatches the verified event. It always 200s after
-a valid signature so Stripe stops retrying; handler errors are logged, not
-surfaced. Guards: `env.IS_HOSTED` (404 on self-host) and configured keys (503).
+in both Node and Edge), then writes the verified event to the inbox. It returns
+200 only after durable storage succeeds; a persistence failure returns 500 so
+Stripe retries. Guards: `env.IS_HOSTED` (404 on self-host) and configured keys (503).
 The hostname gate allows `/api/stripe/*` on both the customer host and the admin
 host (`ADMIN_HOST_SHARED_PREFIXES`).
 
@@ -154,5 +154,6 @@ through to the subscription metadata and mirrored back onto the local row.
   `cancelSubscription`, `createBillingPortalSession`, `getOrCreateStripeCustomer`.
 - `mirror.ts` — `mirrorStripeSubscription`, `mirrorSubscriptionById`,
   `mirrorCheckoutSession`.
-- `webhook.ts` — dispatch: claim idempotency, delegate to mirror, expire founding reservations, payment-failed email.
+- `webhook.ts` — dispatches a claimed inbox event to mirror, reservation expiry, and payment-failed email.
+- `webhook-inbox.ts` — claims, retries, and completes the durable Stripe event inbox.
 - `reconcile.ts` — periodic drift correction against live Stripe state.

--- a/src/lib/hosted/billing/webhook-inbox.ts
+++ b/src/lib/hosted/billing/webhook-inbox.ts
@@ -3,6 +3,7 @@ import {
     claimDueStripeWebhookEvents,
     completeStripeWebhookEvent,
     failStripeWebhookEvent,
+    renewStripeWebhookEventClaim,
 } from "@/db/queries/billing";
 import { captureServerException } from "@/lib/posthog-server";
 import { handleStripeWebhook } from "./webhook";
@@ -10,6 +11,7 @@ import { handleStripeWebhook } from "./webhook";
 const MAX_EVENTS_PER_TICK = 20;
 const MAX_ATTEMPTS = 5;
 const PROCESSING_LEASE_MS = 15 * 60 * 1000;
+const CLAIM_RENEWAL_MS = PROCESSING_LEASE_MS / 3;
 const RETRY_BASE_MS = 60 * 1000;
 const RETRY_MAX_MS = 60 * 60 * 1000;
 
@@ -43,14 +45,49 @@ async function processEvent(row: {
     attempts: number;
     claimToken: string;
 }): Promise<{ completed: number; retried: number; failed: number }> {
+    let renewing = false;
+    let claimLost = false;
+    const renew = async (): Promise<boolean> => {
+        if (renewing) return !claimLost;
+        renewing = true;
+        try {
+            const renewed = await renewStripeWebhookEventClaim({
+                eventId: row.eventId,
+                claimToken: row.claimToken,
+                processingLeaseMs: PROCESSING_LEASE_MS,
+            });
+            claimLost = !renewed;
+            return renewed;
+        } catch (error) {
+            claimLost = true;
+            console.error(
+                `[stripe-webhook-inbox] failed to renew claim for ${row.eventId}:`,
+                error,
+            );
+            return false;
+        } finally {
+            renewing = false;
+        }
+    };
+
+    if (!(await renew())) return { completed: 0, retried: 0, failed: 0 };
+    const renewal = setInterval(() => {
+        void renew();
+    }, CLAIM_RENEWAL_MS);
+    renewal.unref?.();
+
     try {
         await handleStripeWebhook(eventFromInboxRow(row));
+        if (claimLost || !(await renew())) {
+            return { completed: 0, retried: 0, failed: 0 };
+        }
         const completed = await completeStripeWebhookEvent({
             eventId: row.eventId,
             claimToken: row.claimToken,
         });
         return { completed: completed ? 1 : 0, retried: 0, failed: 0 };
     } catch (error) {
+        if (claimLost) return { completed: 0, retried: 0, failed: 0 };
         const message = error instanceof Error ? error.message : String(error);
         const outcome = await failStripeWebhookEvent({
             eventId: row.eventId,
@@ -78,6 +115,8 @@ async function processEvent(row: {
             error,
         );
         return { completed: 0, retried: 1, failed: 0 };
+    } finally {
+        clearInterval(renewal);
     }
 }
 

--- a/src/lib/hosted/billing/webhook-inbox.ts
+++ b/src/lib/hosted/billing/webhook-inbox.ts
@@ -4,6 +4,7 @@ import {
     completeStripeWebhookEvent,
     failStripeWebhookEvent,
     renewStripeWebhookEventClaim,
+    withStripeWebhookEventLock,
 } from "@/db/queries/billing";
 import { captureServerException } from "@/lib/posthog-server";
 import { handleStripeWebhook } from "./webhook";
@@ -45,79 +46,82 @@ async function processEvent(row: {
     attempts: number;
     claimToken: string;
 }): Promise<{ completed: number; retried: number; failed: number }> {
-    let renewing = false;
-    let claimLost = false;
-    const renew = async (): Promise<boolean> => {
-        if (renewing) return !claimLost;
-        renewing = true;
+    return withStripeWebhookEventLock(row.eventId, async () => {
+        let renewing = false;
+        let claimLost = false;
+        const renew = async (): Promise<boolean> => {
+            if (renewing) return !claimLost;
+            renewing = true;
+            try {
+                const renewed = await renewStripeWebhookEventClaim({
+                    eventId: row.eventId,
+                    claimToken: row.claimToken,
+                    processingLeaseMs: PROCESSING_LEASE_MS,
+                });
+                claimLost = !renewed;
+                return renewed;
+            } catch (error) {
+                claimLost = true;
+                console.error(
+                    `[stripe-webhook-inbox] failed to renew claim for ${row.eventId}:`,
+                    error,
+                );
+                return false;
+            } finally {
+                renewing = false;
+            }
+        };
+
+        if (!(await renew())) return { completed: 0, retried: 0, failed: 0 };
+        const renewal = setInterval(() => {
+            void renew();
+        }, CLAIM_RENEWAL_MS);
+        renewal.unref?.();
+
         try {
-            const renewed = await renewStripeWebhookEventClaim({
+            await handleStripeWebhook(eventFromInboxRow(row));
+            if (claimLost || !(await renew())) {
+                return { completed: 0, retried: 0, failed: 0 };
+            }
+            const completed = await completeStripeWebhookEvent({
                 eventId: row.eventId,
                 claimToken: row.claimToken,
-                processingLeaseMs: PROCESSING_LEASE_MS,
             });
-            claimLost = !renewed;
-            return renewed;
+            return { completed: completed ? 1 : 0, retried: 0, failed: 0 };
         } catch (error) {
-            claimLost = true;
-            console.error(
-                `[stripe-webhook-inbox] failed to renew claim for ${row.eventId}:`,
-                error,
-            );
-            return false;
-        } finally {
-            renewing = false;
-        }
-    };
-
-    if (!(await renew())) return { completed: 0, retried: 0, failed: 0 };
-    const renewal = setInterval(() => {
-        void renew();
-    }, CLAIM_RENEWAL_MS);
-    renewal.unref?.();
-
-    try {
-        await handleStripeWebhook(eventFromInboxRow(row));
-        if (claimLost || !(await renew())) {
-            return { completed: 0, retried: 0, failed: 0 };
-        }
-        const completed = await completeStripeWebhookEvent({
-            eventId: row.eventId,
-            claimToken: row.claimToken,
-        });
-        return { completed: completed ? 1 : 0, retried: 0, failed: 0 };
-    } catch (error) {
-        if (claimLost) return { completed: 0, retried: 0, failed: 0 };
-        const message = error instanceof Error ? error.message : String(error);
-        const outcome = await failStripeWebhookEvent({
-            eventId: row.eventId,
-            claimToken: row.claimToken,
-            errorMessage: message,
-            maxAttempts: MAX_ATTEMPTS,
-            retryAt: retryAtForAttempt(row.attempts + 1),
-        });
-        if (!outcome) return { completed: 0, retried: 0, failed: 0 };
-        if (outcome.status === "failed") {
-            console.error(
-                `[stripe-webhook-inbox] event ${row.eventId} failed permanently after ${outcome.attempts} attempt(s):`,
-                error,
-            );
-            captureServerException(error, {
-                source: "worker:billing-webhook-inbox",
+            if (claimLost) return { completed: 0, retried: 0, failed: 0 };
+            const message =
+                error instanceof Error ? error.message : String(error);
+            const outcome = await failStripeWebhookEvent({
                 eventId: row.eventId,
-                eventType: row.type,
-                attempts: outcome.attempts,
+                claimToken: row.claimToken,
+                errorMessage: message,
+                maxAttempts: MAX_ATTEMPTS,
+                retryAt: retryAtForAttempt(row.attempts + 1),
             });
-            return { completed: 0, retried: 0, failed: 1 };
+            if (!outcome) return { completed: 0, retried: 0, failed: 0 };
+            if (outcome.status === "failed") {
+                console.error(
+                    `[stripe-webhook-inbox] event ${row.eventId} failed permanently after ${outcome.attempts} attempt(s):`,
+                    error,
+                );
+                captureServerException(error, {
+                    source: "worker:billing-webhook-inbox",
+                    eventId: row.eventId,
+                    eventType: row.type,
+                    attempts: outcome.attempts,
+                });
+                return { completed: 0, retried: 0, failed: 1 };
+            }
+            console.warn(
+                `[stripe-webhook-inbox] event ${row.eventId} failed attempt ${outcome.attempts}/${MAX_ATTEMPTS}; requeued`,
+                error,
+            );
+            return { completed: 0, retried: 1, failed: 0 };
+        } finally {
+            clearInterval(renewal);
         }
-        console.warn(
-            `[stripe-webhook-inbox] event ${row.eventId} failed attempt ${outcome.attempts}/${MAX_ATTEMPTS}; requeued`,
-            error,
-        );
-        return { completed: 0, retried: 1, failed: 0 };
-    } finally {
-        clearInterval(renewal);
-    }
+    });
 }
 
 export interface StripeWebhookInboxResult {

--- a/src/lib/hosted/billing/webhook-inbox.ts
+++ b/src/lib/hosted/billing/webhook-inbox.ts
@@ -1,0 +1,110 @@
+import type Stripe from "stripe";
+import {
+    claimDueStripeWebhookEvents,
+    completeStripeWebhookEvent,
+    failStripeWebhookEvent,
+} from "@/db/queries/billing";
+import { captureServerException } from "@/lib/posthog-server";
+import { handleStripeWebhook } from "./webhook";
+
+const MAX_EVENTS_PER_TICK = 20;
+const MAX_ATTEMPTS = 5;
+const PROCESSING_LEASE_MS = 15 * 60 * 1000;
+const RETRY_BASE_MS = 60 * 1000;
+const RETRY_MAX_MS = 60 * 60 * 1000;
+
+function retryAtForAttempt(attempt: number): Date {
+    const delay = Math.min(
+        RETRY_BASE_MS * 2 ** Math.max(0, attempt - 1),
+        RETRY_MAX_MS,
+    );
+    return new Date(Date.now() + delay);
+}
+
+function eventFromInboxRow(row: {
+    eventId: string;
+    type: string;
+    eventCreatedAt: Date;
+    payload: Record<string, unknown>;
+}): Stripe.Event {
+    return {
+        id: row.eventId,
+        type: row.type,
+        created: Math.floor(row.eventCreatedAt.getTime() / 1000),
+        data: { object: row.payload },
+    } as unknown as Stripe.Event;
+}
+
+async function processEvent(row: {
+    eventId: string;
+    type: string;
+    eventCreatedAt: Date;
+    payload: Record<string, unknown>;
+    attempts: number;
+    claimToken: string;
+}): Promise<{ completed: number; retried: number; failed: number }> {
+    try {
+        await handleStripeWebhook(eventFromInboxRow(row));
+        const completed = await completeStripeWebhookEvent({
+            eventId: row.eventId,
+            claimToken: row.claimToken,
+        });
+        return { completed: completed ? 1 : 0, retried: 0, failed: 0 };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const outcome = await failStripeWebhookEvent({
+            eventId: row.eventId,
+            claimToken: row.claimToken,
+            errorMessage: message,
+            maxAttempts: MAX_ATTEMPTS,
+            retryAt: retryAtForAttempt(row.attempts + 1),
+        });
+        if (!outcome) return { completed: 0, retried: 0, failed: 0 };
+        if (outcome.status === "failed") {
+            console.error(
+                `[stripe-webhook-inbox] event ${row.eventId} failed permanently after ${outcome.attempts} attempt(s):`,
+                error,
+            );
+            captureServerException(error, {
+                source: "worker:billing-webhook-inbox",
+                eventId: row.eventId,
+                eventType: row.type,
+                attempts: outcome.attempts,
+            });
+            return { completed: 0, retried: 0, failed: 1 };
+        }
+        console.warn(
+            `[stripe-webhook-inbox] event ${row.eventId} failed attempt ${outcome.attempts}/${MAX_ATTEMPTS}; requeued`,
+            error,
+        );
+        return { completed: 0, retried: 1, failed: 0 };
+    }
+}
+
+export interface StripeWebhookInboxResult {
+    claimed: number;
+    completed: number;
+    retried: number;
+    failed: number;
+}
+
+/** Process one bounded batch of durably accepted Stripe events. */
+export async function processStripeWebhookInbox(): Promise<StripeWebhookInboxResult> {
+    const events = await claimDueStripeWebhookEvents({
+        limit: MAX_EVENTS_PER_TICK,
+        processingLeaseMs: PROCESSING_LEASE_MS,
+    });
+    const result: StripeWebhookInboxResult = {
+        claimed: events.length,
+        completed: 0,
+        retried: 0,
+        failed: 0,
+    };
+    for (const event of events) {
+        const outcome = await processEvent(event);
+        result.completed += outcome.completed;
+        result.retried += outcome.retried;
+        result.failed += outcome.failed;
+    }
+    return result;
+}

--- a/src/lib/hosted/billing/webhook-inbox.ts
+++ b/src/lib/hosted/billing/webhook-inbox.ts
@@ -2,6 +2,7 @@ import type Stripe from "stripe";
 import {
     claimDueStripeWebhookEvents,
     completeStripeWebhookEvent,
+    completeStripeWebhookEventUnderLock,
     failStripeWebhookEvent,
     renewStripeWebhookEventClaim,
     withStripeWebhookEventLock,
@@ -80,13 +81,13 @@ async function processEvent(row: {
 
         try {
             await handleStripeWebhook(eventFromInboxRow(row));
-            if (claimLost || !(await renew())) {
-                return { completed: 0, retried: 0, failed: 0 };
-            }
-            const completed = await completeStripeWebhookEvent({
-                eventId: row.eventId,
-                claimToken: row.claimToken,
-            });
+            const completed =
+                claimLost || !(await renew())
+                    ? await completeStripeWebhookEventUnderLock(row.eventId)
+                    : await completeStripeWebhookEvent({
+                          eventId: row.eventId,
+                          claimToken: row.claimToken,
+                      });
             return { completed: completed ? 1 : 0, retried: 0, failed: 0 };
         } catch (error) {
             if (claimLost) return { completed: 0, retried: 0, failed: 0 };

--- a/src/lib/hosted/billing/webhook.ts
+++ b/src/lib/hosted/billing/webhook.ts
@@ -2,7 +2,6 @@ import { eq } from "drizzle-orm";
 import type Stripe from "stripe";
 import { db } from "@/db";
 import {
-    claimWebhookDelivery,
     expireFoundingMemberReservationByCheckoutSession,
     getBillingCustomerByStripeId,
 } from "@/db/queries/billing";
@@ -26,23 +25,11 @@ function subscriptionIdFromInvoice(invoice: Stripe.Invoice): string | null {
 }
 
 /**
- * Idempotent Stripe webhook dispatch. The caller (route) is responsible
- * for signature verification; this consumes the already-verified event.
- * Duplicate deliveries are skipped at the DB claim on `event.id`.
+ * Dispatches one event claimed from the durable Stripe inbox. The receiver
+ * verifies and persists events; the worker owns retries and idempotency.
  */
 export async function handleStripeWebhook(event: Stripe.Event): Promise<void> {
-    const claim = await claimWebhookDelivery({
-        eventId: event.id,
-        type: event.type,
-    });
-    if (!claim) {
-        console.log(
-            `[stripe-webhook] duplicate delivery for ${event.id}; acknowledging`,
-        );
-        return;
-    }
-
-    console.log(`[stripe-webhook] received ${event.type} id=${event.id}`);
+    console.log(`[stripe-webhook] processing ${event.type} id=${event.id}`);
 
     switch (event.type) {
         case "checkout.session.completed": {
@@ -144,21 +131,12 @@ async function handleInvoicePaymentFailed(
     const base = env.APP_URL?.replace(/\/$/, "");
     if (!base) return;
 
-    try {
-        await sendPaymentFailedEmail({
-            userId,
-            email: row.email,
-            paymentId: invoice.id ?? `invoice:${subId}`,
-            billingUrl: `${base}/settings#billing`,
-            nextRetryAt: unixToDate(invoice.next_payment_attempt),
-            accessUntil: unixToDate(
-                sub.items.data[0]?.current_period_end ?? null,
-            ),
-        });
-    } catch (error) {
-        console.error(
-            `[stripe-webhook] payment-failed email failed for user ${userId}:`,
-            error,
-        );
-    }
+    await sendPaymentFailedEmail({
+        userId,
+        email: row.email,
+        paymentId: invoice.id ?? `invoice:${subId}`,
+        billingUrl: `${base}/settings#billing`,
+        nextRetryAt: unixToDate(invoice.next_payment_attempt),
+        accessUntil: unixToDate(sub.items.data[0]?.current_period_end ?? null),
+    });
 }

--- a/src/lib/hosted/billing/worker.ts
+++ b/src/lib/hosted/billing/worker.ts
@@ -7,6 +7,7 @@ import { processGraceReminders } from "./grace-reminders";
 import { processExpiredTrials } from "./lapse";
 import { reconcileStaleSubscriptions } from "./reconcile";
 import { processTransitionEmails } from "./transition-emails";
+import { processStripeWebhookInbox } from "./webhook-inbox";
 
 const TICK_MS = 5 * 60 * 1000;
 const RECONCILE_EVERY_N_TICKS = 6;
@@ -37,6 +38,15 @@ export async function tick(): Promise<void> {
     if (running) return;
     running = true;
     try {
+        await runPhase("webhook-inbox", async () => {
+            const inbox = await processStripeWebhookInbox();
+            if (inbox.claimed > 0 || inbox.retried > 0 || inbox.failed > 0) {
+                console.log(
+                    `[billing-worker] webhook-inbox claimed=${inbox.claimed} completed=${inbox.completed} retried=${inbox.retried} failed=${inbox.failed}`,
+                );
+            }
+        });
+
         await runPhase("cycle-close", async () => {
             const closed = await closeDueCycles();
             if (closed > 0) {
@@ -126,6 +136,7 @@ export async function tick(): Promise<void> {
  * (subsequent calls return immediately).
  *
  * Each tick (every 5 minutes):
+ *  - Claims and processes durably stored Stripe webhook events
  *  - Closes due Mynah cycles
  *  - Detects expired trials with no card -> demotes + schedules deletion
  *  - Processes accounts whose grace window has elapsed -> hard delete

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -156,20 +156,6 @@ async function sendClaimedEmail(
     }
 }
 
-async function sendRequiredClaimedEmail(
-    claim: { userId: string; kind: string },
-    build: () => Promise<EmailOptions>,
-): Promise<void> {
-    const claimed = await claimEmailSend(claim);
-    if (!claimed) return;
-    try {
-        await sendEmailWithError(await build());
-    } catch (error) {
-        await releaseEmailSend(claim);
-        throw error;
-    }
-}
-
 export async function sendNewRecordingEmail(
     email: string,
     count: number,
@@ -294,8 +280,9 @@ export async function sendWelcomeHostedProEmail(input: {
 }
 
 /**
- * Payment-failed nudge. Per-failure, not once-only: kind is namespaced
- * with the payment id so each failed payment can send exactly once.
+ * Payment-failed nudge. The webhook inbox owns delivery retries, so this
+ * deliberately does not pre-claim an email-log row that a crashed worker
+ * could strand before SMTP accepts the message.
  */
 export async function sendPaymentFailedEmail(input: {
     userId: string;
@@ -305,23 +292,18 @@ export async function sendPaymentFailedEmail(input: {
     nextRetryAt: Date | null;
     accessUntil: Date | null;
 }): Promise<void> {
-    await sendRequiredClaimedEmail(
-        { userId: input.userId, kind: `payment_failed:${input.paymentId}` },
-        async () => {
-            const html = await renderEmailHtml(
-                React.createElement(PaymentFailedEmail, {
-                    billingUrl: input.billingUrl,
-                    nextRetryAt: input.nextRetryAt,
-                    accessUntil: input.accessUntil,
-                }),
-            );
-            return {
-                to: input.email,
-                subject: "Riffado: payment failed",
-                html,
-            };
-        },
+    const html = await renderEmailHtml(
+        React.createElement(PaymentFailedEmail, {
+            billingUrl: input.billingUrl,
+            nextRetryAt: input.nextRetryAt,
+            accessUntil: input.accessUntil,
+        }),
     );
+    await sendEmailWithError({
+        to: input.email,
+        subject: "Riffado: payment failed",
+        html,
+    });
 }
 
 /**

--- a/src/lib/notifications/email.ts
+++ b/src/lib/notifications/email.ts
@@ -156,6 +156,20 @@ async function sendClaimedEmail(
     }
 }
 
+async function sendRequiredClaimedEmail(
+    claim: { userId: string; kind: string },
+    build: () => Promise<EmailOptions>,
+): Promise<void> {
+    const claimed = await claimEmailSend(claim);
+    if (!claimed) return;
+    try {
+        await sendEmailWithError(await build());
+    } catch (error) {
+        await releaseEmailSend(claim);
+        throw error;
+    }
+}
+
 export async function sendNewRecordingEmail(
     email: string,
     count: number,
@@ -290,8 +304,8 @@ export async function sendPaymentFailedEmail(input: {
     billingUrl: string;
     nextRetryAt: Date | null;
     accessUntil: Date | null;
-}): Promise<boolean> {
-    return sendClaimedEmail(
+}): Promise<void> {
+    await sendRequiredClaimedEmail(
         { userId: input.userId, kind: `payment_failed:${input.paymentId}` },
         async () => {
             const html = await renderEmailHtml(

--- a/src/tests/billing/webhook-inbox.test.ts
+++ b/src/tests/billing/webhook-inbox.test.ts
@@ -5,6 +5,7 @@ const { queryMock, webhookMock } = vi.hoisted(() => ({
         claimDueStripeWebhookEvents: vi.fn(),
         completeStripeWebhookEvent: vi.fn(),
         failStripeWebhookEvent: vi.fn(),
+        renewStripeWebhookEventClaim: vi.fn(),
     },
     webhookMock: { handleStripeWebhook: vi.fn() },
 }));
@@ -31,6 +32,7 @@ describe("Stripe webhook inbox", () => {
         vi.clearAllMocks();
         queryMock.claimDueStripeWebhookEvents.mockResolvedValue([inboxEvent]);
         queryMock.completeStripeWebhookEvent.mockResolvedValue(true);
+        queryMock.renewStripeWebhookEventClaim.mockResolvedValue(true);
     });
 
     it("completes a successfully dispatched event", async () => {
@@ -43,6 +45,11 @@ describe("Stripe webhook inbox", () => {
                 data: { object: { id: "sub_1" } },
             }),
         );
+        expect(queryMock.renewStripeWebhookEventClaim).toHaveBeenCalledWith({
+            eventId: "evt_1",
+            claimToken: "claim_1",
+            processingLeaseMs: 15 * 60 * 1000,
+        });
         expect(queryMock.completeStripeWebhookEvent).toHaveBeenCalledWith({
             eventId: "evt_1",
             claimToken: "claim_1",
@@ -50,6 +57,21 @@ describe("Stripe webhook inbox", () => {
         expect(result).toEqual({
             claimed: 1,
             completed: 1,
+            retried: 0,
+            failed: 0,
+        });
+    });
+
+    it("does not dispatch an event after its claim is lost", async () => {
+        queryMock.renewStripeWebhookEventClaim.mockResolvedValue(false);
+
+        const result = await processStripeWebhookInbox();
+
+        expect(webhookMock.handleStripeWebhook).not.toHaveBeenCalled();
+        expect(queryMock.completeStripeWebhookEvent).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            claimed: 1,
+            completed: 0,
             retried: 0,
             failed: 0,
         });

--- a/src/tests/billing/webhook-inbox.test.ts
+++ b/src/tests/billing/webhook-inbox.test.ts
@@ -6,6 +6,7 @@ const { queryMock, webhookMock } = vi.hoisted(() => ({
         completeStripeWebhookEvent: vi.fn(),
         failStripeWebhookEvent: vi.fn(),
         renewStripeWebhookEventClaim: vi.fn(),
+        withStripeWebhookEventLock: vi.fn(),
     },
     webhookMock: { handleStripeWebhook: vi.fn() },
 }));
@@ -33,6 +34,9 @@ describe("Stripe webhook inbox", () => {
         queryMock.claimDueStripeWebhookEvents.mockResolvedValue([inboxEvent]);
         queryMock.completeStripeWebhookEvent.mockResolvedValue(true);
         queryMock.renewStripeWebhookEventClaim.mockResolvedValue(true);
+        queryMock.withStripeWebhookEventLock.mockImplementation(
+            (_eventId: string, run: () => Promise<unknown>) => run(),
+        );
     });
 
     it("completes a successfully dispatched event", async () => {
@@ -44,6 +48,10 @@ describe("Stripe webhook inbox", () => {
                 type: "customer.subscription.updated",
                 data: { object: { id: "sub_1" } },
             }),
+        );
+        expect(queryMock.withStripeWebhookEventLock).toHaveBeenCalledWith(
+            "evt_1",
+            expect.any(Function),
         );
         expect(queryMock.renewStripeWebhookEventClaim).toHaveBeenCalledWith({
             eventId: "evt_1",

--- a/src/tests/billing/webhook-inbox.test.ts
+++ b/src/tests/billing/webhook-inbox.test.ts
@@ -4,6 +4,7 @@ const { queryMock, webhookMock } = vi.hoisted(() => ({
     queryMock: {
         claimDueStripeWebhookEvents: vi.fn(),
         completeStripeWebhookEvent: vi.fn(),
+        completeStripeWebhookEventUnderLock: vi.fn(),
         failStripeWebhookEvent: vi.fn(),
         renewStripeWebhookEventClaim: vi.fn(),
         withStripeWebhookEventLock: vi.fn(),
@@ -33,6 +34,7 @@ describe("Stripe webhook inbox", () => {
         vi.clearAllMocks();
         queryMock.claimDueStripeWebhookEvents.mockResolvedValue([inboxEvent]);
         queryMock.completeStripeWebhookEvent.mockResolvedValue(true);
+        queryMock.completeStripeWebhookEventUnderLock.mockResolvedValue(true);
         queryMock.renewStripeWebhookEventClaim.mockResolvedValue(true);
         queryMock.withStripeWebhookEventLock.mockImplementation(
             (_eventId: string, run: () => Promise<unknown>) => run(),
@@ -62,6 +64,25 @@ describe("Stripe webhook inbox", () => {
             eventId: "evt_1",
             claimToken: "claim_1",
         });
+        expect(result).toEqual({
+            claimed: 1,
+            completed: 1,
+            retried: 0,
+            failed: 0,
+        });
+    });
+
+    it("completes under the advisory lock when a replacement claim arrives during handling", async () => {
+        queryMock.renewStripeWebhookEventClaim
+            .mockResolvedValueOnce(true)
+            .mockResolvedValueOnce(false);
+
+        const result = await processStripeWebhookInbox();
+
+        expect(
+            queryMock.completeStripeWebhookEventUnderLock,
+        ).toHaveBeenCalledWith("evt_1");
+        expect(queryMock.completeStripeWebhookEvent).not.toHaveBeenCalled();
         expect(result).toEqual({
             claimed: 1,
             completed: 1,

--- a/src/tests/billing/webhook-inbox.test.ts
+++ b/src/tests/billing/webhook-inbox.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queryMock, webhookMock } = vi.hoisted(() => ({
+    queryMock: {
+        claimDueStripeWebhookEvents: vi.fn(),
+        completeStripeWebhookEvent: vi.fn(),
+        failStripeWebhookEvent: vi.fn(),
+    },
+    webhookMock: { handleStripeWebhook: vi.fn() },
+}));
+
+vi.mock("@/db/queries/billing", () => queryMock);
+vi.mock("@/lib/hosted/billing/webhook", () => webhookMock);
+vi.mock("@/lib/posthog-server", () => ({
+    captureServerException: vi.fn(),
+}));
+
+import { processStripeWebhookInbox } from "@/lib/hosted/billing/webhook-inbox";
+
+const inboxEvent = {
+    eventId: "evt_1",
+    type: "customer.subscription.updated",
+    eventCreatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    payload: { id: "sub_1" },
+    attempts: 0,
+    claimToken: "claim_1",
+};
+
+describe("Stripe webhook inbox", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        queryMock.claimDueStripeWebhookEvents.mockResolvedValue([inboxEvent]);
+        queryMock.completeStripeWebhookEvent.mockResolvedValue(true);
+    });
+
+    it("completes a successfully dispatched event", async () => {
+        const result = await processStripeWebhookInbox();
+
+        expect(webhookMock.handleStripeWebhook).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: "evt_1",
+                type: "customer.subscription.updated",
+                data: { object: { id: "sub_1" } },
+            }),
+        );
+        expect(queryMock.completeStripeWebhookEvent).toHaveBeenCalledWith({
+            eventId: "evt_1",
+            claimToken: "claim_1",
+        });
+        expect(result).toEqual({
+            claimed: 1,
+            completed: 1,
+            retried: 0,
+            failed: 0,
+        });
+    });
+
+    it("requeues a transient failure with the next attempt's backoff", async () => {
+        webhookMock.handleStripeWebhook.mockRejectedValue(
+            new Error("Stripe down"),
+        );
+        queryMock.failStripeWebhookEvent.mockResolvedValue({
+            status: "pending",
+            attempts: 2,
+        });
+
+        const before = Date.now();
+        const result = await processStripeWebhookInbox();
+
+        expect(queryMock.failStripeWebhookEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                eventId: "evt_1",
+                claimToken: "claim_1",
+                errorMessage: "Stripe down",
+                maxAttempts: 5,
+                retryAt: expect.any(Date),
+            }),
+        );
+        const retryAt = queryMock.failStripeWebhookEvent.mock.calls[0]?.[0]
+            ?.retryAt as Date;
+        expect(retryAt.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+        expect(result).toEqual({
+            claimed: 1,
+            completed: 0,
+            retried: 1,
+            failed: 0,
+        });
+    });
+});

--- a/src/tests/billing/webhook.test.ts
+++ b/src/tests/billing/webhook.test.ts
@@ -138,6 +138,42 @@ describe("handleStripeWebhook", () => {
         );
     });
 
+    it("fails the event when payment-failed email delivery fails", async () => {
+        stripeMock.getStripe.mockReturnValue({
+            subscriptions: {
+                retrieve: vi.fn().mockResolvedValue({
+                    id: "sub_pf_error",
+                    metadata: { userId: "u1" },
+                    items: { data: [{ current_period_end: 1_900_000_000 }] },
+                }),
+            },
+        });
+        dbMock.select.mockReturnValue({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi
+                        .fn()
+                        .mockResolvedValue([{ email: "u1@example.com" }]),
+                }),
+            }),
+        });
+        emailMock.sendPaymentFailedEmail.mockRejectedValue(
+            new Error("SMTP unavailable"),
+        );
+
+        await expect(
+            handleStripeWebhook(
+                event("invoice.payment_failed", {
+                    id: "in_pf_error",
+                    next_payment_attempt: 1_800_000_000,
+                    parent: {
+                        subscription_details: { subscription: "sub_pf_error" },
+                    },
+                }),
+            ),
+        ).rejects.toThrow("SMTP unavailable");
+    });
+
     it("resolves userId via the billing-customer mapping when metadata.userId is missing", async () => {
         stripeMock.getStripe.mockReturnValue({
             subscriptions: {

--- a/src/tests/billing/webhook.test.ts
+++ b/src/tests/billing/webhook.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { queriesMock, mirrorMock, stripeMock, emailMock, dbMock } = vi.hoisted(
     () => ({
         queriesMock: {
-            claimWebhookDelivery: vi.fn(),
             expireFoundingMemberReservationByCheckoutSession: vi.fn(),
             getBillingCustomerByStripeId: vi.fn().mockResolvedValue(null),
         },
@@ -44,15 +43,6 @@ function event(type: string, object: unknown): Stripe.Event {
 describe("handleStripeWebhook", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        queriesMock.claimWebhookDelivery.mockResolvedValue({ eventId: "x" });
-    });
-
-    it("skips processing on a duplicate delivery", async () => {
-        queriesMock.claimWebhookDelivery.mockResolvedValue(null);
-        await handleStripeWebhook(
-            event("customer.subscription.updated", { id: "sub_1" }),
-        );
-        expect(mirrorMock.mirrorSubscriptionById).not.toHaveBeenCalled();
     });
 
     it("mirrors a completed checkout session", async () => {

--- a/src/tests/billing/worker.test.ts
+++ b/src/tests/billing/worker.test.ts
@@ -8,6 +8,7 @@ const {
     transitionMock,
     foundingReservationsMock,
     reconcileMock,
+    webhookInboxMock,
 } = vi.hoisted(() => ({
     cycleCloseMock: { closeDueCycles: vi.fn() },
     lapseMock: { processExpiredTrials: vi.fn() },
@@ -16,6 +17,7 @@ const {
     transitionMock: { processTransitionEmails: vi.fn() },
     foundingReservationsMock: { reconcileExpiredFoundingReservations: vi.fn() },
     reconcileMock: { reconcileStaleSubscriptions: vi.fn() },
+    webhookInboxMock: { processStripeWebhookInbox: vi.fn() },
 }));
 
 vi.mock("@/lib/hosted/billing/cycle-close", () => cycleCloseMock);
@@ -28,6 +30,7 @@ vi.mock(
     () => foundingReservationsMock,
 );
 vi.mock("@/lib/hosted/billing/reconcile", () => reconcileMock);
+vi.mock("@/lib/hosted/billing/webhook-inbox", () => webhookInboxMock);
 vi.mock("@/lib/env", () => ({
     env: { IS_HOSTED: true, BILLING_ENABLED: true },
 }));
@@ -67,6 +70,12 @@ function zeroResults() {
     reconcileMock.reconcileStaleSubscriptions.mockResolvedValue({
         inspected: 0,
         errors: 0,
+    });
+    webhookInboxMock.processStripeWebhookInbox.mockResolvedValue({
+        claimed: 0,
+        completed: 0,
+        retried: 0,
+        failed: 0,
     });
 }
 


### PR DESCRIPTION
## Description

Make Stripe webhook processing durable so verified events are not lost when downstream billing work fails after acknowledgment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Dependency update

## Related Issues

Fixes #
Relates to #

## Changes Made

- Store verified Stripe events in a durable inbox before returning success to Stripe.
- Claim inbox events with database leases, retry failures with exponential backoff, and retain terminal failures for replay.
- Add an audited admin action to requeue failed Stripe events without deleting inbox rows.

## Screenshots (if applicable)

Not applicable.

## Testing

### Test Environment
- OS: macOS
- Node version: v24.18.0
- Browser (if UI changes): Not applicable

### Test Steps
1. Ran `pnpm format-and-lint:fix`.
2. Ran `pnpm type-check`.
3. Ran `pnpm test src/tests/billing/webhook.test.ts src/tests/billing/webhook-inbox.test.ts src/tests/billing/worker.test.ts`.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

- [x] I have generated a new migration (`pnpm db:generate`)
- [ ] I have tested the migration locally
- [ ] I have included rollback instructions (if applicable)

## Breaking Changes

None.

## Additional Notes

Migration `0036_wide_raider` preserves legacy webhook claim rows as completed and supplies an empty payload default for those rows. The migration was generated but not applied locally.

## For Reviewers

- Verify the inbox claim, lease, retry, and terminal-failure transitions.
- Verify the failed-event replay action remains limited to elevated admins and is audited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Stripe webhook processing durable by inserting verified events into a DB inbox before acknowledging, then handling them in the billing worker with leases, advisory locks, and retries. Also completes reclaimed events under lock to prevent lost or duplicated side effects, and adds a safe, audited admin replay.

- **Bug Fixes**
  - Webhook route persists verified events into `stripe_webhook_events` with `eventCreatedAt` and `payload`, then 200s only after insert; duplicates suppressed by unique `event.id`.
  - Worker claims due rows with per-claim tokens and 15‑minute leases, renews during processing, serializes side effects per `event.id`, completes reclaimed events under an advisory lock, retries with backoff (1m–60m, up to 5), and records terminal failures; audited admin replay at POST `/api/admin/actions/replay-stripe-webhook` with `{ eventId, reason }` safely requeues failed events.
  - Payment‑failed email delivery is required: send errors fail the event and trigger retries; no pre-claim in the email log.

- **Migration**
  - `0036_wide_raider` upgrades `stripe_webhook_events` into a durable inbox: adds `status` enum, `payload`, `attempts`, `claim_token`, `started/next_attempt_at`, `last_error`, `completed/failed_at`, `created/updated`, due/created indices; renames `processed_at` to `event_created_at`. Legacy rows remain `completed` with a default payload.
  - Inert on self-hosts unless hosted billing is enabled.

<sup>Written for commit 13ee2def8b2b54a6a43436a837dd76af54c3b6eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

